### PR TITLE
Rebuilding 'settings' dropdown on clean install

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -256,6 +256,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 
             }
         });
+
+        // CommCare-159047: this method call rebuilds the options menu
+        supportInvalidateOptionsMenu();
     }
 
     private boolean isOnline() {
@@ -450,8 +453,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 break;
             case PREFERENCES_ACTIVITY:
                 configUi();
-                // CommCare-159047: this method call rebuilds the options menu
-                supportInvalidateOptionsMenu();
                 return;
             case MISSING_MEDIA_ACTIVITY:
                 if(resultCode == RESULT_CANCELED){


### PR DESCRIPTION
Solving bug [159047](http://manage.dimagi.com/default.asp?159047), follow-up to [166](https://github.com/dimagi/commcare-odk/pull/166), to solve localization issues after an app install with an international default locale.