### PR TITLE
Lock the install to prevent SD Card Move

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.commcare.dalvik"
     android:versionCode="106"
-    android:versionName="2.19" >
+    android:versionName="2.19" 
+    android:installLocation="internalOnly">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />


### PR DESCRIPTION
Prevent Move to SD Card until we can fix/investigate the outcomes there.