### PR TITLE
Wrap getSession calls in try/catch

### DIFF
--- a/app/src/org/commcare/android/tasks/DataPullTask.java
+++ b/app/src/org/commcare/android/tasks/DataPullTask.java
@@ -391,6 +391,8 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
                 e.printStackTrace();
                 Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Couldn't sync due to IO Error|" + e.getMessage());
             } catch (SessionUnavailableException sue) {
+                // TODO PLM: eventually take out this catch. These should be
+                // checked locally
                 //TODO: Keys were lost somehow.
                 sue.printStackTrace();
             }

--- a/app/src/org/commcare/android/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/android/tasks/LogSubmissionTask.java
@@ -215,7 +215,7 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
             return false;
         }
 
-        if (user.getUserType().equals(User.TYPE_DEMO)) {
+        if (User.TYPE_DEMO.equals(user.getUserType())) {
             generator = new HttpRequestGenerator();
         } else {
             generator = new HttpRequestGenerator(user);

--- a/app/src/org/commcare/android/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/android/tasks/LogSubmissionTask.java
@@ -207,15 +207,15 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
         //signal that it's time to start submitting the file
         this.startSubmission(index, f.length());
         HttpRequestGenerator generator;
-        User user = null;
+        User user;
         try {
             user = CommCareApplication._().getSession().getLoggedInUser();
         } catch (SessionUnavailableException e) {
-            // Session probably expired, so we will continue submitting logs,
-            // pretending to be a demo user.
+            // lost the session, so report failed submission
+            return false;
         }
 
-        if (user == null || user.getUserType().equals(User.TYPE_DEMO)) {
+        if (user.getUserType().equals(User.TYPE_DEMO)) {
             generator = new HttpRequestGenerator();
         } else {
             generator = new HttpRequestGenerator(user);

--- a/app/src/org/commcare/android/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/android/tasks/LogSubmissionTask.java
@@ -207,8 +207,15 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
         //signal that it's time to start submitting the file
         this.startSubmission(index, f.length());
         HttpRequestGenerator generator;
-        User user = CommCareApplication._().getSession().getLoggedInUser();
-        if(user.getUserType().equals(User.TYPE_DEMO)) {
+        User user = null;
+        try {
+            user = CommCareApplication._().getSession().getLoggedInUser();
+        } catch (SessionUnavailableException e) {
+            // Session probably expired, so we will continue submitting logs,
+            // pretending to be a demo user.
+        }
+
+        if (user == null || user.getUserType().equals(User.TYPE_DEMO)) {
             generator = new HttpRequestGenerator();
         } else {
             generator = new HttpRequestGenerator(user);

--- a/app/src/org/commcare/android/tasks/SendTask.java
+++ b/app/src/org/commcare/android/tasks/SendTask.java
@@ -146,6 +146,10 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
             } catch(FileNotFoundException fe){
                 Log.e("E", Localization.get("bulk.send.file.error", new String[] {f.getAbsolutePath()}), fe);
                 publishProgress(Localization.get("bulk.send.file.error", new String[] {fe.getMessage()}));
+            } catch (SessionUnavailableException e) {
+                // The session probably expired, so don't send anything and log it.
+                Log.e("E", Localization.get("bulk.send.file.error", new String[] {f.getAbsolutePath()}), e);
+                publishProgress(Localization.get("bulk.send.file.error", new String[] {e.getMessage()}));
             }
         }
         return allSuccessful;

--- a/app/src/org/commcare/android/util/CommCareUtil.java
+++ b/app/src/org/commcare/android/util/CommCareUtil.java
@@ -108,8 +108,15 @@ public class CommCareUtil {
             //This is mostly for dev purposes
             Toast.makeText(c, "Couldn't submit logs! Invalid submission URL...", Toast.LENGTH_LONG).show();
         } else {
-            LogSubmissionTask reportSubmitter = new LogSubmissionTask(CommCareApplication._(), true, CommCareApplication._().getSession().startDataSubmissionListener(R.string.submission_logs_title), url);
-            reportSubmitter.execute();
+            try {
+                LogSubmissionTask reportSubmitter =
+                    new LogSubmissionTask(CommCareApplication._(), true,
+                            CommCareApplication._().getSession().startDataSubmissionListener(R.string.submission_logs_title),
+                            url);
+                reportSubmitter.execute();
+            } catch (SessionUnavailableException e) {
+                Toast.makeText(c, "Couldn't submit logs! No longer logged in", Toast.LENGTH_LONG).show();
+            }
         }
     }
 }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -306,7 +306,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     }
     
     private void syncData(boolean formsToSend) {
-        User u = null;
+        User u;
         try {
             u = CommCareApplication._().getSession().getLoggedInUser();
         } catch (SessionUnavailableException sue) {

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -306,7 +306,13 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     }
     
     private void syncData(boolean formsToSend) {
-        User u = CommCareApplication._().getSession().getLoggedInUser();
+        User u = null;
+        try {
+            u = CommCareApplication._().getSession().getLoggedInUser();
+        } catch (SessionUnavailableException sue) {
+            // abort since it looks like the session expired
+            return;
+        }
         
         if(User.TYPE_DEMO.equals(u.getUserType())) {
             //Remind the user that there's no syncing in demo mode.0
@@ -1115,7 +1121,13 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             }
             
         };
-        mProcess.setListeners(CommCareApplication._().getSession().startDataSubmissionListener());
+
+        try {
+            mProcess.setListeners(CommCareApplication._().getSession().startDataSubmissionListener());
+        } catch (SessionUnavailableException sue) {
+            // abort since it looks like the session expired
+            return;
+        }
         mProcess.connect(this);
         
         //Execute on a true multithreaded chain. We should probably replace all of our calls with this

--- a/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
@@ -169,23 +169,28 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
                         CommCareApplication._().getCurrentApp().getAppPreferences();
                 String url = settings.getString("PostURL", null);
                 
-                if(url != null) 
-                {
-                    LogSubmissionTask reportSubmitter = 
+                if(url != null) {
+                    DataSubmissionListener dataListener = null;
+
+                    try {
+                        dataListener =
+                            CommCareApplication._().getSession().startDataSubmissionListener(R.string.submission_logs_title)
+                    } catch (SessionUnavailableException sue) {
+                        // abort since it looks like the session expired
+                        return;
+                    }
+                    LogSubmissionTask reportSubmitter =
                             new LogSubmissionTask(
-                                    CommCareApplication._(), 
-                                    true, 
-                                    CommCareApplication._().getSession().startDataSubmissionListener(
-                                            R.string.submission_logs_title), url);
+                                    CommCareApplication._(),
+                                    true,
+                                    dataListener, url);
                     reportSubmitter.execute();
                     ConnectionDiagnosticActivity.this.finish();
                     Toast.makeText(
                             CommCareApplication._(), 
                             Localization.get("connection.task.report.commcare.popup"), 
                             Toast.LENGTH_LONG).show();
-                } 
-                else 
-                {
+                } else {
                     Logger.log(ConnectionDiagnosticTask.CONNECTION_DIAGNOSTIC_REPORT, logUnsetPostURLMessage);
                     ConnectionDiagnosticActivity.this.txtInteractiveMessages.setText(MarkupUtil.localizeStyleSpannable(ConnectionDiagnosticActivity.this, "connection.task.unset.posturl"));
                     ConnectionDiagnosticActivity.this.txtInteractiveMessages.setVisibility(View.VISIBLE);

--- a/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
@@ -14,8 +14,10 @@ import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.tasks.ConnectionDiagnosticTask;
+import org.commcare.android.tasks.DataSubmissionListener;
 import org.commcare.android.tasks.LogSubmissionTask;
 import org.commcare.android.util.MarkupUtil;
+import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.CustomProgressDialog;
@@ -170,11 +172,11 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
                 String url = settings.getString("PostURL", null);
                 
                 if(url != null) {
-                    DataSubmissionListener dataListener = null;
+                    DataSubmissionListener dataListener;
 
                     try {
                         dataListener =
-                            CommCareApplication._().getSession().startDataSubmissionListener(R.string.submission_logs_title)
+                            CommCareApplication._().getSession().startDataSubmissionListener(R.string.submission_logs_title);
                     } catch (SessionUnavailableException sue) {
                         // abort since it looks like the session expired
                         return;

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -75,8 +75,15 @@ public class EntityDetailActivity extends CommCareActivity implements DetailCall
     public void onCreate(Bundle savedInstanceState) {        
         Intent i = getIntent();
         
-        asw = CommCareApplication._().getCurrentSessionWrapper();
-        session = asw.getSession();            
+        try {
+            asw = CommCareApplication._().getCurrentSessionWrapper();
+            session = asw.getSession();
+        } catch(SessionUnavailableException sue){
+            // The user isn't logged in! bounce this back to where we came from
+            this.setResult(RESULT_CANCELED, this.getIntent());
+            this.finish();
+            return;
+        }
         String passedCommand = getIntent().getStringExtra(SessionFrame.STATE_COMMAND_ID);
 
         if (passedCommand != null) {

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -420,7 +420,15 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         switch (item.getItemId()) {
             case DOWNLOAD_FORMS:
                 SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
-                User u = CommCareApplication._().getSession().getLoggedInUser();
+
+                User u = null;
+                try {
+                    u = CommCareApplication._().getSession().getLoggedInUser();
+                } catch (SessionUnavailableException sue) {
+                    // abort since it looks like the session expired
+                    return;
+                }
+
                 String source = prefs.getString("form-record-url", this.getString(R.string.form_record_url));
                 
                 //We should go digest auth this user on the server and see whether to pull them

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -421,12 +421,13 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
             case DOWNLOAD_FORMS:
                 SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
 
-                User u = null;
+                User u;
                 try {
                     u = CommCareApplication._().getSession().getLoggedInUser();
                 } catch (SessionUnavailableException sue) {
-                    // abort since it looks like the session expired
-                    return;
+                    // abort and let default processing happen, since it looks
+                    // like the session expired.
+                    return false;
                 }
 
                 String source = prefs.getString("form-record-url", this.getString(R.string.form_record_url));

--- a/app/src/org/commcare/dalvik/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/dalvik/activities/RecoveryActivity.java
@@ -136,7 +136,15 @@ public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
                     }
                     
                 };
-                mProcess.setListeners(CommCareApplication._().getSession().startDataSubmissionListener());
+
+                try {
+                    mProcess.setListeners(CommCareApplication._().getSession().startDataSubmissionListener());
+                } catch (SessionUnavailableException sue) {
+                    // abort since it looks like the session expired
+                    displayMessage("CommCare session is no longer available.");
+                    return;
+                }
+
                 mProcess.connect(RecoveryActivity.this);
                 
                 //Execute on a true multithreaded chain. We should probably replace all of our calls with this

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -573,6 +573,7 @@ public class CommCareApplication extends Application {
 //        
 //        getStorage(GeocodeCacheModel.STORAGE_KEY, GeocodeCacheModel.class).removeAll();
 
+        // TODO PLM wrap in try/catch for SessionUnavailableException
         final String username = this.getSession().getLoggedInUser().getUsername();
 
         final Set<String> dbIdsToRemove = new HashSet<String>();

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -34,6 +34,7 @@ import org.commcare.android.references.ArchiveFileRoot;
 import org.commcare.android.references.AssetFileRoot;
 import org.commcare.android.references.JavaHttpRoot;
 import org.commcare.android.storage.framework.Table;
+import org.commcare.android.tasks.DataSubmissionListener;
 import org.commcare.android.tasks.ExceptionReportTask;
 import org.commcare.android.tasks.FormRecordCleanupTask;
 import org.commcare.android.tasks.LogSubmissionTask;

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -755,9 +755,19 @@ public class CommCareApplication extends Application {
             return;
         }
 
+        DataSubmissionListener dataListener = null;
+
+        try {
+            dataListener =
+                CommCareApplication.this.getSession().startDataSubmissionListener(R.string.submission_logs_title);
+        } catch (SessionUnavailableException sue) {
+            // abort since it looks like the session expired
+            return;
+        }
+
         LogSubmissionTask task = new LogSubmissionTask(this,
                 force || isPending(settings.getLong(CommCarePreferences.LOG_LAST_DAILY_SUBMIT, 0), DateUtils.DAY_IN_MILLIS),
-                CommCareApplication.this.getSession().startDataSubmissionListener(R.string.submission_logs_title),
+                dataListener,
                 url);
 
         //Execute on a true multithreaded chain, since this is an asynchronous process

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2891,7 +2891,12 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
             }
         }
 
-        CommCareApplication._().getSession().unregisterFormSaveCallback();
+        try {
+            CommCareApplication._().getSession().unregisterFormSaveCallback();
+        } catch (SessionUnavailableException sue) {
+            // looks like the session expired
+        }
+
         this.dismissDialogs();
         finish();
     }


### PR DESCRIPTION
Many places call getSession (the CommCareSessionService one, not the one with unfortunately the same name found in AndroidSessionWrapper). These calls usually occur when a task, that accesses the user database, is getting ready to spin up. 

This PR wraps almost all calls to getSession in a try/catch to handle when the session has expired and is no longer available. In most cases such failed calls to getSession will result in tasks not getting launched.