### PR TITLE
Display saved forms incrementally; only call load once.

### DIFF
--- a/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
@@ -36,35 +36,49 @@ import android.widget.BaseAdapter;
  *
  */
 public class IncompleteFormListAdapter extends BaseAdapter implements FormRecordLoadListener {
+    private final Context context;
     
-    private AndroidCommCarePlatform platform;
-    private Context context;
+    private final List<DataSetObserver> observers;
     
-    List<DataSetObserver> observers;
-    
-    FormRecordFilter filter;
-    // loaded form records, before filtering occurs
+    private FormRecordFilter filter;
+
+    /**
+     * All loaded form records of a given status, with no filtering.
+     */
     private List<FormRecord> records;
-    // filtered form records
-    private List<FormRecord> current = new ArrayList<FormRecord>();
 
-    // Maps FormRecord ID to an array of text that will be shown to the user
-    // and query-able. Text should includes modified date, record title, & form
-    // name.
-    private Hashtable<Integer, String[]> searchCache;
+    /**
+     * Filtered form records. getView reads from this to display all the forms.
+     */
+    private final List<FormRecord> current = new ArrayList<FormRecord>();
 
-    // last query made, used to filter records
-    private String query;
+    /**
+     * Maps FormRecord ID to an array of text that will be shown to the user
+     * and query-able. Text should includes modified date, record title, & form
+     * name.
+     */
+    private final Hashtable<Integer, String[]> searchCache = new Hashtable<Integer, String[]>();
 
-    FormRecordLoaderTask loader;
+    /**
+     * The last query made, used to filter forms.
+     */
+    private String query = "";
 
-    // Maps form namespace (unique id for forms) to their form title
-    // (entry-point text). Needed because FormRecords don't have form title
-    // info, but do have the namespace.
-    Hashtable<String, Text> names;
+    /**
+     * The current query split up by spaces. Used for filtering forms.
+     */
+    private String [] queryPieces = new String[0];
+
+    private FormRecordLoaderTask loader;
+
+    /**
+     * Maps form namespace (unique id for forms) to their form title
+     * (entry-point text). Needed because FormRecords don't have form title
+     * info, but do have the namespace.
+     */
+    private final Hashtable<String, Text> names;
 
     public IncompleteFormListAdapter(Context context, AndroidCommCarePlatform platform, FormRecordLoaderTask loader) throws SessionUnavailableException{
-        this.platform = platform;
         this.context = context;
         this.filter = null;
         this.loader = loader;
@@ -88,21 +102,21 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
     }
 
     /**
-     * Unused since priority loading logic is currently too messy/broken.
+     * Add a newly-loaded form to the current list if it satisfies the current
+     * query.
      */
-    public void notifyPriorityLoaded(Integer first, boolean contains) {
-        return;
+    @Override
+    public void notifyPriorityLoaded(FormRecord record, boolean isLoaded) {
+        if (isLoaded && satisfiesQuery(record)) {
+            current.add(record);
+        }
     }
 
     /**
-     * Filter and display the form list after form record data has finished
-     * loading.
-     *
-     * Implements FormRecordLoadListener and is called every time
-     * FormRecordLoaderTask finishes loading.
+     * Notify observers that the form list has loaded/potentially been updated.
      */
+    @Override
     public void notifyLoaded() {
-        this.filterValues();
         this.notifyDataSetChanged();
     }
 
@@ -149,7 +163,8 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
             }
         });
 
-        searchCache = new Hashtable<Integer, String[]>();
+        searchCache.clear();
+        current.clear();
 
         // load specific data about the 'records' into the searchCache, such as
         // record title, form name, modified date
@@ -306,25 +321,41 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
 
         current.clear();
 
-        if (query == null || query.equals("")) {
+        if ("".equals(query)) {
             current.addAll(records);
             return;
         }
 
-        String[] pieces = query.toLowerCase().split(" ");
-
         // collect all forms that have text data that contains pieces.
-        full:
         for (FormRecord r : records) {
-            for (String cacheValue : searchCache.get(r.getID())) {
-                for (String piece : pieces) {
-                    if (cacheValue.toLowerCase().contains(piece)) {
-                        current.add(r);
-                        continue full;
-                    }
+            if (satisfiesQuery(r)) {
+                current.add(r);
+            }
+        }
+    }
+
+    /**
+     * Does the form record have text that contains one of the query segments?
+     *
+     * @param r Lookup this form record's text and compare to the current query
+     *          segments.
+     * @return Did the text corresponding to the form record argument contain
+     * any of the query segments?
+     */
+    private boolean satisfiesQuery(FormRecord r) {
+        if (queryPieces.length == 0) {
+            // empty queries always pass
+            return true;
+        }
+
+        for (String cacheValue : searchCache.get(r.getID())) {
+            for (String piece : this.queryPieces) {
+                if (cacheValue.toLowerCase().contains(piece)) {
+                    return true;
                 }
             }
         }
+        return false;
     }
 
     /**
@@ -333,8 +364,23 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
      * @param newQuery set the current query to this value.
      */
     public void applyTextFilter(String newQuery) {
+        if (this.query.trim().equals(newQuery.trim())) {
+            // don't perform filtering if old and new queries are same, modulo
+            // whitespace
+            return;
+        }
+
         this.query = newQuery;
+
+        // split the query up into segments, by whitespace.
+        if ("".equals(this.query)) {
+            this.queryPieces = new String[0];
+        } else {
+            this.queryPieces = newQuery.toLowerCase().split(" ");
+        }
+
         filterValues();
+
         for (DataSetObserver o : observers) {
             o.onChanged();
         }

--- a/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
@@ -54,8 +54,8 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
 
     /**
      * Maps FormRecord ID to an array of text that will be shown to the user
-     * and query-able. Text should includes modified date, record title, & form
-     * name.
+     * and query-able. Text should includes modified date, record title, and
+     * form name.
      */
     private final Hashtable<Integer, String[]> searchCache = new Hashtable<Integer, String[]>();
 

--- a/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
@@ -121,6 +121,19 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
     }
 
     /**
+     * Load new records and text if the given FormFilter differs from the
+     * current filter.
+     *
+     * @param newFilter update the internal FormFilter to this value
+     */
+    public void setFilterAndResetRecords(FormRecordFilter newFilter) {
+        if (!newFilter.equals(this.filter)) {
+            setFormFilter(newFilter);
+            resetRecords();
+        }
+    }
+
+    /**
      * Reload form record list for current filter status and collect pertinent
      * text data using FormRecordLoaderTask; results will then be re-filtered
      * and displayed via callbacks.

--- a/app/src/org/commcare/android/tasks/FormRecordLoadListener.java
+++ b/app/src/org/commcare/android/tasks/FormRecordLoadListener.java
@@ -1,15 +1,27 @@
-/**
- * 
- */
 package org.commcare.android.tasks;
 
+import org.commcare.android.database.user.models.FormRecord;
+
 /**
- * @author ctsims
+ * Listener methods that are used to keep track of loading progress of form
+ * records and their query-able data.
  *
+ * @author ctsims
  */
 public interface FormRecordLoadListener {
 
-    void notifyPriorityLoaded(Integer first, boolean contains);
-    
+    /**
+     * Called every time a single FormRecord has been processed by
+     * FormRecordLoaderTask.
+     *
+     * @param record   The form record that was processed.
+     * @param isLoaded Currently unused. TODO PLM: figure out how to use this
+     *                 or remove it.
+     */
+    void notifyPriorityLoaded(FormRecord record, boolean isLoaded);
+
+    /**
+     * Called every time FormRecordLoaderTask finishes loading.
+     */
     void notifyLoaded();
 }

--- a/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
@@ -27,7 +27,7 @@ import android.util.Pair;
  * @author ctsims
  *
  */
-public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<Integer, ArrayList<String>>, Integer> {
+public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<FormRecord, ArrayList<String>>, Integer> {
 
     private Hashtable<String,String> descriptorCache;
     private SqlStorage<SessionStateDescriptor> descriptorStorage;
@@ -194,7 +194,7 @@ public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<Integer, Ar
 
             // Copy data into search task and notify anything waiting on this
             // record.
-            this.publishProgress(new Pair<Integer, ArrayList<String>>(current.getID(), recordTextDesc));
+            this.publishProgress(new Pair<FormRecord, ArrayList<String>>(current, recordTextDesc));
         }
         return 1;
     }
@@ -238,7 +238,7 @@ public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<Integer, Ar
      * @see android.os.AsyncTask#onProgressUpdate(Progress[])
      */
     @Override
-    protected void onProgressUpdate(Pair<Integer, ArrayList<String>>... values) {
+    protected void onProgressUpdate(Pair<FormRecord, ArrayList<String>>... values) {
         super.onProgressUpdate(values);
 
         // copy a single form record's data out of method arguments
@@ -249,14 +249,15 @@ public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<Integer, Ar
         }
 
         // store the loaded data in the search cache
-        this.searchCache.put(values[0].first, vals);
+        this.searchCache.put(values[0].first.getID(), vals);
 
         for (FormRecordLoadListener listener : this.listeners) {
             if (listener != null) {
                 // XXX: PLM: pretty sure loaded.contains(values[0].first) is always true at this point.
                 // Should really refactor the following line so that this is
                 // only called if we pulled the value from the priority queue
-                listener.notifyPriorityLoaded(values[0].first, loaded.contains(values[0].first));
+                listener.notifyPriorityLoaded(values[0].first,
+                        loaded.contains(values[0].first.getID()));
             }
         }
     }

--- a/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
@@ -253,9 +253,8 @@ public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<FormRecord,
 
         for (FormRecordLoadListener listener : this.listeners) {
             if (listener != null) {
-                // XXX: PLM: pretty sure loaded.contains(values[0].first) is always true at this point.
-                // Should really refactor the following line so that this is
-                // only called if we pulled the value from the priority queue
+                // XXX: PLM: pretty sure loaded.contains(values[0].first) is
+                // always true at this point.
                 listener.notifyPriorityLoaded(values[0].first,
                         loaded.contains(values[0].first.getID()));
             }

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -179,6 +179,10 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                      */
                     @Override
                     public void onItemSelected(AdapterView<?> arg0, View arg1, int index, long id) {
+                        // NOTE: This gets called every time a spinner gets
+                        // set-up and also every time spinner state is restored
+                        // on scree-rotation. Hence we defer onCreate record
+                        // loading until this gets triggered automatically.
                         adapter.setFilterAndResetRecords(FormRecordFilter.values()[index]);
 
                         //This is only relevant with the new menu format, old menus have a hard

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -176,6 +176,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                 ArrayAdapter<String> spinneritems = new ArrayAdapter<String>(this, R.layout.form_filter_display, names);
                 filterSelect.setAdapter(spinneritems);
                 spinneritems.setDropDownViewResource(R.layout.form_filter_item);
+                filterSelect.setSelection(0, false);
                 filterSelect.setOnItemSelectedListener(new OnItemSelectedListener() {
                     
                     /*
@@ -422,7 +423,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                 SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
                 User u = CommCareApplication._().getSession().getLoggedInUser();
                 String source = prefs.getString("form-record-url", this.getString(R.string.form_record_url));
-                
+
                 //We should go digest auth this user on the server and see whether to pull them
                 //down.
                 DataPullTask<FormRecordListActivity> pull = new DataPullTask<FormRecordListActivity>(u.getUsername(),u.getCachedPwd(), source, "", this) {
@@ -586,13 +587,14 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
     }
 
 
-    public void notifyPriorityLoaded(Integer record, boolean priority) {
+    @Override
+    public void notifyPriorityLoaded(FormRecord record, boolean priority) {
         if(priority) {
             adapter.notifyDataSetChanged();
         }
     }
 
-
+    @Override
     public void notifyLoaded() {
         enableSearch();
     }


### PR DESCRIPTION
The 'Saved Form Listing' view was trying to load saved forms more than once and only showing results once everything had loaded. 

This PR makes sure forms loading doesn't occur more than once per view entry and enables incremental results to be displayed.

Hopefully helpful for this [ticket](http://manage.dimagi.com/default.asp?167729)