### PR TITLE
Silent XPath errors

### DIFF
--- a/app/src/org/commcare/android/models/NodeEntityFactory.java
+++ b/app/src/org/commcare/android/models/NodeEntityFactory.java
@@ -83,10 +83,14 @@ public class NodeEntityFactory {
                 xpe.printStackTrace();
                 details[count] = "<invalid xpath: " + xpe.getMessage() + ">";
                 backgroundDetails[count] = "";
+                // assume that if there's an error, user should see it
+                relevancyDetails[count] = true;
             } catch (XPathSyntaxException e) {
                 e.printStackTrace();
                 details[count] = "<invalid xpath: " + e.getMessage() + ">";
                 backgroundDetails[count] = "";
+                // assume that if there's an error, user should see it
+                relevancyDetails[count] = true;
             }
             count++;
         }


### PR DESCRIPTION
Fields with XPath errors have been getting dropped altogether from case details.

Testing for relevancy can itself cause XPath errors, so just display fields with errors without checking for relevancy.