### PR TITLE
Removed unused fields that cause crash on 4.2.2

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
@@ -41,9 +41,6 @@ import android.widget.TextView;
 
 @ManagedUi(R.layout.screen_form_dump)
 public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpActivity> {
-    
-    @UiElement(R.id.screen_bulk_image1)
-    ImageView banner;
      
     @UiElement(value = R.id.screen_bulk_form_prompt, locale="bulk.form.prompt")
     TextView txtDisplayPrompt;

--- a/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
@@ -30,17 +30,9 @@ import org.javarosa.core.services.locale.Localization;
 
 @ManagedUi(R.layout.connection_diagnostic)
 public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDiagnosticActivity> {
-    
 
-    
     public static final String logUnsetPostURLMessage = "CCHQ ping test: post URL not set.";
-    
-    @UiElement(R.id.screen_bulk_image1)
-    ImageView banner;
-    
-    @UiElement(value = R.id.connection_test_prompt, locale="connection.test.prompt")
-    TextView connectionPrompt;
-    
+
     @UiElement(value = R.id.run_connection_test, locale="connection.test.run")
     Button btnRunTest;
     


### PR DESCRIPTION
Removing unused class fields that caused a crash when CommCareActivity tried to load them when screen orientation changes.

[ticket](http://manage.dimagi.com/default.asp?167532#939390)