### PR TITLE
Asynchronous Restore Requests

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -87,6 +87,7 @@ sync.fail.bad.local=Your information was fetched, but a problem occured with the
 sync.fail.bad.network=Couldn't contact server. Please make sure an internet connection is available or try again later.
 sync.fail.server.error=The server had an error processing your data. Please try again later. If the problem persists, contact technical support.
 sync.fail.unknown=An unexpected issue occurred during sync. Please try to sync again.
+sync.fail.cancelled=Sync attempt cancelled
 
 sync.progress.title=Communicating with Server
 sync.progress.starting=Requesting Data...
@@ -97,6 +98,12 @@ sync.progress.authing=Contacting server for sync...
 sync.progress.downloading=Server contacted, downloading data.
 sync.process.downloading.progress=Download Progress: ${0}%
 sync.process.processing=Processing server data: ${0}/${1}
+sync.progress.waiting=The remote server needs some time to generate your sync data. Next Attempt: ${0}
+
+timespan.custom.seconds=${0} Seconds
+
+#Make this ${1} to use custom display formatting
+timespan.display.output=${0}
 
 sync.recover.needed=Phone and server have inconsistent data! Starting recovery...
 sync.recover.started=Recovering local DB State. Please do not turn off the app!

--- a/app/src/org/commcare/android/api/ExternalApiReceiver.java
+++ b/app/src/org/commcare/android/api/ExternalApiReceiver.java
@@ -247,7 +247,7 @@ public class ExternalApiReceiver extends BroadcastReceiver {
              */
             @Override
             protected void deliverResult(Object receiver, Integer result) {
-                if(result != DataPullTask.DOWNLOAD_SUCCESS) {
+                if(result != DataPullTask.RESULT_DOWNLOAD_SUCCESS) {
                     Toast.makeText(c, "CommCare couldn't sync. Please try to sync from CommCare directly for more information", Toast.LENGTH_LONG).show();
                 } else {
                     Toast.makeText(c, "CommCare synced!", Toast.LENGTH_LONG).show();

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -704,6 +704,13 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
         if (mProgressDialog != null) {
             if (mProgressDialog.getTaskId() == taskId) {
                 mProgressDialog.updateMessage(updateText);
+                
+                //Try to signal "cancellability"
+                CommCareTask running = stateHolder.currentTask;
+                if(running != null) {
+                    mProgressDialog.setCancelButtonEnabled(running.isCurrentlyCancellable());
+                }
+                
             }
             else {
                 Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, 

--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -195,4 +195,23 @@ public abstract class CommCareTask<A, B, C, R> extends AsyncTask<A, B, C> {
             connector = null;
         }
     }
+    
+    /**
+     * For tasks that are started in a mode where they can be cancelled
+     * this method provides feedback about whether the task can _currently_
+     * be cancelled. 
+     * 
+     * This is expected to change dynamically based on progress updates,
+     * when this flag will be read.
+     * 
+     * This flag will mean nothing if the dialog is started without a
+     * cancel button being enabled.
+     * 
+     * @return True if the task currently can be cancelled. False if the
+     * task has entered a phase where cancellation should no longer
+     * be considered possible.
+     */
+    public boolean isCurrentlyCancellable() {
+        return true;
+    }
 }

--- a/app/src/org/commcare/android/util/StringUtils.java
+++ b/app/src/org/commcare/android/util/StringUtils.java
@@ -6,9 +6,12 @@ package org.commcare.android.util;
 import java.text.Normalizer;
 import java.util.regex.Pattern;
 
+import org.javarosa.core.services.locale.Localization;
+
 import android.annotation.SuppressLint;
 import android.os.Build;
 import android.support.v4.util.LruCache;
+import android.text.format.DateUtils;
 import android.util.Pair;
 
 /**
@@ -139,5 +142,21 @@ public class StringUtils {
             }
         }
         return Pair.create(false, -1);
+    }
+    
+    
+    public static String getRelativeTimeSpanString(long delta, long current, long formatting, int flags) {
+        return getRelativeTimeSpanString(delta, current, formatting, flags, "timespan.custom.seconds");
+    }
+    
+    public static String getRelativeTimeSpanString(long delta, long current, long formatting, int flags, String fallback) {
+         String deviceSpan = DateUtils.getRelativeTimeSpanString(delta, current, formatting, flags).toString();
+         
+        //generate the fallback
+        int seconds = (int)((delta - current) / 1000);
+        String customSpan = Localization.get(fallback, new String[] {String.valueOf(seconds)});
+        
+        //let the current translation pick which one to use.
+        return Localization.get("timespan.display.output", new String[] {deviceSpan, customSpan});
     }
 }

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -434,7 +434,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                     @Override
                     protected void deliverResult(FormRecordListActivity receiver, Integer status) {
                         switch(status) {
-                        case DataPullTask.DOWNLOAD_SUCCESS:                            
+                        case DataPullTask.RESULT_DOWNLOAD_SUCCESS:                            
                             FormRecordCleanupTask<FormRecordListActivity> task = new FormRecordCleanupTask<FormRecordListActivity>(FormRecordListActivity.this, platform,CLEANUP_ID) {
 
                                 /*
@@ -480,22 +480,22 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                             task.connect(receiver);
                             task.execute();
                             break;
-                        case DataPullTask.UNKNOWN_FAILURE:
+                        case DataPullTask.RESULT_UNKNOWN_FAILURE:
                             Toast.makeText(receiver, "Failure retrieving or processing data, please try again later...", Toast.LENGTH_LONG).show();
                             break;
-                        case DataPullTask.AUTH_FAILED:
+                        case DataPullTask.RESULT_AUTH_FAILED:
                             Toast.makeText(receiver, "Authentication failure. Please logout and resync with the server and try again.", Toast.LENGTH_LONG).show();
                             break;
-                        case DataPullTask.BAD_DATA:
+                        case DataPullTask.RESULT_BAD_DATA:
                             Toast.makeText(receiver, "Bad data from server. Please talk with your supervisor.", Toast.LENGTH_LONG).show();
                             break;                            
-                        case DataPullTask.CONNECTION_TIMEOUT:
+                        case DataPullTask.RESULT_CONNECTION_TIMEOUT:
                             Toast.makeText(receiver, "The server took too long to generate a response. Please try again later, and ask your supervisor if the problem persists.", Toast.LENGTH_LONG).show();
                             break;
-                        case DataPullTask.SERVER_ERROR:
+                        case DataPullTask.RESULT_SERVER_ERROR:
                             Toast.makeText(receiver, "The server had an error processing your data. Please try again later, and contact technical support if the problem persists.", Toast.LENGTH_LONG).show();
                             break;
-                        case DataPullTask.UNREACHABLE_HOST:
+                        case DataPullTask.RESULT_UNREACHABLE_HOST:
                             Toast.makeText(receiver, "Couldn't contact server, please check your network connection and try again.", Toast.LENGTH_LONG).show();
                             break;
                         }

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -201,7 +201,7 @@ public class CustomProgressDialog extends DialogFragment {
         
         builder.setView(view);
         Dialog d = builder.create();
-        d.setCanceledOnTouchOutside(isCancelable);
+        d.setCanceledOnTouchOutside(this.isCancelable);
         return d;
     }
     
@@ -240,5 +240,20 @@ public class CustomProgressDialog extends DialogFragment {
             bar.setMax(max);
         }
     }
-
+    
+    /**
+     * For dialogs using the cancel button, certain types of progress may enter a "read only mode" after which the task
+     * can no longer be cancelled. This method allows the dialog to swap that state back and forth.
+     * 
+     * Does nothing if the dialog was not created with addCancelButton
+     * 
+     * @param enabled
+     */
+    public void setCancelButtonEnabled(boolean enabled) {
+        Dialog dialog = getDialog();
+        if (usingCancelButton) {
+            Button b = (Button) dialog.findViewById(R.id.dialog_cancel_button);
+            b.setEnabled(enabled);
+        }
+    }
 }


### PR DESCRIPTION
Extends the sync protocol to accept a 202 response from the server that is processed in full, and then instructs CommCare to wait for a set amount of time before requesting additional data.

Extends asynchronous tasks to be able to inform dialogs that they should enable/disable cancellation.