### PR TITLE
Remove 'delete repeat/clear answer' long-tap option

### DIFF
--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -51,13 +51,8 @@
 <string name="delete_confirm">Borrar %s formulario(s)?</string>
 <string name="delete_file">Borrar los Seleccionados</string>
 <string name="delete_no">No Borrar</string>
-<string name="delete_repeat">Borrar grupo</string>
-<string name="delete_repeat_ask">Borrar este grupo?</string>
-<string name="delete_repeat_confirm">Borrar el grupo \"%s\" y todos sus subgrupos?</string>
-<string name="delete_repeat_no">Cancelar</string>
 <string name="delete_yes">Borrar los Formularios</string>
 <string name="discard_answer">Borrar respuesta</string>
-<string name="discard_group">Borrar grupo</string>
 <string name="download">Obtener los Seleccionados</string>
 <string name="download_forms_result">Resultado de la Baja</string>
 <string name="downloading_data">Conectandose al Servidor</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -50,13 +50,8 @@ License.
 <string name="delete_confirm">Supprimer %s formulaire(s)?</string>
 <string name="delete_file">Supprimer la sélection</string>
 <string name="delete_no">Ne pas supprimer</string>
-<string name="delete_repeat">Enlever le groupe</string>
-<string name="delete_repeat_ask">Enlever ce groupe?</string>
-<string name="delete_repeat_confirm">Enlever le groupe \"%s\" et tous ses sous-groupes?</string>
-<string name="delete_repeat_no">Annuler</string>
 <string name="delete_yes">Supprimer ces formulaires</string>
 <string name="discard_answer">Enlever la réponse</string>
-<string name="discard_group">Enlever le groupe</string>
 <string name="download">Obtenez celle sélectionnée</string>
 <string name="download_forms_result">Resultat du téléchargement</string>
 <string name="downloading_data">Connection au serveur...</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -51,13 +51,8 @@
 <string name="delete_confirm">Ištrinti %s formą(-as)?</string>
 <string name="delete_file">Ištrinti pažymėtas</string>
 <string name="delete_no">Neištrinti</string>
-<string name="delete_repeat">Pašalinti grupę</string>
-<string name="delete_repeat_ask">Pašalinti šią grupę?</string>
-<string name="delete_repeat_confirm">Pašalinti grupę \"%s\" ir visus jos pogrupius?</string>
-<string name="delete_repeat_no">Atšaukti</string>
 <string name="delete_yes">Ištrinti formas</string>
 <string name="discard_answer">Pašalinti atsakymą</string>
-<string name="discard_group">Pašalinti grupę</string>
 <string name="download">Atsiųsti parinktas</string>
 <string name="download_forms_result">Atsiuntimo rezultatas</string>
 <string name="downloading_data">Jungiamasi prie serverio</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -51,13 +51,8 @@
 <string name="delete_confirm">Slett %s skjema(er)?</string>
 <string name="delete_file">Slett utvalgte</string>
 <string name="delete_no">Ikke slett</string>
-<string name="delete_repeat">Slette gruppe</string>
-<string name="delete_repeat_ask">Slette gruppen?</string>
-<string name="delete_repeat_confirm">Slette gruppe \"%s\" og alle sub-grupper?</string>
-<string name="delete_repeat_no">Avbryt</string>
 <string name="delete_yes">Slett skjemaer</string>
 <string name="discard_answer">Slett svar</string>
-<string name="discard_group">Slett gruppe</string>
 <string name="download">Hent utvalgte</string>
 <string name="download_forms_result">Last ned resultat</string>
 <string name="downloading_data">Kobler til server</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -51,13 +51,8 @@
 <string name="delete_confirm">Apagar %s formulário(s)?</string>
 <string name="delete_file">Apagar Selecionados</string>
 <string name="delete_no">Não Apagar</string>
-<string name="delete_repeat">Remover grupo</string>
-<string name="delete_repeat_ask">Remover este Grupo?</string>
-<string name="delete_repeat_confirm">Remover grupo \"%s\" e todos os seus sub-grupos?</string>
-<string name="delete_repeat_no">Cancelar</string>
 <string name="delete_yes">Apagar Formulários</string>
 <string name="discard_answer">Remove response</string>
-<string name="discard_group">Remover grupo</string>
 <string name="download">Pegar Selecionados</string>
 <string name="download_forms_result">Download Resultado</string>
 <string name="downloading_data">Conectando com o Servidor</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -51,13 +51,8 @@
 <string name="delete_confirm">Delete %s form(s)?</string>
 <string name="delete_file">Delete Selected</string>
 <string name="delete_no">Do Not Delete</string>
-<string name="delete_repeat">Remove group</string>
-<string name="delete_repeat_ask">Remove This Group?</string>
-<string name="delete_repeat_confirm">Remove group \"%s\" and all of its sub-groups?</string>
-<string name="delete_repeat_no">Cancel</string>
 <string name="delete_yes">Delete Forms</string>
 <string name="discard_answer">Remove response</string>
-<string name="discard_group">Remove group</string>
 <string name="download">Get Selected</string>
 <string name="download_forms_result">Download Result</string>
 <string name="downloading_data">Connecting to Server</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -137,13 +137,8 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="delete_confirm">Delete %s form(s)?</string>
     <string name="delete_file">Delete Selected</string>
     <string name="delete_no">Do Not Delete</string>
-    <string name="delete_repeat">Remove group</string>
-    <string name="delete_repeat_ask">Remove This Group?</string>
-    <string name="delete_repeat_confirm">Remove group \"%s\" and all of its sub-groups?</string>
-    <string name="delete_repeat_no">Cancel</string>
     <string name="delete_yes">Delete Forms</string>
     <string name="discard_answer">Remove response</string>
-    <string name="discard_group">Remove group</string>
     <string name="download">Get Selected</string>
     <string name="download_forms_result">Download Result</string>
     <string name="downloading_data">Connecting to Server</string>

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -193,9 +193,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     private static final int PROGRESS_DIALOG = 1;
     private static final int SAVING_DIALOG = 2;
 
-    // Random ID
-    private static final int DELETE_REPEAT = 654321;
-
     private String mFormPath;
     public static String mInstancePath;
     private String mInstanceDestination;
@@ -1335,10 +1332,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
-            menu.add(0, v.getId(), 0, StringUtils.getStringSpannableRobust(this, R.string.clear_answer));
-        if (mFormController.indexContainsRepeatableGroup()) {
-            menu.add(0, DELETE_REPEAT, 0, StringUtils.getStringSpannableRobust(this, R.string.delete_repeat));
-        }
+        menu.add(0, v.getId(), 0, StringUtils.getStringSpannableRobust(this, R.string.clear_answer));
         menu.setHeaderTitle(StringUtils.getStringSpannableRobust(this, R.string.edit_prompt));
     }
 
@@ -1349,17 +1343,13 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
      */
     @Override
     public boolean onContextItemSelected(MenuItem item) {
-        /*
-         * We don't have the right view here, so we store the View's ID as the item ID and loop
-         * through the possible views to find the one the user clicked on.
-         */
+        // We don't have the right view here, so we store the View's ID as the
+        // item ID and loop through the possible views to find the one the user
+        // clicked on.
         for (QuestionWidget qw : ((ODKView) mCurrentView).getWidgets()) {
             if (item.getItemId() == qw.getId()) {
                 createClearDialog(qw);
             }
-        }
-        if (item.getItemId() == DELETE_REPEAT) {
-            createDeleteRepeatConfirmDialog();
         }
 
         return super.onContextItemSelected(item);
@@ -1565,9 +1555,13 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                     return new View(this);
                 }
 
-                // Makes a "clear answer" menu pop up on long-click
+                // Makes a "clear answer" menu pop up on long-click of
+                // select-one/select-multiple questions
                 for (QuestionWidget qw : odkv.getWidgets()) {
-                    if (!qw.getPrompt().isReadOnly() && !mFormController.isFormReadOnly()) {
+                    if (!qw.getPrompt().isReadOnly() &&
+                            !mFormController.isFormReadOnly() &&
+                            (qw.getPrompt().getControlType() == Constants.CONTROL_SELECT_ONE ||
+                                    qw.getPrompt().getControlType() == Constants.CONTROL_SELECT_MULTI)) {
                         registerForContextMenu(qw);
                     }
                 }
@@ -2037,44 +2031,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         mAlertDialog.setButton(StringUtils.getStringSpannableRobust(this, R.string.ok), errorListener);
                 mAlertDialog.show();
     }
-
-
-    /**
-     * Creates a confirm/cancel dialog for deleting repeats.
-     */
-    private void createDeleteRepeatConfirmDialog() {
-        mAlertDialog = new AlertDialog.Builder(this).create();
-        mAlertDialog.setIcon(android.R.drawable.ic_dialog_info);
-        String name = mFormController.getLastRepeatedGroupName();
-        int repeatcount = mFormController.getLastRepeatedGroupRepeatCount();
-        if (repeatcount != -1) {
-            name += " (" + (repeatcount + 1) + ")";
-        }
-        mAlertDialog.setTitle(StringUtils.getStringSpannableRobust(this, R.string.delete_repeat_ask, name));
-                mAlertDialog.setMessage(StringUtils.getStringSpannableRobust(this, R.string.delete_repeat_confirm, name));
-                        DialogInterface.OnClickListener quitListener = new DialogInterface.OnClickListener() {
-                            /*
-                             * (non-Javadoc)
-                             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                             */
-                            @Override
-                            public void onClick(DialogInterface dialog, int i) {
-                                switch (i) {
-                                    case DialogInterface.BUTTON1: // yes
-                                        mFormController.deleteRepeat();
-                                        showPreviousView();
-                                        break;
-                                    case DialogInterface.BUTTON2: // no
-                                        break;
-                                }
-                            }
-                        };
-        mAlertDialog.setCancelable(false);
-        mAlertDialog.setButton(StringUtils.getStringSpannableRobust(this, R.string.discard_group), quitListener);
-                mAlertDialog.setButton2(StringUtils.getStringSpannableRobust(this, R.string.delete_repeat_no), quitListener);
-                        mAlertDialog.show();
-    }
-
 
     /**
      * Saves data and writes it to disk. If exit is set, program will exit after save completes.


### PR DESCRIPTION
Remove form entry options to clear an answer or delete a repeat entry, except for in the case of select one/select multiple question types. These options pop up when you long-press question entry areas, which often blocks availability of normal android paste/select functionality.