### PR TITLE
Correctly register the module id in mockEasiestRoute

### DIFF
--- a/app/src/org/commcare/android/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/android/models/AndroidSessionWrapper.java
@@ -418,7 +418,7 @@ public class AndroidSessionWrapper {
                     }
                     
                     wrapper = new AndroidSessionWrapper(platform);
-                    wrapper.session.setCommand(key);
+                    wrapper.session.setCommand(platform.getModuleNameForEntry(e));
                     wrapper.session.setCommand(e.getCommandId());
                     wrapper.session.setDatum(datum.getDataId(), selectedValue);
                 }


### PR DESCRIPTION
mockEasiestRoute, which is used to create a SessionStateDescriptor for a form instance that is manually being loaded onto the phone from an external source, had the following bug:
instead of creating a descriptor of this nature
"COMMAND_ID m0 COMMAND_ID m0-f0 CASE_ID case_id_new_pregnancy_0 ..."
the module id 'm0' was being replaced by the entry id 'm0-f0'
"COMMAND_ID m0-f0 COMMAND_ID m0-f0 CASE_ID case_id_new_pregnancy_0 ..."

This PR fixes this by calling a method that find the module id for an entry.

Cross requested with https://github.com/dimagi/commcare/pull/88