### PR TITLE
Remove dead error-handling code in CommCareHomeActivitiy.onActivityResult

### DIFF
--- a/app/src/org/commcare/android/tasks/ExceptionReportTask.java
+++ b/app/src/org/commcare/android/tasks/ExceptionReportTask.java
@@ -42,10 +42,11 @@ import android.os.AsyncTask;
 
 
 /**
- * Background task for uploading completed forms.
- * 
+ * Catch exceptions that are going to crash the phone, grab the stack trace,
+ * and upload to developers.
+ *
  * @author csims@dimagi.com
- * 
+ *
  **/
 
 public class ExceptionReportTask extends AsyncTask<Throwable, String, String>  

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -57,6 +57,7 @@ import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.odk.collect.android.tasks.FormLoaderTask;
+import org.odk.collect.android.activities.FormEntryActivity;
 
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
@@ -603,28 +604,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             case MODEL_RESULT:
                 //TODO: We might need to load this from serialized state?
                 currentState = CommCareApplication._().getCurrentSessionWrapper();
-                if(resultCode == 1) {
-                    //Exception in form entry!
-                    
-                    if(intent.hasExtra("odk_exception")) {
-                        Throwable ex = (Throwable)intent.getSerializableExtra("odk_exception");
-                        ExceptionReportTask task = new ExceptionReportTask();
-                        task.execute(ex);
-                    } else {
-                        RuntimeException ex = new RuntimeException("Unspecified exception from form entry engine");
-                        ExceptionReportTask task = new ExceptionReportTask();
-                        task.execute(ex);
-                    }
-                    
-                    //TODO: Notification?
-                    Toast.makeText(this, Localization.get("form.entry.segfault"), Toast.LENGTH_LONG);
-                    
-                    
-                    currentState.reset();
-                    refreshView();
-                    break;
-                }
-                
+
                 //This is the state we were in when we _Started_ form entry
                 FormRecord current = currentState.getFormRecord();
                 
@@ -1002,7 +982,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         FormLoaderTask.iif = new CommCareInstanceInitializer(CommCareApplication._().getCurrentSession());
         
         //Create our form entry activity callout
-        Intent i =new Intent(getApplicationContext(), org.odk.collect.android.activities.FormEntryActivity.class);
+        Intent i =new Intent(getApplicationContext(), FormEntryActivity.class);
         i.setAction(Intent.ACTION_EDIT);
         i.putExtra("odk_title_fragment", BreadcrumbBarFragment.class.getName());
         

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -157,7 +157,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
 
     // Extra returned from gp activity
     public static final String LOCATION_RESULT = "LOCATION_RESULT";
-    
 
     // Identifies the gp of the form used to launch form entry
     public static final String KEY_FORMPATH = "formpath";
@@ -294,6 +293,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         try {
             Collect.createODKDirs();
         } catch (RuntimeException e) {
+            Logger.exception(e);
             createErrorDialog(e.getMessage(), EXIT);
             return;
         }
@@ -932,6 +932,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 event = mFormController.getEvent(currentFormIndex);
             }
         } catch (XPathTypeMismatchException e) {
+            Logger.exception(e);
             FormEntryActivity.this.createErrorDialog(e.getMessage(), EXIT);
         }
 
@@ -1542,8 +1543,8 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                                 mFormController.getWidgetFactory(), this, isGroup);
                     Log.i(t, "created view for group");
                 } catch (RuntimeException e) {
+                    Logger.exception(e);
                     createErrorDialog(e.getMessage(), EXIT);
-                    e.printStackTrace();
                     // this is badness to avoid a crash.
                     // really a next view should increment the formcontroller, create the view
                     // if the view is null, then keep the current view and pop an error.
@@ -1677,6 +1678,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 }
             } while (event != FormEntryController.EVENT_END_OF_FORM);
             }catch(XPathTypeMismatchException e){
+                Logger.exception(e);
                 FormEntryActivity.this.createErrorDialog(e.getMessage(), EXIT);
             }
 
@@ -1916,6 +1918,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                             try {
                                 mFormController.newRepeat();
                             } catch (XPathTypeMismatchException e) {
+                                Logger.exception(e);
                                 FormEntryActivity.this.createErrorDialog(e.getMessage(), EXIT);
                                 return;
                             }
@@ -2009,6 +2012,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 switch (i) {
                     case DialogInterface.BUTTON1:
                         if (shouldExit) {
+                            setResult(RESULT_CANCELED);
                             finish();
                         }
                         break;


### PR DESCRIPTION
When returning from FormEntryActivity after a form error occurs, the result code in CommCareHomeActivitiy.onActivityResult was always RESULT_OK, so exception handling never happened. I hence removed the code that tried to do that handling and just logged the form errors when they occurred.