### PR TITLE
Android 4.4+ compat process to convert URI->filepath

### DIFF
--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -228,28 +228,6 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         }
     }
 
-
-    private String getPathFromUri(Uri uri) {
-        if (uri.toString().startsWith("file")) {
-            return uri.toString().substring(6);
-        } else {
-            String[] audioProjection = {
-                Audio.Media.DATA
-            };
-            Cursor c =
-                ((Activity) getContext()).managedQuery(uri, audioProjection, null, null, null);
-            ((Activity) getContext()).startManagingCursor(c);
-            int column_index = c.getColumnIndexOrThrow(Audio.Media.DATA);
-            String audioPath = null;
-            if (c.getCount() > 0) {
-                c.moveToFirst();
-                audioPath = c.getString(column_index);
-            }
-            return audioPath;
-        }
-    }
-
-
     /*
      * (non-Javadoc)
      * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)

--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -33,6 +33,8 @@ import android.widget.Toast;
 
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.application.CommCareApplication;
+import org.commcare.dalvik.utils.UriToFilePath;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -260,7 +262,8 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         }
 
         // get the file path and create a copy in the instance folder
-        String binaryPath = getPathFromUri((Uri) binaryuri);
+        String binaryPath = UriToFilePath.getPathFromUri(CommCareApplication._(),
+                (Uri)binaryuri);
         String extension = binaryPath.substring(binaryPath.lastIndexOf("."));
         String destAudioPath = mInstanceFolder + "/" + System.currentTimeMillis() + extension;
 

--- a/app/src/org/odk/collect/android/widgets/VideoWidget.java
+++ b/app/src/org/odk/collect/android/widgets/VideoWidget.java
@@ -232,28 +232,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
         }
     }
 
-
-    private String getPathFromUri(Uri uri) {
-        if (uri.toString().startsWith("file")) {
-            return uri.toString().substring(6);
-        } else {
-            String[] videoProjection = {
-                Video.Media.DATA
-            };
-            Cursor c =
-                ((Activity) getContext()).managedQuery(uri, videoProjection, null, null, null);
-            ((Activity) getContext()).startManagingCursor(c);
-            int column_index = c.getColumnIndexOrThrow(Video.Media.DATA);
-            String videoPath = null;
-            if (c.getCount() > 0) {
-                c.moveToFirst();
-                videoPath = c.getString(column_index);
-            }
-            return videoPath;
-        }
-    }
-
-
     /*
      * (non-Javadoc)
      * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)

--- a/app/src/org/odk/collect/android/widgets/VideoWidget.java
+++ b/app/src/org/odk/collect/android/widgets/VideoWidget.java
@@ -33,6 +33,8 @@ import android.widget.Toast;
 
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.application.CommCareApplication;
+import org.commcare.dalvik.utils.UriToFilePath;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -264,7 +266,8 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
         }
 
         // get the file path and create a copy in the instance folder
-        String binaryPath = getPathFromUri((Uri) binaryuri);
+        String binaryPath = UriToFilePath.getPathFromUri(CommCareApplication._(),
+                (Uri)binaryuri);
         String extension = binaryPath.substring(binaryPath.lastIndexOf("."));
         String destVideoPath = mInstanceFolder + "/" + System.currentTimeMillis() + extension;
 


### PR DESCRIPTION
Audio and Video widgets use an out of date method for converting URIs into filepaths.
This PR changes them to use the 4.4+ compatible version.