### PR TITLE
Handling dialer/sms app failures gracefully

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -289,7 +289,8 @@ notification.sync.connections.action=You don't have any active data connections 
 
 #Add new localization strings here
 
-
+callout.failure.dialer=Dialer app not found
+callout.failure.sms=SMS app not found
 
 
 

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -289,7 +289,7 @@ notification.sync.connections.action=You don't have any active data connections 
 
 #Add new localization strings here
 
-callout.failure.dialer=Dialer app not found
+callout.failure.dialer=Device is not currently configured to make telephone calls
 callout.failure.sms=SMS app not found
 
 

--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -12,6 +12,9 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
+import android.widget.Toast;
+
+import org.javarosa.core.services.locale.Localization;
 
 /**
  * @author ctsims
@@ -113,11 +116,19 @@ public class CallOutActivity extends Activity {
             
             Intent call = new Intent(Intent.ACTION_CALL);
             call.setData(Uri.parse("tel:" + number));
-            startActivity(Intent.createChooser(call, "Dialing " + number));
+            if(call.resolveActivity(getPackageManager()) != null){
+                startActivity(call);
+            } else {
+                Toast.makeText(getApplicationContext(), Localization.get("callout.failure.dialer"), Toast.LENGTH_SHORT).show();
+            }
         } else {                    
             Intent sms = new Intent(Intent.ACTION_SENDTO);
             sms.setData(Uri.parse("smsto:" + number));
-            startActivityForResult(Intent.createChooser(sms, "Messaging " + number),SMS_RESULT);
+            if(sms.resolveActivity(getPackageManager()) != null){
+                startActivityForResult(sms, SMS_RESULT);
+            } else {
+                Toast.makeText(getApplicationContext(), Localization.get("callout.failure.sms"), Toast.LENGTH_SHORT).show();
+            }
         }
     }
     

--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -107,16 +107,17 @@ public class CallOutActivity extends Activity {
     }
     
     private void dispatchAction(String action) {
+        // using createChooser to handle any errors gracefully
         if(Intent.ACTION_CALL.equals(action) ) {
             tManager.listen(listener, PhoneStateListener.LISTEN_CALL_STATE);
             
             Intent call = new Intent(Intent.ACTION_CALL);
             call.setData(Uri.parse("tel:" + number));
-            startActivity(call);
+            startActivity(Intent.createChooser(call, "Dialing " + number));
         } else {                    
             Intent sms = new Intent(Intent.ACTION_SENDTO);
             sms.setData(Uri.parse("smsto:" + number));
-            startActivityForResult(sms,SMS_RESULT);
+            startActivityForResult(Intent.createChooser(sms, "Messaging " + number),SMS_RESULT);
         }
     }
     

--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -119,7 +119,8 @@ public class CallOutActivity extends Activity {
             if(call.resolveActivity(getPackageManager()) != null){
                 startActivity(call);
             } else {
-                Toast.makeText(getApplicationContext(), Localization.get("callout.failure.dialer"), Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, Localization.get("callout.failure.dialer"), Toast.LENGTH_SHORT).show();
+                finish();
             }
         } else {                    
             Intent sms = new Intent(Intent.ACTION_SENDTO);
@@ -127,7 +128,8 @@ public class CallOutActivity extends Activity {
             if(sms.resolveActivity(getPackageManager()) != null){
                 startActivityForResult(sms, SMS_RESULT);
             } else {
-                Toast.makeText(getApplicationContext(), Localization.get("callout.failure.sms"), Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, Localization.get("callout.failure.sms"), Toast.LENGTH_SHORT).show();
+                finish();
             }
         }
     }


### PR DESCRIPTION
Fix for callout failures, as described in [157429 - CommCare Doesn't Handle Failed Phone Dialer Intent Callout failure gracefully] (http://manage.dimagi.com/default.asp?157429#883355).

In case of failure (when there is no dialer/SMS app installed), the chooser displays an error toast instead of crashing the app.