### PR TITLE
Make session only expire if syncing isn't occurring

### DIFF
--- a/app/src/org/commcare/android/tasks/DataPullTask.java
+++ b/app/src/org/commcare/android/tasks/DataPullTask.java
@@ -39,6 +39,7 @@ import org.commcare.cases.util.CasePurgeFilter;
 import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.odk.provider.FormsProviderAPI.FormsColumns;
+import org.commcare.dalvik.services.CommCareSessionService;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.resources.model.CommCareOTARestoreListener;
 import org.commcare.xml.CommCareTransactionParserFactory;
@@ -147,6 +148,18 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
      */
     @Override
     protected Integer doTaskBackground(Void... params) {
+        // Don't try to sync if logging out is occuring
+        if (!CommCareSessionService.logout_lock.tryLock()) {
+            // TODO PLM: once this task is refactored into manageable
+            // components, it should use the ManagedAsyncTask pattern of
+            // checking for isCancelled() and aborting at safe places.
+            return UNKNOWN_FAILURE;
+        }
+
+
+        // Wrap in a 'try' to enable a 'finally' close that releases the
+        // logout_lock.
+        try {
         publishProgress(PROGRESS_STARTED);
         CommCareApp app = CommCareApplication._().getCurrentApp();
         SharedPreferences prefs = app.getAppPreferences();
@@ -405,7 +418,9 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
             }
             this.publishProgress(PROGRESS_DONE);
             return responseError;
-            
+        } finally {
+            CommCareSessionService.logout_lock.unlock();
+        }
     }
     
     /**
@@ -447,7 +462,7 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
                     
                     //We always wanna notify when we get our first bytes
                     if(lastOutput == 0) {
-                        Log.i("commcare-network", "First"  + bytesRead + " bytes recieved from network: ");
+                        Log.i("commcare-network", "First"  + bytesRead + " bytes received from network: ");
                         notify = true;
                     }
                     //After, if we don't know how much data to expect, we can't do

--- a/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
@@ -21,6 +21,7 @@ import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.activities.LoginActivity;
 import org.commcare.dalvik.application.CommCareApplication;
+import org.commcare.dalvik.services.CommCareSessionService;
 import org.commcare.suite.model.Profile;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -112,6 +113,15 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
      */
     protected Integer doTaskBackground(FormRecord... records) {
         boolean needToSendLogs = false;
+
+        // Don't try to sync if logging out is occuring
+        if (!CommCareSessionService.logout_lock.tryLock()) {
+            // TODO PLM: once this task is refactored into manageable
+            // components, it should use the ManagedAsyncTask pattern of
+            // checking for isCancelled() and aborting at safe places.
+            return (int)PROGRESS_LOGGED_OUT;
+        }
+
         try {
         results = new Long[records.length];
         for(int i = 0; i < records.length ; ++i ) {
@@ -322,9 +332,11 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
             synchronized(processTasks) {
                 processTasks.remove(this);
             }
+
             if(needToSendLogs) {
                 CommCareApplication._().notifyLogsPending();
             }
+            CommCareSessionService.logout_lock.unlock();
         }
     }
     

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -33,6 +33,7 @@ import org.javarosa.core.services.Logger;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -52,26 +53,34 @@ import javax.crypto.spec.SecretKeySpec;
 public class CommCareSessionService extends Service  {
 
     private NotificationManager mNM;
-    
+
+    /**
+     * Milliseconds to wait before rechecking if the session is still fresh.
+     */
     private static final long MAINTENANCE_PERIOD = 1000;
-    // session length in MS
+
+    /**
+     * Session length in MS
+     */
     private static long sessionLength = 1000 * 60 * 60 * 24;
-    
+
+    public static final ReentrantLock logout_lock = new ReentrantLock();
+
     private Timer maintenanceTimer;
     private CipherPool pool;
 
     private byte[] key = null;
-    
+
     private boolean multimediaIsVerified=false;
-    
+
     private Date sessionExpireDate;
-    
+
     private final Object lock = new Object();
-    
+
     private User user;
-    
-    private SQLiteDatabase userDatabase; 
-    
+
+    private SQLiteDatabase userDatabase;
+
     // Unique Identification Number for the Notification.
     // We use it on Notification start, and to cancel it.
     private final int NOTIFICATION = org.commcare.dalvik.R.string.notificationtitle;
@@ -289,34 +298,58 @@ public class CommCareSessionService extends Service  {
                  */
                 @Override
                 public void run() {
-                    maintenance();
+                    timeToExpireSession();
                 }
                 
             }, MAINTENANCE_PERIOD, MAINTENANCE_PERIOD);
         }
     }
-    
-    private void maintenance() {
-        long time = new Date().getTime();
+
+    /**
+     * If the session has been alive for longer than its specified duration
+     * then save any open forms and close it down. If data syncing is in
+     * progess then don't do anything.
+     */
+    private void timeToExpireSession() {
+
+        long currentTime = new Date().getTime();
+
         // If logout process started and has taken longer than the logout
         // timeout then wrap-up the process. This is especially necessary since
         // if the FormEntryActivity  isn't active then it will never launch
         // closeSession upon receiving the KEY_SESSION_ENDING broadcast
         if (logoutStartedAt != -1 &&
-                time > (logoutStartedAt + LOGOUT_TIMEOUT)) {
-            closeSession(true);
-        }
+                currentTime > (logoutStartedAt + LOGOUT_TIMEOUT)) {
+            // Try and grab the logout lock, aborting if synchronization is in
+            // progress.
+            if (!CommCareSessionService.logout_lock.tryLock()) {
+                return;
+            }
+            try {
+                closeSession(true);
+            } finally {
+                CommCareSessionService.logout_lock.unlock();
+            }
+        } else if (isActive() && logoutStartedAt == -1 &&
+                (currentTime > sessionExpireDate.getTime() ||
+                 (sessionExpireDate.getTime() - currentTime  > sessionLength))) {
+            // If we haven't started closing the session and we're either past
+            // the session expire time, or the session expires more than its
+            // period in the future, we need to log the user out. The second
+            // case occurs if the system's clock is altered.
 
-        // If we haven't started closing the session and we're either past the
-        // session expire time, or the session expires more than its period in
-        // the future, we need to log the user out. The second case occurs if
-        // the system's clock is altered.
-        if (isActive() &&
-                logoutStartedAt == -1 &&
-                (time > sessionExpireDate.getTime() || 
-                 (sessionExpireDate.getTime() - time  > sessionLength))) {
-            logoutStartedAt = new Date().getTime();
-            saveFormAndCloseSession();
+            // Try and grab the logout lock, aborting if synchronization is in
+            // progress.
+            if (!CommCareSessionService.logout_lock.tryLock()) {
+                return;
+            }
+
+            try {
+                logoutStartedAt = new Date().getTime();
+                saveFormAndCloseSession();
+            } finally {
+                CommCareSessionService.logout_lock.unlock();
+            }
 
             showLoggedOutNotification();
         }


### PR DESCRIPTION
Make ProcessAndSendTask and DataPullTask background tasks acquire a session logout lock so that the session can't close down when they are running.

Eventually when the task finishes then the session will be able to grab the lock and close down.