### PR TITLE
Show grid even when using custom labels

### DIFF
--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -358,11 +358,11 @@ public class GraphView {
             mRenderer.setYAxisMax(parseYValue(mData.getConfiguration("secondary-y-max"), "secondary-y-max"), 1);
         }
         
-        String showGrid = mData.getConfiguration("show-grid", "true");
-        if (Boolean.valueOf(showGrid).equals(Boolean.FALSE)) {
-            mRenderer.setShowGridX(false);
-            mRenderer.setShowGridY(false);
-        }
+        boolean showGrid = Boolean.valueOf(mData.getConfiguration("show-grid", "true")).equals(Boolean.TRUE);
+        mRenderer.setShowGridX(showGrid);
+        mRenderer.setShowGridY(showGrid);
+        mRenderer.setShowCustomTextGridX(showGrid);
+        mRenderer.setShowCustomTextGridY(showGrid);
 
         String showAxes = mData.getConfiguration("show-axes", "true");
         if (Boolean.valueOf(showAxes).equals(Boolean.FALSE)) {


### PR DESCRIPTION
Parto's horizontal grid lines weren't showing because apparently using custom labels means grid lines are controlled by a different function.