### PR TITLE
PR fixes

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -245,7 +245,7 @@ demo.mode.warning.dismiss=I Understand
 
 select.search.label=Search:
 select.search.status=${0} of ${1} results for your search: "${2}"
-select.detail.confirm=Select
+select.detail.confirm=Continue
 
 mult.install.no.browser=There is no File Browsing application installed on this device! Please download one and try again.
 

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -849,6 +849,9 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
     protected boolean onForwardSwipe() {
         // If user has picked an entity, move along to form entry
         if (selectedIntent != null) {
+            if (inAwesomeMode && detailView != null && detailView.getCurrentTab() < detailView.getTabCount() - 1) {
+                return false;
+            }
             select();
         }
         return true;
@@ -860,6 +863,9 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
      */
     @Override
     protected boolean onBackwardSwipe() {
+        if (inAwesomeMode && detailView != null && detailView.getCurrentTab() > 0) {
+            return false;
+        }
         finish();
         return true;
     }


### PR DESCRIPTION
Fixes for https://github.com/dimagi/commcare-odk/pull/115

- "Continue" text wasn't correctly implemented
- Double-pane layout for extra large screens in landscape wasn't letting you swipe through tabbed case details. It's still a little weird - if you swipe and only touch the left side of the screen, it's possible that nothing will happen (no navigation because tabbed case details aren't in the right state, but tabbed case details don't change state because you didn't actually touch them) - but I don't think it's unacceptably weird.