### PR TITLE
Form cancel should redirect to form selection

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -761,11 +761,12 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 FormRecordCleanupTask.wipeRecord(this, currentState);
             }
 
-            currentState.reset();
             if (wasExternal) {
+                currentState.reset();
                 this.finish();
                 return false;
             } else if (current.getStatus().equals(FormRecord.STATUS_INCOMPLETE)) {
+                currentState.reset();
                 // We should head back to the incomplete forms screen
                 goToFormArchive(true, current);
                 return false;


### PR DESCRIPTION
Erroring-out of form entry took the user back to the module selection screen, whereas it should take one back to the form selection screen. 

[ticket](http://manage.dimagi.com/default.asp?167803#935571)