### PR TITLE
Incomplete forms loading its elements on every refreshView()

### DIFF
--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -231,6 +231,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
      */
     private void refreshView() {
         disableSearch();
+        adapter.resetRecords();
         listView.setAdapter(adapter);
     }
     


### PR DESCRIPTION
Solving bug [171246](http://manage.dimagi.com/default.asp?171246), in which the incomplete forms screen would not show any elements.