### PR TITLE
Multiple datum navigation

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -882,7 +882,12 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 });
                 return;
             }
-            startFormEntry(CommCareApplication._().getCurrentSessionWrapper());
+            AndroidSessionWrapper asw = CommCareApplication._().getCurrentSessionWrapper();
+            // COMMCARE-167204 by dcluna on 06/10/2015:
+            // only try to start form entry if there is an actual form behind this
+            if(asw.getSession().getForm() != null) {
+                startFormEntry(asw);
+            }
         }
         else if(needed == SessionFrame.STATE_COMMAND_ID) {
              Intent i;


### PR DESCRIPTION
Implementing [Commcare-167204](http://manage.dimagi.com/default.asp?167204), allowing a user to navigate a set of multiple <datum> elements inside a <session> without ending in a form.

Cross: https://github.com/dimagi/commcare/pull/90