### PR TITLE
Check array size before removing questions and dividers

### DIFF
--- a/app/src/org/odk/collect/android/views/ODKView.java
+++ b/app/src/org/odk/collect/android/views/ODKView.java
@@ -197,11 +197,17 @@ public class ODKView extends ScrollView implements OnLongClickListener, WidgetCh
     }
     
     public void removeQuestionFromIndex(int i){
-        mView.removeView((View) widgets.get(i));
         int dividerIndex = Math.max(i - 1, 0);
-        mView.removeView(dividers.get(dividerIndex));
-        widgets.remove(i);
-        dividers.remove(dividerIndex);
+
+        if (dividerIndex < dividers.size()) {
+            mView.removeView(dividers.get(dividerIndex));
+            dividers.remove(dividerIndex);
+        }
+
+        if (i < widgets.size()) {
+            mView.removeView((View) widgets.get(i));
+            widgets.remove(i);
+        }
     }
     
     public void removeQuestionsFromIndex(ArrayList<Integer> indexes){


### PR DESCRIPTION
QA is experiencing a strange crash when session expiration tries to save a form that has questions that violate constraints.

I was unable to reproduce the bug, but worked off of the stack trace, found at http://manage.dimagi.com/default.asp?168163#945195