### PR TITLE
Change login duration setting to be represent seconds not hours

### DIFF
--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -238,7 +238,7 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
 
         // default to 24 hours
-        return properties.getFloat(LOGIN_DURATION, 28800);
+        return properties.getInt(LOGIN_DURATION, 28800);
     }
 
     /*

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -174,7 +174,6 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
                             CommCareApplication._().getCurrentApp().getAppPreferences().
                                     edit().putString(DeveloperPreferences.SUPERUSER_ENABLED, YES).commit();
                             Toast.makeText(CommCarePreferences.this, "Developer Mode Enabled", Toast.LENGTH_SHORT).show();
-                            ;
                         }
                     }
 
@@ -197,7 +196,8 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
     }
 
     public static boolean isInSenseMode() {
-        return CommCareApplication._().getCommCarePlatform().getCurrentProfile() != null && CommCareApplication._().getCommCarePlatform().getCurrentProfile().isFeatureActive("sense");
+        return (CommCareApplication._().getCommCarePlatform().getCurrentProfile() != null &&
+                CommCareApplication._().getCommCarePlatform().getCurrentProfile().isFeatureActive("sense"));
     }
 
     public static boolean isIncompleteFormsEnabled() {
@@ -238,7 +238,11 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
 
         // default to 24 hours
-        return Integer.parseInt(properties.getString(LOGIN_DURATION, "28800"));
+        try {
+            return Integer.parseInt(properties.getString(LOGIN_DURATION, "28800"));
+        } catch (NumberFormatException e) {
+            return 28000;
+        }
     }
 
     /*

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -238,7 +238,7 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
 
         // default to 24 hours
-        return properties.getInt(LOGIN_DURATION, 28800);
+        return Integer.parseInt(properties.getString(LOGIN_DURATION, "28800"));
     }
 
     /*

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -86,7 +86,7 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
 
     public final static String FUZZY_SEARCH = "cc-fuzzy-search-enabled";
 
-    public final static String LOGIN_DURATION = "cc-login-duration-hours";
+    public final static String LOGIN_DURATION = "cc-login-duration-seconds";
 
     public final static String BRAND_BANNER_LOGIN = "brand-banner-login";
     public final static String BRAND_BANNER_HOME = "brand-banner-home";
@@ -230,10 +230,15 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
         return properties.getString(FUZZY_SEARCH, NO).equals(YES);
     }
 
+    /**
+     * @return How many seconds should a user session remain open before
+     *         expiring?
+     */
     public static int getLoginDuration() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
 
-        return properties.getInt(LOGIN_DURATION, 24);
+        // default to 24 hours
+        return properties.getFloat(LOGIN_DURATION, 28800);
     }
 
     /*

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -54,7 +54,7 @@ public class CommCareSessionService extends Service  {
     private static long MAINTENANCE_PERIOD = 1000;
 
     // session length in MS
-    private static long SESSION_LENGTH = 1000*60*60*24;
+    private static long sessionLength = 1000 * 60 * 60 * 24;
     
     private Timer maintenanceTimer;
     private CipherPool pool;
@@ -253,7 +253,7 @@ public class CommCareSessionService extends Service  {
             
             this.user = user;
             
-            this.sessionExpireDate = new Date(new Date().getTime() + SESSION_LENGTH);
+            this.sessionExpireDate = new Date(new Date().getTime() + sessionLength);
             
             // Display a notification about us starting.  We put an icon in the status bar.
             showLoggedInNotification(user);
@@ -279,7 +279,7 @@ public class CommCareSessionService extends Service  {
         long time = new Date().getTime();
         // If we're either past the session expire time, or the session expires more than its period in the future, 
         // we need to log the user out
-        if(time > sessionExpireDate.getTime() || (sessionExpireDate.getTime() - time  > SESSION_LENGTH )) { 
+        if(time > sessionExpireDate.getTime() || (sessionExpireDate.getTime() - time  > sessionLength )) { 
             logout = true;
         }
         
@@ -502,10 +502,14 @@ public class CommCareSessionService extends Service  {
         };
     }
 
+    /**
+     * Read the login session duration from app preferences and set the session
+     * length accordingly.
+     */
     public void setSessionLength(){
-        SESSION_LENGTH = CommCarePreferences.getLoginDuration() * 1000 * 60 * 60;
+        sessionLength = CommCarePreferences.getLoginDuration() * 1000;
     }
-    
+
     public boolean isMultimediaVerified(){
         return multimediaIsVerified;
     }


### PR DESCRIPTION
To test apps we need to be able to set session expiration lengths to be on the order of seconds/minutes, so changed this app preference to be in terms of seconds instead of hours.