### PR TITLE
[Minor] Buffer formdef deserialization for major improvement in load times

### DIFF
--- a/app/src/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/app/src/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.tasks;
 
+import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -319,7 +320,7 @@ public class FormLoaderTask extends AsyncTask<Uri, String, FormLoaderTask.FECWra
             // create new form def
             fd = new FormDef();
             fis = new FileInputStream(formDef);
-            DataInputStream dis = new DataInputStream(fis);
+            DataInputStream dis = new DataInputStream(new BufferedInputStream(fis));
 
             // read serialized formdef into new formdef
             fd.readExternal(dis, ApkUtils.getPrototypeFactory(context));


### PR DESCRIPTION
Formdef deserialziation wasn't buffered before and its run through a complex process, so this makes a massive difference on large forms.