### PR TITLE
Remove TransactionParser's name & namespace fields

### DIFF
--- a/app/src/org/commcare/android/models/logic/FormRecordProcessor.java
+++ b/app/src/org/commcare/android/models/logic/FormRecordProcessor.java
@@ -69,17 +69,16 @@ public class FormRecordProcessor {
     public FormRecord process(FormRecord record) throws InvalidStructureException, IOException, XmlPullParserException, UnfullfilledRequirementsException, StorageFullException {
         String form = record.getPath(c);
         
-        DataModelPullParser parser;
         final File f = new File(form);
 
         final Cipher decrypter = FormUploadUtil.getDecryptCipher((new SecretKeySpec(record.getAesKey(), "AES")));
         InputStream is = new CipherInputStream(new FileInputStream(f), decrypter);
-        parser = new DataModelPullParser(is, new TransactionParserFactory() {
-            
-            public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
-                if(LedgerXmlParsers.STOCK_XML_NAMESPACE.equals(namespace)) {
+
+        DataModelPullParser parser = new DataModelPullParser(is, new TransactionParserFactory() {
+            public TransactionParser getParser(KXmlParser parser) {
+                if (LedgerXmlParsers.STOCK_XML_NAMESPACE.equals(parser.getNamespace())) {
                     return new LedgerXmlParsers(parser, CommCareApplication._().getUserStorage(Ledger.STORAGE_KEY, Ledger.class));
-                }else if(name.toLowerCase().equals("case")) {
+                } else if("case".equalsIgnoreCase(parser.getName())) {
                     return new AndroidCaseXmlParser(parser, CommCareApplication._().getUserStorage(ACase.STORAGE_KEY, ACase.class), decrypter, null, f.getParentFile());
                 } 
                 return null;

--- a/app/src/org/commcare/android/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/android/tasks/ManageKeyRecordTask.java
@@ -268,10 +268,11 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
 
             /*
              * (non-Javadoc)
-             * @see org.commcare.data.xml.TransactionParserFactory#getParser(java.lang.String, java.lang.String, org.kxml2.io.KXmlParser)
+             * @see org.commcare.data.xml.TransactionParserFactory#getParser(org.kxml2.io.KXmlParser)
              */
             @Override
-            public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
+            public TransactionParser getParser(KXmlParser parser) {
+                String name = parser.getName();
                 if("auth_keys".equals(name)) {
                     return new KeyRecordParser(parser, username, password, keyRecords) {
 

--- a/app/src/org/commcare/xml/CommCareTransactionParserFactory.java
+++ b/app/src/org/commcare/xml/CommCareTransactionParserFactory.java
@@ -103,7 +103,7 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
             //server message;
             //" <message nature=""/>"
         } else if(name != null && name.toLowerCase().equals("sync") && namespace != null && "http://commcarehq.org/sync".equals(namespace)) {
-            return new TransactionParser<String>(parser, namespace, namespace) {
+            return new TransactionParser<String>(parser) {
                 /*
                  * (non-Javadoc)
                  * @see org.commcare.data.xml.TransactionParser#commit(java.lang.Object)

--- a/app/src/org/commcare/xml/CommCareTransactionParserFactory.java
+++ b/app/src/org/commcare/xml/CommCareTransactionParserFactory.java
@@ -21,9 +21,22 @@ import org.xmlpull.v1.XmlPullParserException;
 import android.content.Context;
 
 /**
- * @author ctsims
+ * The CommCare Transaction Parser Factory wraps all of the current
+ * transactions that CommCare knows about, and provides the appropriate hooks
+ * for parsing through XML and dispatching the right handler for each
+ * transaction.
  *
+ * It should be the central point of processing for transactions (eliminating
+ * the use of the old datamodel based processors) and should be used in any
+ * situation where a transaction is expected to be present.
+ *
+ * It is expected to behave more or less as a black box, in that it directly
+ * creates/modifies the data models on the system, rather than producing them
+ * for another layer or processing.
+ *
+ * @author ctsims
  */
+
 public class CommCareTransactionParserFactory implements TransactionParserFactory {
 
     private Context context;
@@ -44,8 +57,9 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
         this.generator = generator;
         fixtureParser = new TransactionParserFactory() {
             FixtureXmlParser created = null;
-            
-            public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
+
+            @Override
+            public TransactionParser getParser(KXmlParser parser) {
                 if(created == null) {
                     created = new FixtureXmlParser(parser) {
                         //TODO: store these on the file system instead of in DB?
@@ -72,37 +86,39 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
     
     
     /* (non-Javadoc)
-     * @see org.commcare.data.xml.TransactionParserFactory#getParser(java.lang.String, java.lang.String, org.kxml2.io.KXmlParser)
+     * @see org.commcare.data.xml.TransactionParserFactory#getParser(org.kxml2.io.KXmlParser)
      */
-    public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
-        if(namespace != null && formInstanceNamespaces != null && formInstanceNamespaces.containsKey(namespace)) {
+    public TransactionParser getParser(KXmlParser parser) {
+        String name = parser.getName();
+        String namespace = parser.getNamespace();
+        if (namespace != null && formInstanceNamespaces != null && formInstanceNamespaces.containsKey(namespace)) {
             req();
-            return formInstanceParser.getParser(name, namespace, parser);
+            return formInstanceParser.getParser(parser);
         } else if(LedgerXmlParsers.STOCK_XML_NAMESPACE.matches(namespace)) {
             if(stockParser == null) {
                 throw new RuntimeException("Couldn't process Stock transaction without initialization!");
             }
             req();
-            return stockParser.getParser(name, namespace, parser);
-        } else if(name != null && name.toLowerCase().equals("case")) {
+            return stockParser.getParser(parser);
+        } else if("case".equalsIgnoreCase(name)) {
             if(caseParser == null) {
                 throw new RuntimeException("Couldn't receive Case transaction without initialization!");
             }
             req();
-            return caseParser.getParser(name, namespace, parser);
-        } else if(name != null && name.toLowerCase().equals("registration")) {
+            return caseParser.getParser(parser);
+        } else if ("registration".equalsIgnoreCase(name)) {
             if(userParser == null) {
                 throw new RuntimeException("Couldn't receive User transaction without initialization!");
             }
             req();
-            return userParser.getParser(name, namespace, parser);
-        } else if(name != null && name.toLowerCase().equals("fixture")) {
+            return userParser.getParser(parser);
+        } else if ("fixture".equalsIgnoreCase(name)) {
             req();
-            return fixtureParser.getParser(name, namespace, parser);
-        }else if(name != null && name.toLowerCase().equals("message")) {
+            return fixtureParser.getParser(parser);
+        } else if ("message".equalsIgnoreCase(name)) {
             //server message;
             //" <message nature=""/>"
-        } else if(name != null && name.toLowerCase().equals("sync") && namespace != null && "http://commcarehq.org/sync".equals(namespace)) {
+        } else if("sync".equalsIgnoreCase(name) && "http://commcarehq.org/sync".equals(namespace)) {
             return new TransactionParser<String>(parser) {
                 /*
                  * (non-Javadoc)
@@ -126,7 +142,6 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
                     syncToken = syncToken.trim();
                     return syncToken;
                 }
-                
             };
         }
         return null;
@@ -144,8 +159,9 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
     public void initUserParser(final byte[] wrappedKey) {
         userParser = new TransactionParserFactory() {
             UserXmlParser created = null;
-            
-            public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
+
+            @Override
+            public TransactionParser getParser(KXmlParser parser) {
                 if(created == null) {
                     created = new UserXmlParser(parser, context, wrappedKey);
                 }
@@ -159,8 +175,9 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
         final int[] tallies = new int[3];
         caseParser = new TransactionParserFactory() {
             CaseXmlParser created = null;
-            
-            public TransactionParser<Case> getParser(String name, String namespace, KXmlParser parser) {
+
+            @Override
+            public TransactionParser<Case> getParser(KXmlParser parser) {
                 if(created == null) {
                     created = new AndroidCaseXmlParser(parser, tallies, true, CommCareApplication._().getUserStorage(ACase.STORAGE_KEY, ACase.class), generator);
                 }
@@ -173,7 +190,7 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
     public void initStockParser() {
         stockParser = new TransactionParserFactory() {
             
-            public TransactionParser<Ledger[]> getParser(String name, String namespace, KXmlParser parser) {
+            public TransactionParser<Ledger[]> getParser(KXmlParser parser) {
                 return new LedgerXmlParsers(parser, CommCareApplication._().getUserStorage(Ledger.STORAGE_KEY, Ledger.class));
             }
         };
@@ -183,8 +200,9 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
         this.formInstanceNamespaces = namespaces;
         formInstanceParser = new TransactionParserFactory() {
             FormInstanceXmlParser created = null;
-            
-            public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
+
+            @Override
+            public TransactionParser getParser(KXmlParser parser) {
                 if(created == null) {
                     //TODO: We really don't wanna keep using fsPath eventually
                     created = new FormInstanceXmlParser(parser, context, formInstanceNamespaces, CommCareApplication._().getCurrentApp().fsPath(GlobalConstants.FILE_CC_FORMS));

--- a/app/src/org/commcare/xml/FormInstanceXmlParser.java
+++ b/app/src/org/commcare/xml/FormInstanceXmlParser.java
@@ -53,24 +53,11 @@ public class FormInstanceXmlParser extends TransactionParser<FormRecord> {
     private String destination;
     
     public FormInstanceXmlParser(KXmlParser parser, Context c, Hashtable<String, String> namespaces, String destination) {
-        super(parser, null, null);
+        super(parser);
         this.c = c;
         this.namespaces = namespaces;
         this.destination = destination;
     }
-    
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.data.xml.TransactionParser#parses(java.lang.String, java.lang.String)
-     */
-    @Override
-    public boolean parses(String name, String namespace) {
-        if(namespaces.containsKey(namespace)) {
-            return true;
-        }
-        return false;
-    }
-
 
     public FormRecord parse() throws InvalidStructureException, IOException, XmlPullParserException, SessionUnavailableException {
         String xmlns = parser.getNamespace();

--- a/app/src/org/commcare/xml/KeyRecordParser.java
+++ b/app/src/org/commcare/xml/KeyRecordParser.java
@@ -26,7 +26,7 @@ public abstract class KeyRecordParser extends TransactionParser<ArrayList<UserKe
     ArrayList<UserKeyRecord> keyRecords;
 
     public KeyRecordParser(KXmlParser parser, String username, String currentpwd, ArrayList<UserKeyRecord> keyRecords) {
-        super(parser,"auth_keys", null);
+        super(parser);
         this.username = username;
         this.currentpwd = currentpwd;
         this.keyRecords = new ArrayList<UserKeyRecord>();

--- a/app/src/org/commcare/xml/MetaDataXmlParser.java
+++ b/app/src/org/commcare/xml/MetaDataXmlParser.java
@@ -15,7 +15,7 @@ import org.xmlpull.v1.XmlPullParserException;
 public class MetaDataXmlParser extends TransactionParser<String[]> {
 
     public MetaDataXmlParser(KXmlParser parser) {
-        super(parser, "meta", null);
+        super(parser);
     }
 
     /*

--- a/app/src/org/commcare/xml/UserXmlParser.java
+++ b/app/src/org/commcare/xml/UserXmlParser.java
@@ -24,7 +24,7 @@ public class UserXmlParser extends TransactionParser<User> {
     byte[] wrappedKey;
     
     public UserXmlParser(KXmlParser parser, Context context, byte[] wrappedKey) {
-        super(parser, "registration", null);
+        super(parser);
         this.context = context;
         this.wrappedKey = wrappedKey;
     }


### PR DESCRIPTION
Since TransactionParser and its extensions didn't use the following, remove them:
 -  'parses' method
 - 'name' and 'namespace' fields

Change TransactionParserFactory's getParser to not take in a name or namespace field. These were rarely used, and in the cases that they were, the name/namespace values were obtained from the parser argument, and hence were redundant.

Cross requested with https://github.com/dimagi/commcare/pull/84