### PR TITLE
Null check to try to fix NPE

### DIFF
--- a/app/src/org/commcare/android/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/android/models/AndroidSessionWrapper.java
@@ -160,6 +160,10 @@ public class AndroidSessionWrapper {
     public FormRecord commitRecordTransaction() throws InvalidStateException {
         FormRecord current = getFormRecord();
 
+        if (current == null) {
+            throw new InvalidStateException("No form record found when trying to save form.");
+        }
+
         String recordStatus = null;
         if (InstanceProviderAPI.STATUS_COMPLETE.equals(instanceStatus)) {
             recordStatus = FormRecord.STATUS_COMPLETE;


### PR DESCRIPTION
Saw the following trace in the device log details and figured the null check in this PR would be a good idea

java.lang.NullPointerException at org.commcare.android.models.AndroidSessionWrapper.commitRecordTransaction(AndroidSessionWrapper.java:172) at org.commcare.dalvik.odk.provider.InstanceProvider.linkToSessionFormRecord(InstanceProvider.java:488) at org.commcare.dalvik.odk.provider.InstanceProvider.update(InstanceProvider.java:398) at android.content.ContentProvider$Transport.update(ContentProvider.java:287) at android.content.ContentResolver.update(ContentResolver.java:1321) at org.odk.collect.android.tasks.SaveToDiskTask.updateInstanceDatabase(SaveToDiskTask.java:154) at org.odk.collect.android.tasks.SaveToDiskTask.exportData(SaveToDiskTask.java:217) at org.odk.collect.android.tasks.SaveToDiskTask.doInBackground(SaveToDiskTask.java:119) at org.odk.collect.android.tasks.SaveToDiskTask.doInBackground(SaveToDiskTask.java:61) at android.os.AsyncTask$2.call(AsyncTask.java:288) at java.util.concurrent.FutureTask.run(FutureTask.java:237) at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:231) at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112) at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587) at java.lang.Thread.run(Thread.java:841)