### PR TITLE
Entity detail view/activity refactoring

### DIFF
--- a/app/res/layout-land/screen_compound_select.xml
+++ b/app/res/layout-land/screen_compound_select.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:weightSum="1" >
+
+    <FrameLayout
+        android:id="@+id/screen_compound_select_left_pane"
+        android:layout_width="0px"
+        android:layout_height="match_parent"
+        android:layout_weight="0.5" >
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/screen_compound_select_right_pane"
+        android:layout_width="0px"
+        android:layout_height="match_parent"
+        android:layout_weight="0.5"
+        android:background="@drawable/background_compound_detail" >
+
+        <TextView
+            android:id="@+id/screen_compound_select_prompt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical|center_horizontal"
+            android:layout_margin="60dp"
+            android:background="@drawable/border_dashed_edges"
+            android:gravity="center_vertical|center_horizontal"
+            android:paddingBottom="30dp"
+            android:paddingLeft="10dp"
+            android:paddingRight="10dp"
+            android:paddingTop="30dp"
+            android:text="Please select a case"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+    </FrameLayout>
+
+</LinearLayout>

--- a/app/res/layout-land/screen_compound_select.xml
+++ b/app/res/layout-land/screen_compound_select.xml
@@ -6,14 +6,14 @@
     android:weightSum="1" >
 
     <FrameLayout
-        android:id="@+id/screen_compound_select_left_pane"
+        android:id="@+id/screen_compound_select_first_pane"
         android:layout_width="0px"
         android:layout_height="match_parent"
         android:layout_weight="0.5" >
     </FrameLayout>
 
     <FrameLayout
-        android:id="@+id/screen_compound_select_right_pane"
+        android:id="@+id/screen_compound_select_second_pane"
         android:layout_width="0px"
         android:layout_height="match_parent"
         android:layout_weight="0.5"

--- a/app/res/layout/screen_compound_select.xml
+++ b/app/res/layout/screen_compound_select.xml
@@ -2,29 +2,37 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal" android:weightSum="1">
-
+    android:orientation="vertical"
+    android:weightSum="1" >
+
     <FrameLayout
         android:id="@+id/screen_compound_select_left_pane"
-        android:layout_width="0px"
-        android:layout_height="match_parent" android:layout_weight="0.5">
-
+        android:layout_width="match_parent"
+        android:layout_height="0px"
+        android:layout_weight="0.5" >
     </FrameLayout>
-
+
     <FrameLayout
         android:id="@+id/screen_compound_select_right_pane"
-        android:layout_width="0px"
-        android:layout_height="match_parent" android:layout_weight="0.5" android:background="@drawable/background_compound_detail">
-
+        android:layout_width="match_parent"
+        android:layout_height="0px"
+        android:layout_weight="0.5"
+        android:background="@drawable/background_compound_detail" >
+
         <TextView
             android:id="@+id/screen_compound_select_prompt"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|center_horizontal"
+            android:layout_margin="60dp"
+            android:background="@drawable/border_dashed_edges"
             android:gravity="center_vertical|center_horizontal"
+            android:paddingBottom="30dp"
+            android:paddingLeft="10dp"
+            android:paddingRight="10dp"
+            android:paddingTop="30dp"
             android:text="Please select a case"
-            android:textAppearance="?android:attr/textAppearanceMedium" android:background="@drawable/border_dashed_edges" android:layout_margin="60dp" android:paddingLeft="10dp" android:paddingRight="10dp" android:paddingTop="30dp" android:paddingBottom="30dp"/>
-
+            android:textAppearance="?android:attr/textAppearanceMedium" />
     </FrameLayout>
 
 </LinearLayout>

--- a/app/res/layout/screen_compound_select.xml
+++ b/app/res/layout/screen_compound_select.xml
@@ -6,14 +6,14 @@
     android:weightSum="1" >
 
     <FrameLayout
-        android:id="@+id/screen_compound_select_left_pane"
+        android:id="@+id/screen_compound_select_first_pane"
         android:layout_width="match_parent"
         android:layout_height="0px"
         android:layout_weight="0.5" >
     </FrameLayout>
 
     <FrameLayout
-        android:id="@+id/screen_compound_select_right_pane"
+        android:id="@+id/screen_compound_select_second_pane"
         android:layout_width="match_parent"
         android:layout_height="0px"
         android:layout_weight="0.5"

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -11,6 +11,7 @@ import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.CustomProgressDialog;
 import org.commcare.dalvik.dialogs.DialogController;
 import org.commcare.suite.model.Detail;
+import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.util.SessionFrame;
 import org.javarosa.core.model.instance.TreeReference;
@@ -50,6 +51,17 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
     protected final static int DIALOG_PROGRESS = 32;
     protected final static String DIALOG_TEXT = "cca_dialog_text";
     public final static String KEY_DIALOG_FRAG = "dialog_fragment";
+    
+    /**
+     * Utility method to determine whether the given entry is a case
+     * list rather than a form.
+     * 
+     * @param entry
+     * @return
+     */
+    public static boolean isEntryCaseList(Entry entry) {
+        return entry.getCommandId().endsWith("case-list");
+    }
 
     StateFragment stateHolder;
     private boolean firstRun = true;

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -4,6 +4,7 @@ import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.util.DetailCalloutListener;
 import org.commcare.android.util.SerializationUtil;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.components.EntityDetailComponent;
 import org.commcare.suite.model.Detail;
 import org.commcare.util.SessionFrame;
@@ -37,8 +38,9 @@ public class EntityDetailActivity extends CommCareActivity implements DetailCall
     public void onCreate(Bundle savedInstanceState) {   
         
         TreeReference treeReference = SerializationUtil.deserializeFromIntent(getIntent(), EntityDetailActivity.CONTEXT_REFERENCE, TreeReference.class);
-        
+
         mDetailComponent = new EntityDetailComponent(
+                CommCareApplication._().getCurrentSessionWrapper(),
                 this,
                 null,
                 getIntent(),

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -789,6 +789,11 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
             
             Vector<Entry> entries = session.getEntriesForCommand(passedCommand == null ? session.getCommand() : passedCommand);
             prototype = entries.elementAt(0);
+            
+            // TODO: best way to check whether form is a case list?
+            if (prototype.getCommandId().endsWith("case-list")) {
+                mDetailComponent.notifyIsCaseList();
+            }
 
             if (mDetailComponent.isCompound()) {
                 // border around right panel doesn't look right when there are tabs

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -388,7 +388,7 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         //See if we even have a long datum
         if(selectDatum.getLongDetail() != null) {
             //If so, add this. otherwise that'll be the queue to just return
-            i.putExtra(EntityDetailActivity.DETAIL_ID, selectDatum.getLongDetail()); 
+            i.putExtra(EntityDetailComponent.DETAIL_ID, selectDatum.getLongDetail()); 
             i.putExtra(EntityDetailActivity.DETAIL_PERSISTENT_ID, selectDatum.getPersistentDetail());
         }
    

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -792,7 +792,7 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
             prototype = entries.elementAt(0);
             
             if (isEntryCaseList(prototype)) {
-                mDetailComponent.notifyIsCaseList();
+                mDetailComponent.notifyNoResult();
             }
 
             if (mDetailComponent.isCompound()) {

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -106,7 +106,7 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
     private EntityLoaderTask loader;
     
     private boolean inAwesomeMode = false;
-    FrameLayout rightFrame;
+    FrameLayout secondFrame;
     private EntityDetailComponent mDetailComponent;
     
     Intent selectedIntent = null;
@@ -156,10 +156,10 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
             
             //Inflate and set up the normal view for now.
             setContentView(R.layout.screen_compound_select);
-            View.inflate(this, R.layout.entity_select_layout, (ViewGroup)findViewById(R.id.screen_compound_select_left_pane));
+            View.inflate(this, R.layout.entity_select_layout, (ViewGroup)findViewById(R.id.screen_compound_select_first_pane));
             inAwesomeMode = true;
             
-            rightFrame = (FrameLayout)findViewById(R.id.screen_compound_select_right_pane);
+            secondFrame = (FrameLayout)findViewById(R.id.screen_compound_select_second_pane);
             
             TextView message = (TextView)findViewById(R.id.screen_compound_select_prompt);
             message.setText(Localization.get("select.placeholder.message", new String[] {Localization.get("cchq.case")}));
@@ -768,18 +768,18 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
 		return inAwesomeMode;
     }
     
-    boolean rightFrameSetup = false;
+    boolean secondFrameSetup = false;
     
     public void displayReferenceAwesome(final TreeReference selection, int detailIndex) {
         selectedIntent = getDetailIntent(selection, getIntent());
         //this should be 100% "fragment" able
-        if(!rightFrameSetup) {
+        if(!secondFrameSetup) {
             findViewById(R.id.screen_compound_select_prompt).setVisibility(View.GONE);
             
             mDetailComponent = new EntityDetailComponent(
                     asw,
                     this,
-                    rightFrame,
+                    secondFrame,
                     selectedIntent,
                     selection,
                     detailIndex,
@@ -797,10 +797,10 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
 
             if (mDetailComponent.isCompound()) {
                 // border around right panel doesn't look right when there are tabs
-                rightFrame.setBackgroundDrawable(null);
+                secondFrame.setBackgroundDrawable(null);
             }
 
-            rightFrameSetup = true;
+            secondFrameSetup = true;
         }
 
         mDetailComponent.refresh(selectedIntent, selection, detailIndex);

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -230,6 +230,7 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
                 //connect the new one
                 adapter.registerDataSetObserver(this.mListStateObserver);
                 
+                // See if we changed orientation and had an item selected before
                 if(inAwesomeMode && mSelectedPosition >= 0) {
                     TreeReference selection = adapter.getItem(mSelectedPosition);
                     displayReferenceAwesome(selection, mSelectedPosition);
@@ -790,8 +791,7 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
             Vector<Entry> entries = session.getEntriesForCommand(passedCommand == null ? session.getCommand() : passedCommand);
             prototype = entries.elementAt(0);
             
-            // TODO: best way to check whether form is a case list?
-            if (prototype.getCommandId().endsWith("case-list")) {
+            if (isEntryCaseList(prototype)) {
                 mDetailComponent.notifyIsCaseList();
             }
 

--- a/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
+++ b/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
@@ -41,6 +41,8 @@ public class EntityDetailComponent {
     
     private Intent selectedIntent;
     
+    private boolean isCaseList;
+    
     public EntityDetailComponent(
             AndroidSessionWrapper asw,
             final Activity activity,
@@ -71,10 +73,13 @@ public class EntityDetailComponent {
         buttonNext.setOnClickListener(new OnClickListener() {
             
             public void onClick(View view) {
-                Intent i = new Intent(activity.getIntent());
-                
-                i.putExtra(SessionFrame.STATE_DATUM_VAL, EntityDetailComponent.this.selectedIntent.getStringExtra(SessionFrame.STATE_DATUM_VAL));
-                activity.setResult(Activity.RESULT_OK, i);
+                // Do not try to return a result if it's a case list
+                if (!isCaseList) {
+                    Intent i = new Intent(activity.getIntent());
+                    
+                    i.putExtra(SessionFrame.STATE_DATUM_VAL, EntityDetailComponent.this.selectedIntent.getStringExtra(SessionFrame.STATE_DATUM_VAL));
+                    activity.setResult(Activity.RESULT_OK, i);
+                }
                 
                 activity.finish();
             }
@@ -104,6 +109,10 @@ public class EntityDetailComponent {
     
     public boolean isCompound() {
         return factory.getDetail().isCompound();
+    }
+    
+    public void notifyIsCaseList() {
+        isCaseList = true;
     }
     
     public void refresh(Intent selectedIntent, TreeReference selection, int detailIndex) {

--- a/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
+++ b/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
@@ -41,7 +41,7 @@ public class EntityDetailComponent {
     
     private Intent selectedIntent;
     
-    private boolean isCaseList;
+    private boolean ignoreResult;
     
     public EntityDetailComponent(
             AndroidSessionWrapper asw,
@@ -73,8 +73,7 @@ public class EntityDetailComponent {
         buttonNext.setOnClickListener(new OnClickListener() {
             
             public void onClick(View view) {
-                // Do not try to return a result if it's a case list
-                if (!isCaseList) {
+                if (!ignoreResult) {
                     Intent i = new Intent(activity.getIntent());
                     
                     i.putExtra(SessionFrame.STATE_DATUM_VAL, EntityDetailComponent.this.selectedIntent.getStringExtra(SessionFrame.STATE_DATUM_VAL));
@@ -111,8 +110,8 @@ public class EntityDetailComponent {
         return factory.getDetail().isCompound();
     }
     
-    public void notifyIsCaseList() {
-        isCaseList = true;
+    public void notifyNoResult() {
+        ignoreResult = true;
     }
     
     public void refresh(Intent selectedIntent, TreeReference selection, int detailIndex) {

--- a/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
+++ b/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
@@ -1,0 +1,113 @@
+package org.commcare.dalvik.components;
+
+import org.commcare.android.models.AndroidSessionWrapper;
+import org.commcare.android.models.NodeEntityFactory;
+import org.commcare.android.view.TabbedDetailView;
+import org.commcare.dalvik.R;
+import org.commcare.dalvik.application.CommCareApplication;
+import org.commcare.suite.model.Detail;
+import org.commcare.util.CommCareSession;
+import org.commcare.util.SessionFrame;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.locale.Localization;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.RelativeLayout;
+
+public class EntityDetailComponent {
+
+    public static final String IS_DEAD_END = "eda_ide";
+    public static final String DETAIL_ID = "eda_detail_id";
+    
+    private final RelativeLayout container;
+    private final Button buttonNext;
+    private final TabbedDetailView detailView;
+    
+    private final CommCareSession session;
+    private final AndroidSessionWrapper asw;
+    private final NodeEntityFactory factory;
+    
+    private TreeReference selection;
+    private int detailIndex;
+    private final boolean hasDetailCalloutListener;
+    
+    public EntityDetailComponent(
+            final Activity activity,
+            ViewGroup root,
+            final Intent selectedIntent,
+            TreeReference selection,
+            int detailIndex,
+            boolean hasDetailCalloutListener) {
+        
+        this.selection = selection;
+        this.detailIndex = detailIndex;
+        this.hasDetailCalloutListener = hasDetailCalloutListener;
+        
+        if (root == null) {
+            activity.setContentView(R.layout.entity_detail);
+            container = (RelativeLayout) activity.findViewById(R.id.entity_detail);
+        } else {
+            container = (RelativeLayout) View.inflate(
+                    activity,
+                    R.layout.entity_detail,
+                    root
+            ).findViewById(R.id.entity_detail);
+        }
+        
+        buttonNext = (Button) container.findViewById(R.id.entity_select_button);
+        buttonNext.setText(Localization.get("select.detail.confirm"));
+        buttonNext.setOnClickListener(new OnClickListener() {
+            
+            public void onClick(View view) {
+                Intent i = new Intent(activity.getIntent());
+                
+                i.putExtra(SessionFrame.STATE_DATUM_VAL, selectedIntent.getStringExtra(SessionFrame.STATE_DATUM_VAL));
+                activity.setResult(Activity.RESULT_OK, i);
+                
+                activity.finish();
+            }
+            
+        });
+        
+        if(activity.getIntent().getBooleanExtra(IS_DEAD_END, false)) {
+            buttonNext.setText("Done");
+        }
+        
+        detailView = (TabbedDetailView) container.findViewById(R.id.entity_detail_tabs);
+        
+        detailView.setRoot((ViewGroup) container.findViewById(R.id.entity_detail_tabs));
+        
+        asw = CommCareApplication._().getCurrentSessionWrapper();
+        session = asw.getSession();
+        
+        factory = new NodeEntityFactory(session.getDetail(selectedIntent.getStringExtra(DETAIL_ID)), asw.getEvaluationContext());
+        
+        detailView.setDetail(factory.getDetail());
+        
+        refresh();
+    }
+    
+    public Detail getDetail(String detailId) {
+        return session.getDetail(detailId);
+    }
+    
+    public boolean isCompound() {
+        return factory.getDetail().isCompound();
+    }
+    
+    public void refresh(TreeReference selection, int detailIndex) {
+        this.selection = selection;
+        this.detailIndex = detailIndex;
+        refresh();
+    }
+    
+    public void refresh() {
+        detailView.refresh(factory.getDetail(), selection, detailIndex, hasDetailCalloutListener);
+    }
+
+}

--- a/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
+++ b/app/src/org/commcare/dalvik/components/EntityDetailComponent.java
@@ -4,7 +4,6 @@ import org.commcare.android.models.AndroidSessionWrapper;
 import org.commcare.android.models.NodeEntityFactory;
 import org.commcare.android.view.TabbedDetailView;
 import org.commcare.dalvik.R;
-import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.suite.model.Detail;
 import org.commcare.util.CommCareSession;
 import org.commcare.util.SessionFrame;
@@ -19,6 +18,11 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.RelativeLayout;
 
+/**
+ * 
+ * @author Richard Lu
+ *
+ */
 public class EntityDetailComponent {
 
     public static final String IS_DEAD_END = "eda_ide";
@@ -29,21 +33,24 @@ public class EntityDetailComponent {
     private final TabbedDetailView detailView;
     
     private final CommCareSession session;
-    private final AndroidSessionWrapper asw;
     private final NodeEntityFactory factory;
     
     private TreeReference selection;
     private int detailIndex;
     private final boolean hasDetailCalloutListener;
     
+    private Intent selectedIntent;
+    
     public EntityDetailComponent(
+            AndroidSessionWrapper asw,
             final Activity activity,
             ViewGroup root,
-            final Intent selectedIntent,
+            Intent selectedIntent,
             TreeReference selection,
             int detailIndex,
             boolean hasDetailCalloutListener) {
         
+        this.selectedIntent = selectedIntent;
         this.selection = selection;
         this.detailIndex = detailIndex;
         this.hasDetailCalloutListener = hasDetailCalloutListener;
@@ -66,7 +73,7 @@ public class EntityDetailComponent {
             public void onClick(View view) {
                 Intent i = new Intent(activity.getIntent());
                 
-                i.putExtra(SessionFrame.STATE_DATUM_VAL, selectedIntent.getStringExtra(SessionFrame.STATE_DATUM_VAL));
+                i.putExtra(SessionFrame.STATE_DATUM_VAL, EntityDetailComponent.this.selectedIntent.getStringExtra(SessionFrame.STATE_DATUM_VAL));
                 activity.setResult(Activity.RESULT_OK, i);
                 
                 activity.finish();
@@ -82,7 +89,6 @@ public class EntityDetailComponent {
         
         detailView.setRoot((ViewGroup) container.findViewById(R.id.entity_detail_tabs));
         
-        asw = CommCareApplication._().getCurrentSessionWrapper();
         session = asw.getSession();
         
         factory = new NodeEntityFactory(session.getDetail(selectedIntent.getStringExtra(DETAIL_ID)), asw.getEvaluationContext());
@@ -100,7 +106,8 @@ public class EntityDetailComponent {
         return factory.getDetail().isCompound();
     }
     
-    public void refresh(TreeReference selection, int detailIndex) {
+    public void refresh(Intent selectedIntent, TreeReference selection, int detailIndex) {
+        this.selectedIntent = selectedIntent;
         this.selection = selection;
         this.detailIndex = detailIndex;
         refresh();

--- a/app/src/org/commcare/dalvik/components/EntitySelectComponent.java
+++ b/app/src/org/commcare/dalvik/components/EntitySelectComponent.java
@@ -1,0 +1,5 @@
+package org.commcare.dalvik.components;
+
+public class EntitySelectComponent {
+
+}

--- a/app/src/org/commcare/dalvik/components/EntitySelectComponent.java
+++ b/app/src/org/commcare/dalvik/components/EntitySelectComponent.java
@@ -1,5 +1,0 @@
-package org.commcare.dalvik.components;
-
-public class EntitySelectComponent {
-
-}


### PR DESCRIPTION
Factors out the core functionality of R.layout.entity_detail, which is used by both EntityDetailActivity and EntitySelectActivity, into a self-contained component class (didn't feel that it required an entire Fragment).

Also crash fixes:
- Rotating in awesome mode many times resulted in an ill-defined activity stack (due to logic errors in determing whether to rotate back into awesome mode or the detail activity, etc), which sometimes crashed when attempting to exit the form. FIX: turn on awesome mode *all the time* on large screens (with the panes stacked vertically in portrait and horizontally in landscape). This may have caused some of the state-checking logic elsewhere to become obsolete, but I am not familiar enough with the code to know which ones.
- Clicking "Select" for an item in a case list in awesome mode consistently caused crashes. FIX: do not set an activity result upon clicking "Select" if the current entry is a case list.

---

There is also a factoring out of EntitySelectActivity's core functionality on branch entity-select-refactor (based on this branch), but 1) it doesn't seem necessary, since the select view is not used anywhere else, and 2) it's messy, due to the existence of awesome mode being so coupled with the select view code (and me not being thoroughly familiar with the existing code).