### PR TITLE
Ignoring multimedia validation when superuser

### DIFF
--- a/app/src/org/commcare/android/tasks/VerificationTask.java
+++ b/app/src/org/commcare/android/tasks/VerificationTask.java
@@ -4,7 +4,6 @@ import org.commcare.android.util.AndroidCommCarePlatform;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.activities.CommCareVerificationActivity;
 import org.commcare.dalvik.application.CommCareApplication;
-import org.commcare.dalvik.preferences.DeveloperPreferences;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
@@ -92,8 +91,7 @@ public class VerificationTask extends AsyncTask<String, int[], SizeBoundVector<M
             listener.success();
         }
         else if(listener != null) {
-            // ignores the validation result when superuser mode is enabled, useful for dev/testing
-            if(problems.size() == 0 || DeveloperPreferences.isSuperuserEnabled()){
+            if(problems.size() == 0){
                 listener.success();
             } else if(problems.size() > 0){
                 listener.onFinished(problems);

--- a/app/src/org/commcare/android/tasks/VerificationTask.java
+++ b/app/src/org/commcare/android/tasks/VerificationTask.java
@@ -4,6 +4,7 @@ import org.commcare.android.util.AndroidCommCarePlatform;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.activities.CommCareVerificationActivity;
 import org.commcare.dalvik.application.CommCareApplication;
+import org.commcare.dalvik.preferences.DeveloperPreferences;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
@@ -91,7 +92,7 @@ public class VerificationTask extends AsyncTask<String, int[], SizeBoundVector<M
             listener.success();
         }
         else if(listener != null) {
-            if(problems.size() == 0){
+            if(problems.size() == 0 || DeveloperPreferences.isSuperuserEnabled()){
                 listener.success();
             } else if(problems.size() > 0){
                 listener.onFinished(problems);

--- a/app/src/org/commcare/android/tasks/VerificationTask.java
+++ b/app/src/org/commcare/android/tasks/VerificationTask.java
@@ -92,6 +92,7 @@ public class VerificationTask extends AsyncTask<String, int[], SizeBoundVector<M
             listener.success();
         }
         else if(listener != null) {
+            // ignores the validation result when superuser mode is enabled, useful for dev/testing
             if(problems.size() == 0 || DeveloperPreferences.isSuperuserEnabled()){
                 listener.success();
             } else if(problems.size() > 0){

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -1167,7 +1167,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                      Intent i = new Intent(getApplicationContext(), CommCareSetupActivity.class);
                      
                      this.startActivityForResult(i, INIT_APP);
-            } else if(!CommCareApplication._().getCurrentApp().areResourcesValidated()){
+            } else if(!CommCareApplication._().getCurrentApp().areResourcesValidated()
+                    // if superuser is enabled, we won't need to validate multimedia, just launch the home screen directly
+                    && !DeveloperPreferences.isSuperuserEnabled()){
                 
                 Intent i = new Intent(this, CommCareVerificationActivity.class);
                 this.startActivityForResult(i, MISSING_MEDIA_ACTIVITY);


### PR DESCRIPTION
When in [superuser mode] (https://github.com/dimagi/commcare-odk/blob/d6a7df6f546caffc3b0ba44461aaf3725fa762c8/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java#L65), ignores the multimedia validation step result, always returning success. 

Useful if installing an app just for development/testing purposes. 