### PR TITLE
Remove pref edits that were never committed

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -458,10 +458,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                             // if the session isn't available, we don't need to logout
                         }
                     }
-                    //set flag that we should autoupdate on next login
-                    SharedPreferences preferences = CommCareApplication._().getCurrentApp().getAppPreferences();
-                    preferences.edit().putBoolean(CommCarePreferences.AUTO_TRIGGER_UPDATE,true);
-                    //The onResume() will take us to the screen
                     return;
                 }
                 break;

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -773,12 +773,6 @@ public class CommCareApplication extends Application {
         //Establish whether or not an AutoUpdate is Pending
         String autoUpdateFreq = preferences.getString(CommCarePreferences.AUTO_UPDATE_FREQUENCY, CommCarePreferences.FREQUENCY_NEVER);
 
-        boolean autoUpdateTriggered = preferences.getBoolean(CommCarePreferences.AUTO_TRIGGER_UPDATE, false);
-
-        if (autoUpdateTriggered) {
-            preferences.edit().putBoolean(CommCarePreferences.AUTO_TRIGGER_UPDATE, false);
-            return true;
-        }
         //See if auto update is even turned on
         if (!autoUpdateFreq.equals(CommCarePreferences.FREQUENCY_NEVER)) {
             long lastUpdateCheck = preferences.getLong(CommCarePreferences.LAST_UPDATE_ATTEMPT, 0);

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -79,8 +79,6 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
     public final static String YES = "yes";
     public final static String NO = "no";
 
-    public final static String AUTO_TRIGGER_UPDATE = "auto-trigger-update";
-
     public static final String DUMP_FOLDER_PATH = "dump-folder-path";
 
 


### PR DESCRIPTION
@wspride in commit f8928c70076b9b1a9dafb79eef17420815820647 , you added the following logic that I am now asking to be removed. That commit edited some preferences but never committed them by calling '.commit()'. This means that AUTO_TRIGGER_UPDATE was always set to false, making the statements removed in the PR no-ops.

I initially added '.commit()' back in but it broke things, so I decided to remove the code, since it is unclear what the intent of the logic was. 