### PR TITLE
Home activity detects if form entry was processing archive or new form

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -662,9 +662,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         }
 
         // TODO: This should be the default unless we're in some "Uninit" or "incomplete" state
-        if (FormRecord.STATUS_COMPLETE.equals(current.getStatus()) ||
-                FormRecord.STATUS_SAVED.equals(current.getStatus()) ||
-                FormRecord.STATUS_UNSENT.equals(current.getStatus())) {
+        if (intent.getBooleanExtra(FormEntryActivity.IS_ARCHIVED_FORM, false) ||
+                FormRecord.STATUS_COMPLETE.equals(current.getStatus()) ||
+                FormRecord.STATUS_SAVED.equals(current.getStatus())) {
             // Viewing an old form, so don't change the historical record
             // regardless of the exit code
             currentState.reset();

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -186,6 +186,13 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     
     public static final String KEY_HAS_SAVED = "org.odk.collect.form.has.saved";
 
+    /**
+     * Intent extra flag to track if this form is an archive. Used to trigger
+     * return logic when this activity exits to the home screen, such as
+     * whether to redirect to archive view or sync the form.
+     */
+    public static final String IS_ARCHIVED_FORM = "is-archive-form";
+
     // Identifies whether this is a new form, or reloading a form after a screen
     // rotation (or similar)
     private static final String NEWFORM = "newform";
@@ -2551,7 +2558,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         if(mFormController.isFormReadOnly()) {
             //It's possible we just want to "finish" here, but
             //I don't really wanna break any c compatibility
-            finishReturnInstance();
+            finishReturnInstance(false);
         } else {
             createQuitDialog();
         }
@@ -2905,10 +2912,14 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 c.moveToFirst();
                 String id = c.getString(c.getColumnIndex(InstanceColumns._ID));
                 Uri instance = Uri.withAppendedPath(instanceProviderContentURI, id);
+
+                Intent formReturnIntent = new Intent();
+                formReturnIntent.putExtra(IS_ARCHIVED_FORM, mFormController.isFormReadOnly());
+
                 if(reportSaved || hasSaved) {
-                    setResult(RESULT_OK, new Intent().setData(instance));
+                    setResult(RESULT_OK, formReturnIntent.setData(instance));
                 } else {
-                    setResult(RESULT_CANCELED, new Intent().setData(instance));
+                    setResult(RESULT_CANCELED, formReturnIntent.setData(instance));
                 }
             }
         }


### PR DESCRIPTION
When returning from FormEntryActivity to the CommCareHomeActivity, forms weren't correctly being synced. This PR fixes that by adding and extra to the intent returned from FormEntryActivity that signals if the form that was being processed was an archive or a newly saved form.

[ticket](http://manage.dimagi.com/default.asp?167352#932439)