### PR TITLE
Increase form save logout timeout to 90 secs

### DIFF
--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -77,8 +77,8 @@ public class CommCareSessionService extends Service  {
     private final int SUBMISSION_NOTIFICATION = org.commcare.dalvik.R.string.submission_notification_title;
 
     // How long to wait until we force the session to finish logging out. Set
-    // at 30 seconds to make sure huge forms on slow phones actually get saved
-    private static final long LOGOUT_TIMEOUT = 1000 * 30;
+    // at 90 seconds to make sure huge forms on slow phones actually get saved
+    private static final long LOGOUT_TIMEOUT = 1000 * 90;
 
     // The logout process start time, used to wrap up logging out if
     // the saving of incomplete forms takes too long

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -76,8 +76,9 @@ public class CommCareSessionService extends Service  {
     private final int NOTIFICATION = org.commcare.dalvik.R.string.notificationtitle;
     private final int SUBMISSION_NOTIFICATION = org.commcare.dalvik.R.string.submission_notification_title;
 
-    // How long to wait until we force the session to finish logging out
-    private static final long LOGOUT_TIMEOUT = 1000;
+    // How long to wait until we force the session to finish logging out. Set
+    // at 30 seconds to make sure huge forms on slow phones actually get saved
+    private static final long LOGOUT_TIMEOUT = 1000 * 30;
 
     // The logout process start time, used to wrap up logging out if
     // the saving of incomplete forms takes too long


### PR DESCRIPTION
When the session expires and a form tries to save, there is a timeout period, which when reached the form saving is aborted. Increase this timeout to 90 seconds because who knows how long it might take to save some huge form on a slow phone.