### PR TITLE
Refreshing home screen dropdown on locale change

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -450,6 +450,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 break;
             case PREFERENCES_ACTIVITY:
                 configUi();
+                // CommCare-159047: this method call rebuilds the options menu
+                supportInvalidateOptionsMenu();
                 return;
             case MISSING_MEDIA_ACTIVITY:
                 if(resultCode == RESULT_CANCELED){


### PR DESCRIPTION
Fix for the bug [159047](http://manage.dimagi.com/default.asp?159047), in which the home screen dropdown would not be refreshed automatically when settings changed.