### PR TITLE
Add progress bar to CustomProgressDialog

### DIFF
--- a/app/res/layout/fragment_progress_dialog.xml
+++ b/app/res/layout/fragment_progress_dialog.xml
@@ -48,15 +48,15 @@
      </Button>
 
     <ProgressBar
-   		android:id="@+id/progress_bar_horizontal"
-   		style="?android:attr/progressBarStyleHorizontal"
-   		android:layout_width="match_parent"
-   		android:layout_height="wrap_content"
-    	android:layout_below="@id/dialog_cancel_button"
-    	android:layout_marginLeft="@dimen/spacer"
-    	android:layout_marginRight="@dimen/spacer"
-    	android:layout_marginTop="@dimen/spacer"
-    	android:layout_marginBottom="@dimen/spacer"
-   		android:visibility="gone" />
+        android:id="@+id/progress_bar_horizontal"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/dialog_cancel_button"
+        android:layout_marginLeft="@dimen/spacer"
+        android:layout_marginRight="@dimen/spacer"
+        android:layout_marginTop="@dimen/spacer"
+        android:layout_marginBottom="@dimen/spacer"
+        android:visibility="gone" />
      
 </RelativeLayout>

--- a/app/res/layout/fragment_progress_dialog.xml
+++ b/app/res/layout/fragment_progress_dialog.xml
@@ -46,5 +46,17 @@
     	 android:text="Cancel"
     	 android:visibility="gone" >
      </Button>
+
+    <ProgressBar
+   		android:id="@+id/progress_bar_horizontal"
+   		style="?android:attr/progressBarStyleHorizontal"
+   		android:layout_width="match_parent"
+   		android:layout_height="wrap_content"
+    	android:layout_below="@id/dialog_cancel_button"
+    	android:layout_marginLeft="@dimen/spacer"
+    	android:layout_marginRight="@dimen/spacer"
+    	android:layout_marginTop="@dimen/spacer"
+    	android:layout_marginBottom="@dimen/spacer"
+   		android:visibility="gone" />
      
 </RelativeLayout>

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -11,7 +11,6 @@ import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.CustomProgressDialog;
 import org.commcare.dalvik.dialogs.DialogController;
 import org.commcare.suite.model.Detail;
-import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.util.SessionFrame;
 import org.javarosa.core.model.instance.TreeReference;
@@ -705,6 +704,35 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
         if (mProgressDialog != null) {
             if (mProgressDialog.getTaskId() == taskId) {
                 mProgressDialog.updateMessage(updateText);
+            }
+            else {
+                Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, 
+                        "Attempting to update a progress dialog whose taskId does not match the"
+                        + "task for which the update message was intended.");
+            }
+        }
+    }
+
+    @Override
+    public void updateProgressBar(int progress, int max, int taskId) {
+        CustomProgressDialog mProgressDialog = getCurrentDialog();
+        if (mProgressDialog != null) {
+            if (mProgressDialog.getTaskId() == taskId) {
+                mProgressDialog.updateProgressBar(progress, max);
+            }
+            else {
+                Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, 
+                        "Attempting to update a progress dialog whose taskId does not match the"
+                        + "task for which the update message was intended.");
+            }
+        }
+    }
+    
+    public void removeProgressBar(int taskId) {
+        CustomProgressDialog mProgressDialog = getCurrentDialog();
+        if (mProgressDialog != null) {
+            if (mProgressDialog.getTaskId() == taskId) {
+                mProgressDialog.removeProgressBar();
             }
             else {
                 Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, 

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -713,6 +713,10 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
         }
     }
 
+    /*
+     * (non-Javadoc)
+     * @see org.commcare.dalvik.dialogs.DialogController#updateProgressBar(int, int, int)
+     */
     @Override
     public void updateProgressBar(int progress, int max, int taskId) {
         CustomProgressDialog mProgressDialog = getCurrentDialog();
@@ -728,6 +732,11 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
         }
     }
     
+    /*
+     * (non-Javadoc)
+     * @see org.commcare.dalvik.dialogs.DialogController#removeProgressBar(int)
+     */
+    /*@Override
     public void removeProgressBar(int taskId) {
         CustomProgressDialog mProgressDialog = getCurrentDialog();
         if (mProgressDialog != null) {
@@ -740,7 +749,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
                         + "task for which the update message was intended.");
             }
         }
-    }
+    }*/
 
     /*
      * (non-Javadoc)

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -734,25 +734,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
     
     /*
      * (non-Javadoc)
-     * @see org.commcare.dalvik.dialogs.DialogController#removeProgressBar(int)
-     */
-    /*@Override
-    public void removeProgressBar(int taskId) {
-        CustomProgressDialog mProgressDialog = getCurrentDialog();
-        if (mProgressDialog != null) {
-            if (mProgressDialog.getTaskId() == taskId) {
-                mProgressDialog.removeProgressBar();
-            }
-            else {
-                Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, 
-                        "Attempting to update a progress dialog whose taskId does not match the"
-                        + "task for which the update message was intended.");
-            }
-        }
-    }*/
-
-    /*
-     * (non-Javadoc)
      * @see org.commcare.dalvik.dialogs.DialogController#showProgressDialog(int)
      */
     @Override

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -354,12 +354,17 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 } else if(update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
                     receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[] {String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
                 } else if(update[0] == DataPullTask.PROGRESS_PROCESSING) {
+                    receiver.updateProgress(Localization.get("sync.process.processing", new String[] {String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
                     receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
                 }  else if(update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
                     receiver.updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
                 } else if(update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
                     receiver.updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
                 }
+
+                /*if(update[0] != DataPullTask.PROGRESS_PROCESSING) {
+                    receiver.removeProgressBar(DataPullTask.DATA_PULL_TASK_ID);
+                }*/
             }
 
             /*

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -345,7 +345,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
              */
             @Override
             protected void deliverUpdate(CommCareHomeActivity receiver, Integer... update) {
-                
                 if(update[0] == DataPullTask.PROGRESS_STARTED) {
                     receiver.updateProgress(Localization.get("sync.progress.purge"), DataPullTask.DATA_PULL_TASK_ID);
                 } else if(update[0] == DataPullTask.PROGRESS_CLEANED) {
@@ -355,7 +354,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 } else if(update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
                     receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[] {String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
                 } else if(update[0] == DataPullTask.PROGRESS_PROCESSING) {
-                    receiver.updateProgress(Localization.get("sync.process.processing", new String[] {String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
+                    receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
                 }  else if(update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
                     receiver.updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
                 } else if(update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
@@ -1690,8 +1689,11 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                     + "any valid possibilities in CommCareHomeActivity");
             return null;
         }
-        return CustomProgressDialog.newInstance(title, message, taskId);
-        
+        CustomProgressDialog dialog = CustomProgressDialog.newInstance(title, message, taskId);
+        if (taskId == ProcessAndSendTask.PROCESSING_PHASE_ID) {
+            dialog.addProgressBar();
+        }
+        return dialog;
     }
     
     /*

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -361,10 +361,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 } else if(update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
                     receiver.updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
                 }
-
-                /*if(update[0] != DataPullTask.PROGRESS_PROCESSING) {
-                    receiver.removeProgressBar(DataPullTask.DATA_PULL_TASK_ID);
-                }*/
             }
 
             /*

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -987,7 +987,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             } else if (phase == ResourceEngineTask.PHASE_COMMIT) {
                 updateProgress(Localization.get("updates.downloaded"), DIALOG_INSTALL_PROGRESS);
             }
-            removeProgressBar(DIALOG_INSTALL_PROGRESS);
+            //removeProgressBar(DIALOG_INSTALL_PROGRESS);
         }
         else {
             updateProgress(Localization.get("profile.found", new String[]{""+done,""+total}), DIALOG_INSTALL_PROGRESS);

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -987,7 +987,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             } else if (phase == ResourceEngineTask.PHASE_COMMIT) {
                 updateProgress(Localization.get("updates.downloaded"), DIALOG_INSTALL_PROGRESS);
             }
-            //removeProgressBar(DIALOG_INSTALL_PROGRESS);
         }
         else {
             updateProgress(Localization.get("profile.found", new String[]{""+done,""+total}), DIALOG_INSTALL_PROGRESS);

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -987,9 +987,11 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             } else if (phase == ResourceEngineTask.PHASE_COMMIT) {
                 updateProgress(Localization.get("updates.downloaded"), DIALOG_INSTALL_PROGRESS);
             }
+            removeProgressBar(DIALOG_INSTALL_PROGRESS);
         }
         else {
             updateProgress(Localization.get("profile.found", new String[]{""+done,""+total}), DIALOG_INSTALL_PROGRESS);
+            updateProgressBar(done, total, DIALOG_INSTALL_PROGRESS);
         }
     }
 
@@ -1025,6 +1027,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         CustomProgressDialog lastDialog = getCurrentDialog();
         boolean isChecked = (lastDialog == null) ? false : lastDialog.isChecked();
         dialog.addCheckbox(checkboxText, isChecked);
+        dialog.addProgressBar();
         return dialog;
     }
 

--- a/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
@@ -133,7 +133,7 @@ public class CommCareVerificationActivity extends CommCareActivity<CommCareVerif
     public void updateVerifyProgress(int done, int pending) {
         updateProgress(Localization.get("verification.progress",new String[] {""+done,""+pending}),
             DIALOG_VERIFY_PROGRESS);
-        
+        updateProgressBar(done, pending, DIALOG_VERIFY_PROGRESS);
     }
 
     /*
@@ -247,8 +247,10 @@ public class CommCareVerificationActivity extends CommCareActivity<CommCareVerif
     @Override
     public CustomProgressDialog generateProgressDialog(int taskId) {
         if (taskId == DIALOG_VERIFY_PROGRESS) {
-            return CustomProgressDialog.newInstance
+            CustomProgressDialog dialog = CustomProgressDialog.newInstance
                     (Localization.get("verification.title"), Localization.get("verification.checking"), taskId);
+            dialog.addProgressBar();
+            return dialog;
         }
         System.out.println("WARNING: taskId passed to generateProgressDialog does not match "
                 + "any valid possibilities in CommCareVerificationActivity");        

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -228,10 +228,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                         } else if(update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
                             receiver.updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
                         }
-                        
-                        /*if(update[0] != DataPullTask.PROGRESS_PROCESSING) {
-                            receiver.removeProgressBar(DataPullTask.DATA_PULL_TASK_ID);
-                        }*/
                     }
 
                     /*

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -221,6 +221,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                         } else if(update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
                             receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[] {String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
                         } else if(update[0] == DataPullTask.PROGRESS_PROCESSING) {
+                            receiver.updateProgress(Localization.get("sync.process.processing", new String[] {String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
                             receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
                         } else if(update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
                             receiver.updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
@@ -228,9 +229,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                             receiver.updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
                         }
                         
-                        if(update[0] != DataPullTask.PROGRESS_PROCESSING) {
+                        /*if(update[0] != DataPullTask.PROGRESS_PROCESSING) {
                             receiver.removeProgressBar(DataPullTask.DATA_PULL_TASK_ID);
-                        }
+                        }*/
                     }
 
                     /*

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -221,11 +221,15 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                         } else if(update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
                             receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[] {String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
                         } else if(update[0] == DataPullTask.PROGRESS_PROCESSING) {
-                            receiver.updateProgress(Localization.get("sync.process.processing", new String[] {String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
+                            receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
                         } else if(update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
                             receiver.updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
                         } else if(update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
                             receiver.updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
+                        }
+                        
+                        if(update[0] != DataPullTask.PROGRESS_PROCESSING) {
+                            receiver.removeProgressBar(DataPullTask.DATA_PULL_TASK_ID);
                         }
                     }
 
@@ -472,6 +476,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
             dialog = CustomProgressDialog.newInstance(Localization.get("sync.progress.title"),
                     Localization.get("sync.progress.starting"), taskId);
             dialog.addCancelButton();
+            dialog.addProgressBar();
             break;
         default:
             System.out.println("WARNING: taskId passed to generateProgressDialog does not match "

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 public class CustomProgressDialog extends DialogFragment {
@@ -37,6 +38,9 @@ public class CustomProgressDialog extends DialogFragment {
     private final static String KEY_USING_BUTTON = "using_cancel_buton";
     private final static String KEY_TASK_ID = "task_id";
     private final static String KEY_CANCELABLE = "is_cancelable";
+    private final static String KEY_USING_PROGRESS_BAR = "using_progress_bar";
+    private final static String KEY_PROGRESS_BAR_PROGRESS = "progress_bar_progress";
+    private final static String KEY_PROGRESS_BAR_MAX = "progress_bar_max";
     
     //id of the task that spawned this dialog, -1 if not associated with a CommCareTask
     private int taskId;
@@ -53,6 +57,11 @@ public class CustomProgressDialog extends DialogFragment {
     
     //for cancel button
     private boolean usingCancelButton;
+    
+    //for progress bar
+    private boolean usingProgressBar;
+    private int progressBarProgress;
+    private int progressBarMax;
         
     public static CustomProgressDialog newInstance(String title, String message, int taskId) {
         CustomProgressDialog frag = new CustomProgressDialog();
@@ -74,6 +83,21 @@ public class CustomProgressDialog extends DialogFragment {
     
     public void setCancelable() {
         this.isCancelable = true;
+    }
+    
+    public void addProgressBar() {
+        this.usingProgressBar = true;
+        this.progressBarProgress = 0;
+        this.progressBarMax = 0;
+    }
+    
+    public void removeProgressBar() {
+        this.usingProgressBar = false;
+        Dialog dialog = getDialog();
+        if (dialog != null) {
+            dialog.findViewById(R.id.progress_bar_horizontal).setVisibility(View.GONE);
+        }
+        dialog.findViewById(R.id.progress_bar).setVisibility(View.VISIBLE);
     }
     
     private void setTaskId(int id) {
@@ -112,6 +136,9 @@ public class CustomProgressDialog extends DialogFragment {
             this.usingCancelButton = savedInstanceState.getBoolean(KEY_USING_BUTTON);
             this.taskId = savedInstanceState.getInt(KEY_TASK_ID);
             this.isCancelable = savedInstanceState.getBoolean(KEY_CANCELABLE);
+            this.usingProgressBar = savedInstanceState.getBoolean(KEY_USING_PROGRESS_BAR);
+            this.progressBarProgress = savedInstanceState.getInt(KEY_PROGRESS_BAR_PROGRESS);
+            this.progressBarMax = savedInstanceState.getInt(KEY_PROGRESS_BAR_MAX);
         }
     }
 
@@ -170,6 +197,15 @@ public class CustomProgressDialog extends DialogFragment {
             b.setVisibility(View.VISIBLE);
         }
         
+        if (usingProgressBar) {
+            ProgressBar bar = (ProgressBar) view.findViewById(R.id.progress_bar_horizontal);
+            bar.setProgressDrawable(getResources().getDrawable(R.drawable.progressbar));
+            bar.setProgress(progressBarProgress);
+            bar.setMax(progressBarMax);
+            bar.setVisibility(View.VISIBLE);
+            view.findViewById(R.id.progress_bar).setVisibility(View.GONE);
+        }
+        
         builder.setView(view);
         Dialog d = builder.create();
         d.setCanceledOnTouchOutside(isCancelable);
@@ -196,6 +232,20 @@ public class CustomProgressDialog extends DialogFragment {
         outState.putBoolean(KEY_USING_BUTTON, this.usingCancelButton);
         outState.putInt(KEY_TASK_ID, this.taskId);
         outState.putBoolean(KEY_CANCELABLE, this.isCancelable);
+        outState.putBoolean(KEY_USING_PROGRESS_BAR, this.usingProgressBar);
+        outState.putInt(KEY_PROGRESS_BAR_PROGRESS, this.progressBarProgress);
+        outState.putInt(KEY_PROGRESS_BAR_MAX, this.progressBarMax);
+    }
+
+    public void updateProgressBar(int progress, int max) {
+        this.progressBarProgress = progress;
+        this.progressBarMax = max;
+        Dialog dialog = getDialog();
+        if (dialog != null) {
+            ProgressBar bar = (ProgressBar) dialog.findViewById(R.id.progress_bar_horizontal);
+            bar.setProgress(progress);
+            bar.setMax(max);
+        }
     }
 
 }

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -91,15 +91,6 @@ public class CustomProgressDialog extends DialogFragment {
         this.progressBarMax = 0;
     }
     
-    /*public void removeProgressBar() {
-        this.usingProgressBar = false;
-        Dialog dialog = getDialog();
-        if (dialog != null) {
-            dialog.findViewById(R.id.progress_bar_horizontal).setVisibility(View.GONE);
-            dialog.findViewById(R.id.progress_bar).setVisibility(View.VISIBLE);
-        }
-    }*/
-    
     private void setTaskId(int id) {
         this.taskId = id;
     }

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -91,14 +91,14 @@ public class CustomProgressDialog extends DialogFragment {
         this.progressBarMax = 0;
     }
     
-    public void removeProgressBar() {
+    /*public void removeProgressBar() {
         this.usingProgressBar = false;
         Dialog dialog = getDialog();
         if (dialog != null) {
             dialog.findViewById(R.id.progress_bar_horizontal).setVisibility(View.GONE);
+            dialog.findViewById(R.id.progress_bar).setVisibility(View.VISIBLE);
         }
-        dialog.findViewById(R.id.progress_bar).setVisibility(View.VISIBLE);
-    }
+    }*/
     
     private void setTaskId(int id) {
         this.taskId = id;

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -194,6 +194,8 @@ public class CustomProgressDialog extends DialogFragment {
             bar.setProgress(progressBarProgress);
             bar.setMax(progressBarMax);
             bar.setVisibility(View.VISIBLE);
+            
+            // If there's a determinate progress bar, hide the spinning indicator
             view.findViewById(R.id.progress_bar).setVisibility(View.GONE);
         }
         

--- a/app/src/org/commcare/dalvik/dialogs/DialogController.java
+++ b/app/src/org/commcare/dalvik/dialogs/DialogController.java
@@ -25,6 +25,9 @@ public interface DialogController {
     /** Update the current dialog's progress bar **/
     void updateProgressBar(int progress, int max, int taskId);
     
+    /** Remove the progress bar **/
+    //void removeProgressBar(int taskId);
+    
     /** Create an instance of CustomProgressDialog specific to the activity
      *  implementing this method -- this method should be implemented lower down
      *  in the activity hierarchy, in one of CommCareActivity's subclasses, 

--- a/app/src/org/commcare/dalvik/dialogs/DialogController.java
+++ b/app/src/org/commcare/dalvik/dialogs/DialogController.java
@@ -21,6 +21,9 @@ public interface DialogController {
     
     /** Update the current dialog's message to the new text **/
     void updateProgress(String updateText, int taskId);
+
+    /** Update the current dialog's progress bar **/
+    void updateProgressBar(int progress, int max, int taskId);
     
     /** Create an instance of CustomProgressDialog specific to the activity
      *  implementing this method -- this method should be implemented lower down

--- a/app/src/org/commcare/dalvik/dialogs/DialogController.java
+++ b/app/src/org/commcare/dalvik/dialogs/DialogController.java
@@ -25,9 +25,6 @@ public interface DialogController {
     /** Update the current dialog's progress bar **/
     void updateProgressBar(int progress, int max, int taskId);
     
-    /** Remove the progress bar **/
-    //void removeProgressBar(int taskId);
-    
     /** Create an instance of CustomProgressDialog specific to the activity
      *  implementing this method -- this method should be implemented lower down
      *  in the activity hierarchy, in one of CommCareActivity's subclasses, 


### PR DESCRIPTION
This came up in conversation and sounded like an easy win.

The one rough edge is that some tasks only need a progress bar some of the time, e.g., during login, an empty progress bar shows while the message says "Communicating with server" so that it can be used when the message switches to "Processing server data: X/Y."

![screenshot_2015-01-16-16-28-13 1](https://cloud.githubusercontent.com/assets/1486591/5786301/aa4ecf1c-9db0-11e4-890f-f6a96b415899.png)

