### PR TITLE
Relative index lookup caching

### DIFF
--- a/app/src/org/commcare/android/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/android/cases/AndroidCaseInstanceTreeElement.java
@@ -3,7 +3,6 @@
  */
 package org.commcare.android.cases;
 
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Vector;
 
@@ -69,15 +68,37 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         return DataUtil.union(selectedCases, cases);
     }
     
+    //We're storing this here for now because this is a safe lifecycle object that must represent
+    //a single snapshot of the case database, but it could be generalized later.
+    Hashtable<String, Vector<Integer>> mIndexCache = new Hashtable<String, Vector<Integer>>();
+    
     @Override
     protected Vector<Integer> getNextIndexMatch(Vector<String> keys, Vector<Object> values, IStorageUtilityIndexed<?> storage) {
         String firstKey = keys.elementAt(0);
-        
+                
         //If the index object starts with "case_in" it's actually a case index query and we need to run
         //this over the case index table
         if(firstKey.startsWith(Case.INDEX_CASE_INDEX_PRE)) {
+            //CTS - March 9, 2015 - Introduced a small cache for child index queries here because they
+            //are a frequent target of bulk operations like graphing which do multiple requests across the 
+            //same query.
+            //TODO: This should likely be generalized for a number of other queries with bulk/nodeset
+            //returns
             String indexName = firstKey.substring(Case.INDEX_CASE_INDEX_PRE.length());
-            Vector <Integer> matchingCases = mCaseIndexTable.getCasesMatchingIndex(indexName, (String)values.elementAt(0));
+            String value = (String)values.elementAt(0);
+            
+            //TODO: Evaluate whether our indices could contain "|" but I don't imagine how they could.
+            String indexCacheKey = firstKey + "|" + value;
+            
+            //Check whether we've got a cache of this index.
+            if(mIndexCache.containsKey(indexCacheKey)) {
+                //remove the match from the inputs
+                keys.removeElementAt(0);
+                values.removeElementAt(0);
+                return mIndexCache.get(indexCacheKey);
+            }
+            
+            Vector <Integer> matchingCases = mCaseIndexTable.getCasesMatchingIndex(indexName, value);
             
             //Clear the most recent index and wipe it, because there is no way it is going to be useful
             //after this
@@ -86,6 +107,19 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
             //remove the match from the inputs
             keys.removeElementAt(0);
             values.removeElementAt(0);
+
+            //For now we're only going to run this on very small data sets because we don't
+            //want to manage this too explicitly until we generalize. Almost all results here
+            //will be very very small either way (~O(10's of cases)), so given that this only
+            //exists across one session that won't get out of hand
+            if(matchingCases.size() < 50) {
+                //Should never hit this, but don't wanna have any runaway memory if we do.
+                if(mIndexCache.size() > 100) {
+                    mIndexCache.clear();
+                }
+                
+                mIndexCache.put(indexCacheKey, matchingCases);
+            }
             return matchingCases;
         }
         


### PR DESCRIPTION
Introduced a small bullet test for optimizing case index lookups heuristically.

Should only affect people who are performing operations where they retrieve bulk data like graphing, but should really speed up anywhere where those ops are performed repeatedly.