### PR TITLE
Fix for autosync jumping in before submission

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -1236,7 +1236,14 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 String footer = lastSync == 0 ? "never" : SimpleDateFormat.getDateTimeInstance().format(lastSync);
                 Logger.log(AndroidLogger.TYPE_USER, "autosync triggered. Last Sync|" + footer);
                 refreshView();
-                this.syncData(false);
+                
+                //Send unsent forms first. If the process detects unsent forms
+                //it will sync after the are submitted
+                if(!this.checkAndStartUnsentTask(true)) {
+                    //If there were no unsent forms to be sent, we should immediately
+                    //trigger a sync
+                    this.syncData(false);
+                }
             }
             
             //Normal Home Screen login time! 


### PR DESCRIPTION
When autosyncs were triggered, it was possible for them to occur before submissions were fired off, which could dangerously leave the phone in a bad state.

Fix for
http://manage.dimagi.com/default.asp?170109