### PR TITLE
ManageAsyncTasks; enabling task cancellation on session expiration

### DIFF
--- a/app/src/org/commcare/android/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/EntityLoaderTask.java
@@ -7,6 +7,7 @@ import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.models.AsyncNodeEntityFactory;
 import org.commcare.android.models.Entity;
 import org.commcare.android.models.NodeEntityFactory;
+import org.commcare.android.tasks.templates.ManagedAsyncTask;
 import org.commcare.suite.model.Detail;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
@@ -21,7 +22,7 @@ import android.util.Pair;
  * @author ctsims
  *
  */
-public class EntityLoaderTask extends AsyncTask<TreeReference, Integer, Pair<List<Entity<TreeReference>>, List<TreeReference>>> {
+public class EntityLoaderTask extends ManagedAsyncTask<TreeReference, Integer, Pair<List<Entity<TreeReference>>, List<TreeReference>>> {
     
     private static EntityLoaderTask pending[] = {null};
     

--- a/app/src/org/commcare/android/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/EntityLoaderTask.java
@@ -14,7 +14,6 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
 import org.javarosa.xpath.XPathException;
 
-import android.os.AsyncTask;
 import android.util.Pair;
 
 

--- a/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
@@ -11,11 +11,11 @@ import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.android.models.AndroidSessionWrapper;
+import org.commcare.android.tasks.templates.ManagedAsyncTask;
 import org.commcare.android.util.AndroidCommCarePlatform;
 import org.commcare.suite.model.Text;
 
 import android.content.Context;
-import android.os.AsyncTask;
 import android.util.Pair;
 
 /**
@@ -27,7 +27,7 @@ import android.util.Pair;
  * @author ctsims
  *
  */
-public class FormRecordLoaderTask extends AsyncTask<FormRecord, Pair<Integer, ArrayList<String>>, Integer> {
+public class FormRecordLoaderTask extends ManagedAsyncTask<FormRecord, Pair<Integer, ArrayList<String>>, Integer> {
 
     private Hashtable<String,String> descriptorCache;
     private SqlStorage<SessionStateDescriptor> descriptorStorage;

--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -19,7 +19,6 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
     protected int taskId = GENERIC_TASK_ID;
     
     public CommCareTask() {
-        
     }
 
     /* (non-Javadoc)

--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.tasks.templates;
 
 import android.os.AsyncTask;
@@ -9,7 +6,7 @@ import android.os.AsyncTask;
  * @author ctsims
  *
  */
-public abstract class CommCareTask<A, B, C, R> extends AsyncTask<A, B, C> {
+public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C> {
     
     public static final int GENERIC_TASK_ID = 32;
     
@@ -39,7 +36,11 @@ public abstract class CommCareTask<A, B, C, R> extends AsyncTask<A, B, C> {
             return null;
         }
     }
-    
+
+    /**
+     * Catch-wrapped computation to be performed in background thread.
+     * Dispatched by doInBackground
+     */
     protected abstract C doTaskBackground(A... params);
 
     /* (non-Javadoc)

--- a/app/src/org/commcare/android/tasks/templates/CommCareTaskConnector.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTaskConnector.java
@@ -1,47 +1,49 @@
-/**
- * 
- */
 package org.commcare.android.tasks.templates;
 
 /**
  * @author ctsims
- *
  */
 public interface CommCareTaskConnector<R> {
-    
-     /* IMPORTANT: Any implementing class of CommCareTaskConnector should be 
-      * implemented such that it will only automatically manage the dialog of a 
-      * connected task IF the task id is non-negative. If the user does NOT want to 
-      * implement a dialog, or is implementing the dialog in a different way, 
-      * they should be able to use a negative task id in order to avoid this
+
+     /**
+      * IMPORTANT: Any implementing class of CommCareTaskConnector should be
+      * implemented such that it will only automatically manage the dialog of a
+      * connected task IF the task id is non-negative. If the user does NOT
+      * want to implement a dialog, or is implementing the dialog in a
+      * different way, they should be able to use a negative task id in order
+      * to avoid this.
       */
     public <A, B, C> void connectTask(CommCareTask<A,B,C,R> task);
-    
-    /* Should call showProgressDialog() for a task  if its id
-     * is non-negative, and if there is no dialog already showing
+
+    /**
+     * Should call showProgressDialog() for a task if its id is non-negative,
+     * and if there is no dialog already showing
      */
     public void startBlockingForTask(int id);
-    
-    /* Should call dismissProgressDialog() for a task if its id
-     * is non-negative, and if shouldDismissDialog is true (this 
-     * flag should be controlled by the task transition)
+
+    /**
+     * Should call dismissProgressDialog() for a task if its id is
+     * non-negative, and if shouldDismissDialog is true (this flag should be
+     * controlled by the task transition)
      */
     public void stopBlockingForTask(int id);
-    
+
     public void taskCancelled(int id);
 
     public R getReceiver();
-    
-    /* Should be called at the beginning of onPostExecute or onCancelled
-     * for any CommCareTask, indicating that we are starting a potential
-     * transition from one task to another (if the end of the first task
-     * triggers the start of another)
+
+    /**
+     * Should be called at the beginning of onPostExecute or onCancelled for
+     * any CommCareTask, indicating that we are starting a potential transition
+     * from one task to another (if the end of the first task triggers the
+     * start of another)
      */
     public void startTaskTransition();
-    
-    /* Should be called at the end of onPreExecute or onCancelled
-     * for any CommCareTask, indicating that we are ending a potential
-     * transition from one task to another
+
+    /**
+     * Should be called at the end of onPreExecute or onCancelled for any
+     * CommCareTask, indicating that we are ending a potential transition from
+     * one task to another
      */
     public void stopTaskTransition();
 }

--- a/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
+++ b/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
@@ -1,0 +1,66 @@
+package org.commcare.android.tasks.templates;
+
+import android.os.AsyncTask;
+
+import java.util.ArrayList;
+
+/**
+ * AsyncTask that is registered, enabling the task to be cancelled if the
+ * session ends. Useful since the session ending might close resources that the
+ * task depends on to proceed.
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+
+public abstract class ManagedAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
+
+    /**
+     * List of running/to-be-run tasks. Tasks remove themselves automatically
+     * upon completion.
+     */
+    private static final ArrayList<ManagedAsyncTask<?, ?, ?>> livingTasks =
+            new ArrayList<ManagedAsyncTask<?, ?, ?>>();
+
+    /**
+     * Create task and add it to list of managed tasks.
+     */
+    public void ManagedAsyncTask() {
+        livingTasks.add(this);
+    }
+
+    /**
+     * Call cancel on all tasks and then wipe the living task list.
+     */
+    public static void cancelTasks() {
+        synchronized(livingTasks) {
+            for (AsyncTask task : livingTasks) {
+                task.cancel(true);
+            }
+            livingTasks.clear();
+        }
+    }
+
+    /**
+     * On execution completion remove task from managed task list.
+     */
+    @Override
+    protected void onPostExecute(C result) {
+        super.onPostExecute(result);
+
+        synchronized(livingTasks) {
+            livingTasks.remove(this);
+        }
+    }
+
+    /**
+     * On task cancellation remove task from managed task list.
+     */
+    @Override
+    protected void onCancelled() {
+        super.onCancelled();
+
+        synchronized(livingTasks) {
+            livingTasks.remove(this);
+        }
+    }
+}

--- a/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
+++ b/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
@@ -24,8 +24,10 @@ public abstract class ManagedAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
     /**
      * Create task and add it to list of managed tasks.
      */
-    public void ManagedAsyncTask() {
-        livingTasks.add(this);
+    public ManagedAsyncTask() {
+        synchronized(livingTasks) {
+            livingTasks.add(this);
+        }
     }
 
     /**

--- a/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
+++ b/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
@@ -15,20 +15,11 @@ import java.util.ArrayList;
 public abstract class ManagedAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
 
     /**
-     * List of running/to-be-run tasks. Tasks remove themselves automatically
-     * upon completion.
+     * List of running tasks. Tasks add/remove themselves automatically upon
+     * start, cancellation, and completion.
      */
     private static final ArrayList<ManagedAsyncTask<?, ?, ?>> livingTasks =
             new ArrayList<ManagedAsyncTask<?, ?, ?>>();
-
-    /**
-     * Create task and add it to list of managed tasks.
-     */
-    public ManagedAsyncTask() {
-        synchronized(livingTasks) {
-            livingTasks.add(this);
-        }
-    }
 
     /**
      * Call cancel on all tasks and then wipe the living task list.
@@ -39,6 +30,16 @@ public abstract class ManagedAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
                 task.cancel(true);
             }
             livingTasks.clear();
+        }
+    }
+
+    /**
+     * Before executing add the task to list of managed tasks.
+     */
+    @Override
+    protected void onPreExecute() {
+        synchronized(livingTasks) {
+            livingTasks.add(this);
         }
     }
 

--- a/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
+++ b/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
@@ -38,6 +38,8 @@ public abstract class ManagedAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
      */
     @Override
     protected void onPreExecute() {
+        super.onPreExecute();
+
         synchronized(livingTasks) {
             livingTasks.add(this);
         }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -21,6 +21,7 @@ import org.commcare.android.database.user.models.User;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.tasks.DataSubmissionListener;
 import org.commcare.android.tasks.ProcessAndSendTask;
+import org.commcare.android.tasks.templates.ManagedAsyncTask;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.activities.CommCareHomeActivity;
@@ -376,6 +377,10 @@ public class CommCareSessionService extends Service  {
                 // before.
                 return;
             }
+
+            // Cancel any running tasks before closing down the user databse.
+            ManagedAsyncTask.cancelTasks();
+
             key = null;
             String msg = "Logging out service login";
 


### PR DESCRIPTION
Was experiencing a crash in EntityLoaderTask, where if the database closed when it was running, it would crash commcare. Fix this by canceling the task when the db is closed.

 - Create ManageAsyncTask to keep track of running tasks.
 - ManageAsyncTask.cancelTasks calls cancel on all the running tasks; call on session expiration
 - have CommCareTask extend it ManageAsyncTask