### PR TITLE
Add a lock for session expiration/form send synchronization

### DIFF
--- a/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
@@ -21,6 +21,7 @@ import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.activities.LoginActivity;
 import org.commcare.dalvik.application.CommCareApplication;
+import org.commcare.dalvik.services.CommCareSessionService;
 import org.commcare.suite.model.Profile;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -111,219 +112,222 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
      * @see android.os.AsyncTask#doInBackground(Params[])
      */
     protected Integer doTaskBackground(FormRecord... records) {
-        boolean needToSendLogs = false;
-        try {
-        results = new Long[records.length];
-        for(int i = 0; i < records.length ; ++i ) {
-            //Assume failure
-            results[i] = FormUploadUtil.FAILURE;
-        }
-        //The first thing we need to do is make sure everything is processed,
-        //we can't actually proceed before that.
-        for(int i = 0 ; i < records.length ; ++i) {
-            FormRecord record = records[i];
-
-            //If the form is complete, but unprocessed, process it.
-            if(FormRecord.STATUS_COMPLETE.equals(record.getStatus())) {
-                try {
-                    records[i] = processor.process(record);
-                } catch (InvalidStructureException e) {
-                    CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
-                    Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to transaction data|" + getExceptionText(e));
-                    FormRecordCleanupTask.wipeRecord(c, record);
-                    needToSendLogs = true;
-                    continue;
-                } catch (XmlPullParserException e) {
-                    CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
-                    Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad xml|" + getExceptionText(e));
-                    FormRecordCleanupTask.wipeRecord(c, record);
-                    needToSendLogs = true;
-                    continue;
-                } catch (UnfullfilledRequirementsException e) {
-                    CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
-                    Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad requirements|" + getExceptionText(e));
-                    FormRecordCleanupTask.wipeRecord(c, record);
-                    needToSendLogs = true;
-                    continue;
-                } catch (FileNotFoundException e) {
-                    if(CommCareApplication._().isStorageAvailable()) {
-                        //If storage is available generally, this is a bug in the app design
-                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record because file was missing|" + getExceptionText(e));
-                        FormRecordCleanupTask.wipeRecord(c, record);
-                    } else {
-                        CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.StorageRemoved), true);
-                        //Otherwise, the SD card just got removed, and we need to bail anyway.
-                        return (int)PROGRESS_SDCARD_REMOVED;
-                    }
-                    continue;
-                }   catch (IOException e) {
-                    Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "IO Issues processing a form. Tentatively not removing in case they are resolvable|" + getExceptionText(e));
-                    continue;
-                } 
-            }
-        }
-        
-        this.publishProgress(PROGRESS_ALL_PROCESSED);
-        
-        //Put us on the queue!
-        synchronized(processTasks) {
-            processTasks.add(this);
-        }
-        
-        boolean proceed = false;
-        boolean needToRefresh = false;
-        while(!proceed) {
-            //TODO: Terrible?
-            
-            //See if it's our turn to go
-            synchronized(processTasks) {
-                //Are we at the head of the queue?
-                ProcessAndSendTask head = processTasks.peek();
-                if(processTasks.peek() == this) {
-                    proceed = true;
-                    break;
-                }
-                //Otherwise, is the head of the queue busted?
-                //*sigh*. Apparently Cancelled doesn't result in the task status being set
-                //to !Running for reasons which baffle me.
-                if(head.getStatus() != AsyncTask.Status.RUNNING || head.isCancelled()) {
-                    //If so, get rid of it
-                    processTasks.remove(head);
-                }
-            }
-            //If it's not yet quite our turn, take a nap
+        // Don't allow session to expire while we are syncing
+        synchronized(CommCareSessionService.LOGOUT_LOCK) {
+            boolean needToSendLogs = false;
             try {
-                needToRefresh = true;
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+            results = new Long[records.length];
+            for(int i = 0; i < records.length ; ++i ) {
+                //Assume failure
+                results[i] = FormUploadUtil.FAILURE;
             }
-        }
-        
-        if(needToRefresh) {
-            //There was another activity before this one. Refresh our models in case
-            //they were updated
-            for(int i = 0; i < records.length; ++i ){
-                int dbId = records[i].getID();
-                records[i] = processor.getRecord(dbId);
-            }
-        }
-        
-        
-        //Ok, all forms are now processed. Time to focus on sending
-        if(formSubmissionListener != null) {
-            formSubmissionListener.beginSubmissionProcess(records.length);
-        }
-        
-        for(int i = 0 ; i < records.length ; ++i) {
-            //See whether we are OK to proceed based on the last form. We're now guaranteeing
-            //that forms are sent in order, so we won't proceed unless we succeed. We'll also permit
-            //proceeding if there was a local problem with a record, since we'll just move on from that
-            //processing.
-            if(i > 0 && !(results[i - 1] == FormUploadUtil.FULL_SUCCESS || results[i - 1] == FormUploadUtil.RECORD_FAILURE)) {
-                //Something went wrong with the last form, so we need to cancel this whole shebang
-                Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Cancelling submission due to network errors. " + (i - 1) + " forms succesfully sent.");
-                break;
-            }
-            
-            FormRecord record = records[i];
-            try{
-                //If it's unsent, go ahead and send it
-                if(FormRecord.STATUS_UNSENT.equals(record.getStatus())) {
-                    File folder;
+            //The first thing we need to do is make sure everything is processed,
+            //we can't actually proceed before that.
+            for(int i = 0 ; i < records.length ; ++i) {
+                FormRecord record = records[i];
+
+                //If the form is complete, but unprocessed, process it.
+                if(FormRecord.STATUS_COMPLETE.equals(record.getStatus())) {
                     try {
-                        folder = new File(record.getPath(c)).getCanonicalFile().getParentFile();
-                    } catch (IOException e) {
-                        Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Bizarre. Exception just getting the file reference. Not removing." + getExceptionText(e));
+                        records[i] = processor.process(record);
+                    } catch (InvalidStructureException e) {
+                        CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
+                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to transaction data|" + getExceptionText(e));
+                        FormRecordCleanupTask.wipeRecord(c, record);
+                        needToSendLogs = true;
                         continue;
-                    }
-                    
-                    //Good!
-                    //Time to Send!
-                    try {
-                        User mUser = CommCareApplication._().getSession().getLoggedInUser();
-                        
-                        int attemptsMade = 0;
-                        while(attemptsMade < SUBMISSION_ATTEMPTS) {
-                            if(attemptsMade > 0) { 
-                                Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Retrying submission. " + (SUBMISSION_ATTEMPTS - attemptsMade) + " attempts remain");
-                            }
-                            results[i] = FormUploadUtil.sendInstance(i, folder, new SecretKeySpec(record.getAesKey(), "AES"), url, this, mUser);
-                            if(results[i] == FormUploadUtil.FULL_SUCCESS) {
-                                break;
-                            } else {
-                                attemptsMade++;
-                            }
-                        }
-                        
-                        if(results[i] == FormUploadUtil.RECORD_FAILURE) {
-                            //We tried to submit multiple times and there was a local problem (not a remote problem).
-                            //This implies that something is wrong with the current record, and we need to quarantine it.
-                            processor.updateRecordStatus(record, FormRecord.STATUS_LIMBO);
-                            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Quarantined Form Record");
-                            CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.RecordQuarantined), true);
-                        }
+                    } catch (XmlPullParserException e) {
+                        CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
+                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad xml|" + getExceptionText(e));
+                        FormRecordCleanupTask.wipeRecord(c, record);
+                        needToSendLogs = true;
+                        continue;
+                    } catch (UnfullfilledRequirementsException e) {
+                        CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
+                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad requirements|" + getExceptionText(e));
+                        FormRecordCleanupTask.wipeRecord(c, record);
+                        needToSendLogs = true;
+                        continue;
                     } catch (FileNotFoundException e) {
                         if(CommCareApplication._().isStorageAvailable()) {
                             //If storage is available generally, this is a bug in the app design
                             Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record because file was missing|" + getExceptionText(e));
                             FormRecordCleanupTask.wipeRecord(c, record);
                         } else {
-                            //Otherwise, the SD card just got removed, and we need to bail anyway.
                             CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.StorageRemoved), true);
-                            break;
+                            //Otherwise, the SD card just got removed, and we need to bail anyway.
+                            return (int)PROGRESS_SDCARD_REMOVED;
                         }
                         continue;
+                    }   catch (IOException e) {
+                        Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "IO Issues processing a form. Tentatively not removing in case they are resolvable|" + getExceptionText(e));
+                        continue;
+                    } 
+                }
+            }
+            
+            this.publishProgress(PROGRESS_ALL_PROCESSED);
+            
+            //Put us on the queue!
+            synchronized(processTasks) {
+                processTasks.add(this);
+            }
+            
+            boolean proceed = false;
+            boolean needToRefresh = false;
+            while(!proceed) {
+                //TODO: Terrible?
+                
+                //See if it's our turn to go
+                synchronized(processTasks) {
+                    //Are we at the head of the queue?
+                    ProcessAndSendTask head = processTasks.peek();
+                    if(processTasks.peek() == this) {
+                        proceed = true;
+                        break;
                     }
-                    
-                    Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
-                    //Check for success
-                    if(results[i].intValue() == FormUploadUtil.FULL_SUCCESS) {
-                        //Only delete if this device isn't set up to review.
-                        if(p == null || !p.isFeatureActive(Profile.FEATURE_REVIEW)) {
-                            FormRecordCleanupTask.wipeRecord(c, record);
-                        } else {
-                            //Otherwise save and move appropriately
-                            processor.updateRecordStatus(record, FormRecord.STATUS_SAVED);
-                        }
+                    //Otherwise, is the head of the queue busted?
+                    //*sigh*. Apparently Cancelled doesn't result in the task status being set
+                    //to !Running for reasons which baffle me.
+                    if(head.getStatus() != AsyncTask.Status.RUNNING || head.isCancelled()) {
+                        //If so, get rid of it
+                        processTasks.remove(head);
                     }
-                } else {
-                    results[i] = FormUploadUtil.FULL_SUCCESS;
+                }
+                //If it's not yet quite our turn, take a nap
+                try {
+                    needToRefresh = true;
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }
+            
+            if(needToRefresh) {
+                //There was another activity before this one. Refresh our models in case
+                //they were updated
+                for(int i = 0; i < records.length; ++i ){
+                    int dbId = records[i].getID();
+                    records[i] = processor.getRecord(dbId);
+                }
+            }
+            
+            
+            //Ok, all forms are now processed. Time to focus on sending
+            if(formSubmissionListener != null) {
+                formSubmissionListener.beginSubmissionProcess(records.length);
+            }
+            
+            for(int i = 0 ; i < records.length ; ++i) {
+                //See whether we are OK to proceed based on the last form. We're now guaranteeing
+                //that forms are sent in order, so we won't proceed unless we succeed. We'll also permit
+                //proceeding if there was a local problem with a record, since we'll just move on from that
+                //processing.
+                if(i > 0 && !(results[i - 1] == FormUploadUtil.FULL_SUCCESS || results[i - 1] == FormUploadUtil.RECORD_FAILURE)) {
+                    //Something went wrong with the last form, so we need to cancel this whole shebang
+                    Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Cancelling submission due to network errors. " + (i - 1) + " forms succesfully sent.");
+                    break;
                 }
                 
-                
-            } catch (StorageFullException e) {
-                Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Really? Storage full?" + getExceptionText(e));
-                throw new RuntimeException(e);
+                FormRecord record = records[i];
+                try{
+                    //If it's unsent, go ahead and send it
+                    if(FormRecord.STATUS_UNSENT.equals(record.getStatus())) {
+                        File folder;
+                        try {
+                            folder = new File(record.getPath(c)).getCanonicalFile().getParentFile();
+                        } catch (IOException e) {
+                            Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Bizarre. Exception just getting the file reference. Not removing." + getExceptionText(e));
+                            continue;
+                        }
+                        
+                        //Good!
+                        //Time to Send!
+                        try {
+                            User mUser = CommCareApplication._().getSession().getLoggedInUser();
+                            
+                            int attemptsMade = 0;
+                            while(attemptsMade < SUBMISSION_ATTEMPTS) {
+                                if(attemptsMade > 0) { 
+                                    Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Retrying submission. " + (SUBMISSION_ATTEMPTS - attemptsMade) + " attempts remain");
+                                }
+                                results[i] = FormUploadUtil.sendInstance(i, folder, new SecretKeySpec(record.getAesKey(), "AES"), url, this, mUser);
+                                if(results[i] == FormUploadUtil.FULL_SUCCESS) {
+                                    break;
+                                } else {
+                                    attemptsMade++;
+                                }
+                            }
+                            
+                            if(results[i] == FormUploadUtil.RECORD_FAILURE) {
+                                //We tried to submit multiple times and there was a local problem (not a remote problem).
+                                //This implies that something is wrong with the current record, and we need to quarantine it.
+                                processor.updateRecordStatus(record, FormRecord.STATUS_LIMBO);
+                                Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Quarantined Form Record");
+                                CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.RecordQuarantined), true);
+                            }
+                        } catch (FileNotFoundException e) {
+                            if(CommCareApplication._().isStorageAvailable()) {
+                                //If storage is available generally, this is a bug in the app design
+                                Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record because file was missing|" + getExceptionText(e));
+                                FormRecordCleanupTask.wipeRecord(c, record);
+                            } else {
+                                //Otherwise, the SD card just got removed, and we need to bail anyway.
+                                CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.StorageRemoved), true);
+                                break;
+                            }
+                            continue;
+                        }
+                        
+                        Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
+                        //Check for success
+                        if(results[i].intValue() == FormUploadUtil.FULL_SUCCESS) {
+                            //Only delete if this device isn't set up to review.
+                            if(p == null || !p.isFeatureActive(Profile.FEATURE_REVIEW)) {
+                                FormRecordCleanupTask.wipeRecord(c, record);
+                            } else {
+                                //Otherwise save and move appropriately
+                                processor.updateRecordStatus(record, FormRecord.STATUS_SAVED);
+                            }
+                        }
+                    } else {
+                        results[i] = FormUploadUtil.FULL_SUCCESS;
+                    }
+                    
+                    
+                } catch (StorageFullException e) {
+                    Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Really? Storage full?" + getExceptionText(e));
+                    throw new RuntimeException(e);
+                } catch(SessionUnavailableException sue) {
+                    throw sue;
+                } catch (Exception e) {
+                    //Just try to skip for now. Hopefully this doesn't wreck the model :/
+                    Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Totally Unexpected Error during form submission" + getExceptionText(e));
+                    continue;
+                }  
+            }
+            
+            long result = 0;
+            for(int i = 0 ; i < records.length ; ++ i) {
+                if(results[i] > result) {
+                    result = results[i];
+                }
+            }
+                    
+            return (int)result;
             } catch(SessionUnavailableException sue) {
-                throw sue;
-            } catch (Exception e) {
-                //Just try to skip for now. Hopefully this doesn't wreck the model :/
-                Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Totally Unexpected Error during form submission" + getExceptionText(e));
-                continue;
-            }  
-        }
-        
-        long result = 0;
-        for(int i = 0 ; i < records.length ; ++ i) {
-            if(results[i] > result) {
-                result = results[i];
-            }
-        }
-                
-        return (int)result;
-        } catch(SessionUnavailableException sue) {
-            this.cancel(false);
-            return (int)PROGRESS_LOGGED_OUT;
-        } finally {
-            this.endSubmissionProcess();
+                this.cancel(false);
+                return (int)PROGRESS_LOGGED_OUT;
+            } finally {
+                this.endSubmissionProcess();
 
-            synchronized(processTasks) {
-                processTasks.remove(this);
-            }
-            if(needToSendLogs) {
-                CommCareApplication._().notifyLogsPending();
+                synchronized(processTasks) {
+                    processTasks.remove(this);
+                }
+                if(needToSendLogs) {
+                    CommCareApplication._().notifyLogsPending();
+                }
             }
         }
     }

--- a/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
@@ -113,219 +113,219 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
      */
     protected Integer doTaskBackground(FormRecord... records) {
         // Don't allow session to expire while we are syncing
-        synchronized(CommCareSessionService.LOGOUT_LOCK) {
+        synchronized (CommCareSessionService.LOGOUT_LOCK) {
             boolean needToSendLogs = false;
             try {
-            results = new Long[records.length];
-            for(int i = 0; i < records.length ; ++i ) {
-                //Assume failure
-                results[i] = FormUploadUtil.FAILURE;
-            }
-            //The first thing we need to do is make sure everything is processed,
-            //we can't actually proceed before that.
-            for(int i = 0 ; i < records.length ; ++i) {
-                FormRecord record = records[i];
+                results = new Long[records.length];
+                for (int i = 0; i < records.length; ++i) {
+                    //Assume failure
+                    results[i] = FormUploadUtil.FAILURE;
+                }
+                //The first thing we need to do is make sure everything is processed,
+                //we can't actually proceed before that.
+                for (int i = 0; i < records.length; ++i) {
+                    FormRecord record = records[i];
 
-                //If the form is complete, but unprocessed, process it.
-                if(FormRecord.STATUS_COMPLETE.equals(record.getStatus())) {
-                    try {
-                        records[i] = processor.process(record);
-                    } catch (InvalidStructureException e) {
-                        CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
-                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to transaction data|" + getExceptionText(e));
-                        FormRecordCleanupTask.wipeRecord(c, record);
-                        needToSendLogs = true;
-                        continue;
-                    } catch (XmlPullParserException e) {
-                        CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
-                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad xml|" + getExceptionText(e));
-                        FormRecordCleanupTask.wipeRecord(c, record);
-                        needToSendLogs = true;
-                        continue;
-                    } catch (UnfullfilledRequirementsException e) {
-                        CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
-                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad requirements|" + getExceptionText(e));
-                        FormRecordCleanupTask.wipeRecord(c, record);
-                        needToSendLogs = true;
-                        continue;
-                    } catch (FileNotFoundException e) {
-                        if(CommCareApplication._().isStorageAvailable()) {
-                            //If storage is available generally, this is a bug in the app design
-                            Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record because file was missing|" + getExceptionText(e));
+                    //If the form is complete, but unprocessed, process it.
+                    if (FormRecord.STATUS_COMPLETE.equals(record.getStatus())) {
+                        try {
+                            records[i] = processor.process(record);
+                        } catch (InvalidStructureException e) {
+                            CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
+                            Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to transaction data|" + getExceptionText(e));
                             FormRecordCleanupTask.wipeRecord(c, record);
-                        } else {
-                            CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.StorageRemoved), true);
-                            //Otherwise, the SD card just got removed, and we need to bail anyway.
-                            return (int)PROGRESS_SDCARD_REMOVED;
-                        }
-                        continue;
-                    }   catch (IOException e) {
-                        Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "IO Issues processing a form. Tentatively not removing in case they are resolvable|" + getExceptionText(e));
-                        continue;
-                    } 
-                }
-            }
-            
-            this.publishProgress(PROGRESS_ALL_PROCESSED);
-            
-            //Put us on the queue!
-            synchronized(processTasks) {
-                processTasks.add(this);
-            }
-            
-            boolean proceed = false;
-            boolean needToRefresh = false;
-            while(!proceed) {
-                //TODO: Terrible?
-                
-                //See if it's our turn to go
-                synchronized(processTasks) {
-                    //Are we at the head of the queue?
-                    ProcessAndSendTask head = processTasks.peek();
-                    if(processTasks.peek() == this) {
-                        proceed = true;
-                        break;
-                    }
-                    //Otherwise, is the head of the queue busted?
-                    //*sigh*. Apparently Cancelled doesn't result in the task status being set
-                    //to !Running for reasons which baffle me.
-                    if(head.getStatus() != AsyncTask.Status.RUNNING || head.isCancelled()) {
-                        //If so, get rid of it
-                        processTasks.remove(head);
-                    }
-                }
-                //If it's not yet quite our turn, take a nap
-                try {
-                    needToRefresh = true;
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
-            }
-            
-            if(needToRefresh) {
-                //There was another activity before this one. Refresh our models in case
-                //they were updated
-                for(int i = 0; i < records.length; ++i ){
-                    int dbId = records[i].getID();
-                    records[i] = processor.getRecord(dbId);
-                }
-            }
-            
-            
-            //Ok, all forms are now processed. Time to focus on sending
-            if(formSubmissionListener != null) {
-                formSubmissionListener.beginSubmissionProcess(records.length);
-            }
-            
-            for(int i = 0 ; i < records.length ; ++i) {
-                //See whether we are OK to proceed based on the last form. We're now guaranteeing
-                //that forms are sent in order, so we won't proceed unless we succeed. We'll also permit
-                //proceeding if there was a local problem with a record, since we'll just move on from that
-                //processing.
-                if(i > 0 && !(results[i - 1] == FormUploadUtil.FULL_SUCCESS || results[i - 1] == FormUploadUtil.RECORD_FAILURE)) {
-                    //Something went wrong with the last form, so we need to cancel this whole shebang
-                    Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Cancelling submission due to network errors. " + (i - 1) + " forms succesfully sent.");
-                    break;
-                }
-                
-                FormRecord record = records[i];
-                try{
-                    //If it's unsent, go ahead and send it
-                    if(FormRecord.STATUS_UNSENT.equals(record.getStatus())) {
-                        File folder;
-                        try {
-                            folder = new File(record.getPath(c)).getCanonicalFile().getParentFile();
-                        } catch (IOException e) {
-                            Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Bizarre. Exception just getting the file reference. Not removing." + getExceptionText(e));
+                            needToSendLogs = true;
                             continue;
-                        }
-                        
-                        //Good!
-                        //Time to Send!
-                        try {
-                            User mUser = CommCareApplication._().getSession().getLoggedInUser();
-                            
-                            int attemptsMade = 0;
-                            while(attemptsMade < SUBMISSION_ATTEMPTS) {
-                                if(attemptsMade > 0) { 
-                                    Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Retrying submission. " + (SUBMISSION_ATTEMPTS - attemptsMade) + " attempts remain");
-                                }
-                                results[i] = FormUploadUtil.sendInstance(i, folder, new SecretKeySpec(record.getAesKey(), "AES"), url, this, mUser);
-                                if(results[i] == FormUploadUtil.FULL_SUCCESS) {
-                                    break;
-                                } else {
-                                    attemptsMade++;
-                                }
-                            }
-                            
-                            if(results[i] == FormUploadUtil.RECORD_FAILURE) {
-                                //We tried to submit multiple times and there was a local problem (not a remote problem).
-                                //This implies that something is wrong with the current record, and we need to quarantine it.
-                                processor.updateRecordStatus(record, FormRecord.STATUS_LIMBO);
-                                Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Quarantined Form Record");
-                                CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.RecordQuarantined), true);
-                            }
+                        } catch (XmlPullParserException e) {
+                            CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
+                            Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad xml|" + getExceptionText(e));
+                            FormRecordCleanupTask.wipeRecord(c, record);
+                            needToSendLogs = true;
+                            continue;
+                        } catch (UnfullfilledRequirementsException e) {
+                            CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.BadTransactions), true);
+                            Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record due to bad requirements|" + getExceptionText(e));
+                            FormRecordCleanupTask.wipeRecord(c, record);
+                            needToSendLogs = true;
+                            continue;
                         } catch (FileNotFoundException e) {
-                            if(CommCareApplication._().isStorageAvailable()) {
+                            if (CommCareApplication._().isStorageAvailable()) {
                                 //If storage is available generally, this is a bug in the app design
                                 Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record because file was missing|" + getExceptionText(e));
                                 FormRecordCleanupTask.wipeRecord(c, record);
                             } else {
-                                //Otherwise, the SD card just got removed, and we need to bail anyway.
                                 CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.StorageRemoved), true);
-                                break;
+                                //Otherwise, the SD card just got removed, and we need to bail anyway.
+                                return (int)PROGRESS_SDCARD_REMOVED;
                             }
                             continue;
+                        } catch (IOException e) {
+                            Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "IO Issues processing a form. Tentatively not removing in case they are resolvable|" + getExceptionText(e));
+                            continue;
                         }
-                        
-                        Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
-                        //Check for success
-                        if(results[i].intValue() == FormUploadUtil.FULL_SUCCESS) {
-                            //Only delete if this device isn't set up to review.
-                            if(p == null || !p.isFeatureActive(Profile.FEATURE_REVIEW)) {
-                                FormRecordCleanupTask.wipeRecord(c, record);
-                            } else {
-                                //Otherwise save and move appropriately
-                                processor.updateRecordStatus(record, FormRecord.STATUS_SAVED);
-                            }
-                        }
-                    } else {
-                        results[i] = FormUploadUtil.FULL_SUCCESS;
                     }
-                    
-                    
-                } catch (StorageFullException e) {
-                    Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Really? Storage full?" + getExceptionText(e));
-                    throw new RuntimeException(e);
-                } catch(SessionUnavailableException sue) {
-                    throw sue;
-                } catch (Exception e) {
-                    //Just try to skip for now. Hopefully this doesn't wreck the model :/
-                    Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Totally Unexpected Error during form submission" + getExceptionText(e));
-                    continue;
-                }  
-            }
-            
-            long result = 0;
-            for(int i = 0 ; i < records.length ; ++ i) {
-                if(results[i] > result) {
-                    result = results[i];
                 }
-            }
-                    
-            return (int)result;
-            } catch(SessionUnavailableException sue) {
+
+                this.publishProgress(PROGRESS_ALL_PROCESSED);
+
+                //Put us on the queue!
+                synchronized (processTasks) {
+                    processTasks.add(this);
+                }
+
+                boolean proceed = false;
+                boolean needToRefresh = false;
+                while (!proceed) {
+                    //TODO: Terrible?
+
+                    //See if it's our turn to go
+                    synchronized (processTasks) {
+                        //Are we at the head of the queue?
+                        ProcessAndSendTask head = processTasks.peek();
+                        if (processTasks.peek() == this) {
+                            proceed = true;
+                            break;
+                        }
+                        //Otherwise, is the head of the queue busted?
+                        //*sigh*. Apparently Cancelled doesn't result in the task status being set
+                        //to !Running for reasons which baffle me.
+                        if (head.getStatus() != AsyncTask.Status.RUNNING || head.isCancelled()) {
+                            //If so, get rid of it
+                            processTasks.remove(head);
+                        }
+                    }
+                    //If it's not yet quite our turn, take a nap
+                    try {
+                        needToRefresh = true;
+                        Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                        // TODO Auto-generated catch block
+                        e.printStackTrace();
+                    }
+                }
+
+                if (needToRefresh) {
+                    //There was another activity before this one. Refresh our models in case
+                    //they were updated
+                    for (int i = 0; i < records.length; ++i) {
+                        int dbId = records[i].getID();
+                        records[i] = processor.getRecord(dbId);
+                    }
+                }
+
+
+                //Ok, all forms are now processed. Time to focus on sending
+                if (formSubmissionListener != null) {
+                    formSubmissionListener.beginSubmissionProcess(records.length);
+                }
+
+                for (int i = 0; i < records.length; ++i) {
+                    //See whether we are OK to proceed based on the last form. We're now guaranteeing
+                    //that forms are sent in order, so we won't proceed unless we succeed. We'll also permit
+                    //proceeding if there was a local problem with a record, since we'll just move on from that
+                    //processing.
+                    if (i > 0 && !(results[i - 1] == FormUploadUtil.FULL_SUCCESS || results[i - 1] == FormUploadUtil.RECORD_FAILURE)) {
+                        //Something went wrong with the last form, so we need to cancel this whole shebang
+                        Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Cancelling submission due to network errors. " + (i - 1) + " forms succesfully sent.");
+                        break;
+                    }
+
+                    FormRecord record = records[i];
+                    try {
+                        //If it's unsent, go ahead and send it
+                        if (FormRecord.STATUS_UNSENT.equals(record.getStatus())) {
+                            File folder;
+                            try {
+                                folder = new File(record.getPath(c)).getCanonicalFile().getParentFile();
+                            } catch (IOException e) {
+                                Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Bizarre. Exception just getting the file reference. Not removing." + getExceptionText(e));
+                                continue;
+                            }
+
+                            //Good!
+                            //Time to Send!
+                            try {
+                                User mUser = CommCareApplication._().getSession().getLoggedInUser();
+
+                                int attemptsMade = 0;
+                                while (attemptsMade < SUBMISSION_ATTEMPTS) {
+                                    if (attemptsMade > 0) {
+                                        Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Retrying submission. " + (SUBMISSION_ATTEMPTS - attemptsMade) + " attempts remain");
+                                    }
+                                    results[i] = FormUploadUtil.sendInstance(i, folder, new SecretKeySpec(record.getAesKey(), "AES"), url, this, mUser);
+                                    if (results[i] == FormUploadUtil.FULL_SUCCESS) {
+                                        break;
+                                    } else {
+                                        attemptsMade++;
+                                    }
+                                }
+
+                                if (results[i] == FormUploadUtil.RECORD_FAILURE) {
+                                    //We tried to submit multiple times and there was a local problem (not a remote problem).
+                                    //This implies that something is wrong with the current record, and we need to quarantine it.
+                                    processor.updateRecordStatus(record, FormRecord.STATUS_LIMBO);
+                                    Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Quarantined Form Record");
+                                    CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.RecordQuarantined), true);
+                                }
+                            } catch (FileNotFoundException e) {
+                                if (CommCareApplication._().isStorageAvailable()) {
+                                    //If storage is available generally, this is a bug in the app design
+                                    Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Removing form record because file was missing|" + getExceptionText(e));
+                                    FormRecordCleanupTask.wipeRecord(c, record);
+                                } else {
+                                    //Otherwise, the SD card just got removed, and we need to bail anyway.
+                                    CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.StorageRemoved), true);
+                                    break;
+                                }
+                                continue;
+                            }
+
+                            Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
+                            //Check for success
+                            if (results[i].intValue() == FormUploadUtil.FULL_SUCCESS) {
+                                //Only delete if this device isn't set up to review.
+                                if (p == null || !p.isFeatureActive(Profile.FEATURE_REVIEW)) {
+                                    FormRecordCleanupTask.wipeRecord(c, record);
+                                } else {
+                                    //Otherwise save and move appropriately
+                                    processor.updateRecordStatus(record, FormRecord.STATUS_SAVED);
+                                }
+                            }
+                        } else {
+                            results[i] = FormUploadUtil.FULL_SUCCESS;
+                        }
+
+
+                    } catch (StorageFullException e) {
+                        Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Really? Storage full?" + getExceptionText(e));
+                        throw new RuntimeException(e);
+                    } catch (SessionUnavailableException sue) {
+                        throw sue;
+                    } catch (Exception e) {
+                        //Just try to skip for now. Hopefully this doesn't wreck the model :/
+                        Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Totally Unexpected Error during form submission" + getExceptionText(e));
+                        continue;
+                    }
+                }
+
+                long result = 0;
+                for (int i = 0; i < records.length; ++i) {
+                    if (results[i] > result) {
+                        result = results[i];
+                    }
+                }
+
+                return (int)result;
+            } catch (SessionUnavailableException sue) {
                 this.cancel(false);
                 return (int)PROGRESS_LOGGED_OUT;
             } finally {
                 this.endSubmissionProcess();
 
-                synchronized(processTasks) {
+                synchronized (processTasks) {
                     processTasks.remove(this);
                 }
-                if(needToSendLogs) {
+                if (needToSendLogs) {
                     CommCareApplication._().notifyLogsPending();
                 }
             }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -377,8 +377,8 @@ public class CommCareSessionService extends Service  {
      *                       upon closing this session?
      */
     public void closeSession(boolean sessionExpired) {
-        synchronized(lock){
-            synchronized(CommCareSessionService.LOGOUT_LOCK) {
+        synchronized (lock) {
+            synchronized (CommCareSessionService.LOGOUT_LOCK) {
                 if (!isActive()) {
                     // Since both the FormSaveCallback callback and the maintenance
                     // timer might call this, only run if it hasn't been called


### PR DESCRIPTION
Wrap ProcessAndSendTask worker in session logout lock so that when it is running the session will block on closing.

This PR only half-solves the solution: I didn't wrap DataPullTask in the same lock because it is mixed up with login code and calls closeSession, which would cause a deadlock (I think).

Good enough for now...

I've commented the new lines, since re-indentation created a huge (mostly meaningless) diff