### PR TITLE
Change default session length from 8 to 24 hrs

### DIFF
--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -239,9 +239,9 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
 
         // default to 24 hours
         try {
-            return Integer.parseInt(properties.getString(LOGIN_DURATION, "28800"));
+            return Integer.parseInt(properties.getString(LOGIN_DURATION, "86400"));
         } catch (NumberFormatException e) {
-            return 28000;
+            return 86400;
         }
     }
 


### PR DESCRIPTION
Change the default app session length from 8 hrs (28800 seconds) to 24 hrs (86400 seconds)