### PR TITLE
Drop down search crash

### DIFF
--- a/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
@@ -19,6 +19,11 @@ import android.os.AsyncTask;
 import android.util.Pair;
 
 /**
+ * Loads textual information for a list of FormRecords.
+ *
+ * This text currently includes the form name, record title, and last modified
+ * date
+ *
  * @author ctsims
  *
  */
@@ -29,43 +34,81 @@ public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<Integer, Ar
     private AndroidCommCarePlatform platform;
     private Hashtable<Integer, String[]> searchCache;
     private Context context;
-    private FormRecordLoadListener listener;
-    
-    //These are all synchronized together
+
+    // Functions to call when some or all of the data has been loaded.  Data
+    // can be loaded normally, or be given precedence (priority), determining
+    // which callback is dispatched to the listeners.
+    private ArrayList<FormRecordLoadListener> listeners = new ArrayList<FormRecordLoadListener>();
+
+    // These are all synchronized together
     private Queue<FormRecord> priorityQueue;
+
+    // The IDs of FormRecords that have been loaded
     private HashSet<Integer> loaded;
-    
-    private Hashtable<String,Text> formNames;
-    
+
+    // Maps form namespace (unique id for forms) to their form title
+    // (entry-point text). Needed because FormRecords don't have form title
+    // info, but do have the namespace.
+    private Hashtable<String, Text> formNames;
+
+    // Is the background task done loading all the FormRecord information?
+    private boolean loadingComplete = false;
+
     public FormRecordLoaderTask(Context c, SqlStorage<SessionStateDescriptor> descriptorStorage, AndroidCommCarePlatform platform) {
         this(c, descriptorStorage, null, platform);
     }
-    
+
     public FormRecordLoaderTask(Context c, SqlStorage<SessionStateDescriptor> descriptorStorage, Hashtable<String,String> descriptorCache, AndroidCommCarePlatform platform) {
         this.context = c;
         this.descriptorStorage = descriptorStorage;
         this.descriptorCache = descriptorCache;
         this.platform = platform;
     }
-    
+
+    /**
+     * Create a copy of this loader task.
+     */
     public FormRecordLoaderTask spawn() {
         FormRecordLoaderTask task = new FormRecordLoaderTask(context, descriptorStorage, descriptorCache, platform);
-        task.setListener(listener);
+        task.setListeners(listeners);
         return task;
     }
-    
-    public void init(Hashtable<Integer, String[]> searchCache, Hashtable<String,Text> formNames) {
+
+    /**
+     * Pass in hashtables that will be used to store data that is loaded.
+     *
+     * @param searchCache maps FormRecord ID to an array of query-able form descriptor text
+     * @param formNames map from form namespaces to their titles
+     */
+    public void init(Hashtable<Integer, String[]> searchCache, Hashtable<String, Text> formNames) {
         this.searchCache = searchCache;
-        if(descriptorCache == null) {
-            descriptorCache = new Hashtable<String,String>();
+
+        if (descriptorCache == null) {
+            descriptorCache = new Hashtable<String, String>();
         }
+
         priorityQueue = new LinkedList<FormRecord>();
         loaded = new HashSet<Integer>();
         this.formNames = formNames;
     }
-    
-    public void setListener(FormRecordLoadListener listener) {
-        this.listener = listener;
+
+    /**
+     * Set the listeners list, whose callbacks will be executed once the data
+     * has been loaded.
+     *
+     * @param listeners a list of objects to call when data is done loading
+     */
+    public void setListeners(ArrayList<FormRecordLoadListener> listeners) {
+        this.listeners.addAll(listeners);
+    }
+
+    /**
+     * Add a listener to the list that is called once the data has been loaded.
+     *
+     * @param listener an objects to call when data is done loading
+     */
+    public void addListener(FormRecordLoadListener listener) {
+        this.listeners.add(listener);
     }
 
     /*
@@ -74,117 +117,147 @@ public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<Integer, Ar
      */
     @Override
     protected Integer doInBackground(FormRecord... params) {
-        int progress = 0;
-        int target = params.length;
-        while(progress < target && !isCancelled()) {
+        int loadedFormCount = 0;
+
+        // Load text information for every FormRecord passed in, unless task is
+        // cancelled before that.
+        while (loadedFormCount < params.length && !isCancelled()) {
             FormRecord current = null;
             synchronized(priorityQueue) {
                 //If we have one to do immediately, grab it
-                if(!priorityQueue.isEmpty()) {
+                if (!priorityQueue.isEmpty()) {
                     current = priorityQueue.poll();
                     loaded.add(current.getID());
-                    
+
                     //Don't increment progress yet, we'll do so
                     //when we get to this record later.
+                    // XXX: PLM: ^^ it is _very_ indirect how this occurs (by
+                    // deffering to the conditional below). Instead of using
+                    // loadedFormCount in the while-condition we should use
+                    // loaded.size()
                 }
-                
+
                 //If we don't need to jump the queue, grab the next one.
-                if(current == null) {
-                    current = params[progress++];
-                    //If we already loaded this record (due to priority), 
-                    //we don't need to go through this
-                    if(loaded.contains(current.getID())) {
+                if (current == null) {
+                    current = params[loadedFormCount++];
+                    // If we already loaded this record (due to priority),
+                    // we don't need to go through this
+                    if (loaded.contains(current.getID())) {
                         continue;
                     } else {
                         loaded.add(current.getID());
                     }
                 }
             }
-            //Otherwise, let's get this record ready.
-            
-            ArrayList<String> cache = new ArrayList<String>();
+            // Otherwise, let's try to load some text about this record: last
+            // modified date, title of the record, and form name
+            ArrayList<String> recordTextDesc = new ArrayList<String>();
 
-            //Get the date in a searchable format.
-            cache.add(android.text.format.DateUtils.formatDateTime(context, current.lastModified().getTime(), android.text.format.DateUtils.FORMAT_NO_MONTH_DAY | android.text.format.DateUtils.FORMAT_NO_YEAR).toLowerCase()); 
-            
-            //Grab our record hash
+            // Get the date in a searchable format.
+            recordTextDesc.add(android.text.format.DateUtils.formatDateTime(context, current.lastModified().getTime(), android.text.format.DateUtils.FORMAT_NO_MONTH_DAY | android.text.format.DateUtils.FORMAT_NO_YEAR).toLowerCase());
+
+            // Grab our record hash
             SessionStateDescriptor ssd = null;
             try {
              ssd = descriptorStorage.getRecordForValue(SessionStateDescriptor.META_FORM_RECORD_ID, current.getID());
-            } catch(NoSuchElementException nsee) {
+            } catch (NoSuchElementException nsee) {
                 //s'all good
             }
             String dataTitle = "";
             if(ssd != null) {
                 String descriptor = ssd.getSessionDescriptor();
-                if(!descriptorCache.containsKey(descriptor)) {
+                if (!descriptorCache.containsKey(descriptor)) {
                     AndroidSessionWrapper asw = new AndroidSessionWrapper(platform);
                     asw.loadFromStateDescription(ssd);
-                    try{
+                    try {
                         dataTitle = asw.getTitle();
-                    } catch(RuntimeException e){
+                    } catch (RuntimeException e){
                         dataTitle = "[Unavailable]";
                     }
-                    dataTitle = dataTitle == null ? "" : dataTitle;
-                    
+
+                    if (dataTitle == null) {
+                        dataTitle = "";
+                    }
+
                     descriptorCache.put(descriptor, dataTitle);
-                }
-                else {
+                } else {
                     dataTitle = descriptorCache.get(descriptor);
                 }
             }
-            
-            cache.add(dataTitle);
-            
-            if(formNames.containsKey(current.getFormNamespace())) {
+
+            recordTextDesc.add(dataTitle);
+
+            if (formNames.containsKey(current.getFormNamespace())) {
                 Text name = formNames.get(current.getFormNamespace());
-                cache.add(name.evaluate());
+                recordTextDesc.add(name.evaluate());
             }
-            
-            
-            
-            //Notify anyhting waiting on this record
-            this.publishProgress(new Pair<Integer, ArrayList<String>>(current.getID(), cache));
+
+            // Copy data into search task and notify anything waiting on this
+            // record.
+            this.publishProgress(new Pair<Integer, ArrayList<String>>(current.getID(), recordTextDesc));
         }
         return 1;
     }
-    
+
+    @Override
+    protected void onPreExecute() {
+        super.onPreExecute();
+        // Tell users of the data being loaded that it isn't ready yet.
+        this.loadingComplete = false;
+    }
+
+    /**
+     * Has all the FormRecords' textual data been loaded yet? Used to let
+     * users of the data only start accessing it once it is all there.
+     */
+    public boolean doneLoadingFormRecords() {
+        return this.loadingComplete;
+    }
+
     /* (non-Javadoc)
      * @see android.os.AsyncTask#onPostExecute(java.lang.Object)
      */
     @Override
     protected void onPostExecute(Integer result) {
         super.onPostExecute(result);
-        if(listener != null) {
-            listener.notifyLoaded();
-        }
-        
-        //free up everything except the cache, which we might use later.
-        SqlStorage<SessionStateDescriptor> descriptorStorage = null;
-        AndroidCommCarePlatform platform = null;
-        Hashtable<Integer, String[]> searchCache = null;
-        Context context = null;
-        FormRecordLoadListener listener = null;
-        
-        //These are all synchronized together
-        Queue<FormRecord> priorityQueue = null;
-        HashSet<Integer> loaded = null;
+        this.loadingComplete = true;
 
+        for (FormRecordLoadListener listener : this.listeners) {
+            if (listener != null) {
+                listener.notifyLoaded();
+            }
+        }
+
+        // free up things we don't need to spawn new tasks
+        priorityQueue = null;
+        loaded = null;
+        formNames = null;
     }
-    
+
     /* (non-Javadoc)
      * @see android.os.AsyncTask#onProgressUpdate(Progress[])
      */
     @Override
     protected void onProgressUpdate(Pair<Integer, ArrayList<String>>... values) {
         super.onProgressUpdate(values);
+
+        // copy a single form record's data out of method arguments
         String[] vals = new String[values[0].second.size()];
-        for(int i = 0 ; i < vals.length ; ++i) {
+
+        for (int i = 0; i < vals.length; ++i) {
             vals[i] = values[0].second.get(i);
         }
+
+        // store the loaded data in the search cache
         this.searchCache.put(values[0].first, vals);
-        if(listener != null) {
-            listener.notifyPriorityLoaded(values[0].first, loaded.contains(values[0].first));
+
+        for (FormRecordLoadListener listener : this.listeners) {
+            if (listener != null) {
+                // XXX: PLM: pretty sure loaded.contains(values[0].first) is always true at this point.
+                // Should really refactor the following line so that this is
+                // only called if we pulled the value from the priority queue
+                listener.notifyPriorityLoaded(values[0].first, loaded.contains(values[0].first));
+            }
         }
     }
 

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -151,7 +151,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
             
             searchbox.addTextChangedListener(this);
             FormRecordLoaderTask task = new FormRecordLoaderTask(this, CommCareApplication._().getUserStorage(SessionStateDescriptor.class), platform);
-            task.setListener(this);
+            task.addListener(this);
     
             adapter = new IncompleteFormListAdapter(this, platform, task);
             
@@ -569,7 +569,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
     }
     
     public void afterTextChanged(Editable s) {
-        if(searchbox.getText() == s) {
+        if (searchbox.getText() == s) {
             adapter.applyTextFilter(s.toString());
         }
     }


### PR DESCRIPTION
When filtering over saved forms and changing the form status to list, the filtering method would crash because it tried to filter data before it was loaded. This commit  ensures that filtering only occurs after FormRecord text data has been loaded.

The biggest change is that IncompleteFormListAdapter extends FormRecordLoadListener and adds itself to the listeners to be called when FormRecordLoaderTask finishes loading data, in order to filterValues at the proper time.

Fixes [bug 161420](http://manage.dimagi.com/default.asp?161420)