### PR TITLE
Landscape detail fix

### DIFF
--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -40,11 +40,15 @@ import android.widget.RelativeLayout;
  */
 @ManagedUi(R.layout.entity_detail)
 public class EntityDetailActivity extends CommCareActivity implements DetailCalloutListener {
-    
     private CommCareSession session;
     private AndroidSessionWrapper asw;
+
+    // Determines whether to display "Done" or "Continue" on next button
     public static final String IS_DEAD_END = "eda_ide";
+
+    // reference id of selected element being detailed
     public static final String CONTEXT_REFERENCE = "eda_crid";
+
     public static final String DETAIL_ID = "eda_detail_id";
     public static final String DETAIL_PERSISTENT_ID = "eda_persistent_id";
         

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -814,14 +814,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
     boolean rightFrameSetup = false;
     NodeEntityFactory factory;
     
-    private void select() {
-        // create intent for return and store path
-        Intent i = new Intent(EntitySelectActivity.this.getIntent());
-        i.putExtra(SessionFrame.STATE_DATUM_VAL, selectedIntent.getStringExtra(SessionFrame.STATE_DATUM_VAL));
-        setResult(RESULT_OK, i);
-        finish();
-    }
-
     // CommCare-159503: implementing DetailCalloutListener so it will not crash the app when requesting call/sms
     public void callRequested(String phoneNumber) {
         DetailCalloutListenerDefaultImpl.callRequested(this, phoneNumber);
@@ -841,18 +833,11 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         if(!rightFrameSetup) {
             findViewById(R.id.screen_compound_select_prompt).setVisibility(View.GONE);
             View.inflate(this, R.layout.entity_detail, rightFrame);
+
+            // Don't show next button in landscape mode, since there is nowhere
+            // to go from here
             Button next = (Button)findViewById(R.id.entity_select_button);
-            next.setText(Localization.get("select.detail.confirm"));
-            next.setOnClickListener(new OnClickListener() {
-                public void onClick(View v) {
-                    select();
-                    return;
-                }
-            });
-            
-            if(getIntent().getBooleanExtra(EntityDetailActivity.IS_DEAD_END, false)) {
-                next.setText("Done");
-            }
+            next.setVisibility(View.GONE);
 
             String passedCommand = selectedIntent.getStringExtra(SessionFrame.STATE_COMMAND_ID);
             

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -313,6 +313,18 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         //Don't go through making the whole thing if we're finishing anyway.
         if(this.isFinishing() || startOther) {return;}
         
+        // If we changing from landscape mode to portrait mode and have a
+        // selected entity, jump into its detail.
+        if (!inAwesomeMode) {
+            Intent intent = new Intent(this.getIntent());
+            TreeReference selectedRef = SerializationUtil.deserializeFromIntent(intent, EntityDetailActivity.CONTEXT_REFERENCE, TreeReference.class);
+            if (selectedRef != null) {
+                Intent detailIntent = getDetailIntent(selectedRef, null);
+                startActivityForResult(detailIntent, CONFIRM_SELECT);
+            }
+        }
+
+        // XXX: no idea when the following code is ever entered -- PLM
         if(!resuming && !mNoDetailMode && this.getIntent().hasExtra(EXTRA_ENTITY_KEY)) {
             TreeReference entity = selectDatum.getEntityFromID(asw.getEvaluationContext(), this.getIntent().getStringExtra(EXTRA_ENTITY_KEY));
             


### PR DESCRIPTION
This PR removes EntityDetailActivity's (useless) "Continue" button that is displayed while in landscape mode, and that causes crashes when pressed.

Additional fixes:
 * A few comments.
 * When rotating from landscape to portrait with an entity selected, launch EntityDetailActivity with that selection.


[Bug 163637](http://manage.dimagi.com/default.asp?163637)