### PR TITLE
Changing managedQuery to CursorLoader

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CallLogActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallLogActivity.java
@@ -8,8 +8,11 @@ import org.commcare.dalvik.application.CommCareApplication;
 import org.javarosa.core.services.storage.Persistable;
 
 import android.app.ListActivity;
+import android.content.CursorLoader;
 import android.content.Intent;
+import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.CallLog.Calls;
 import android.view.View;
@@ -83,7 +86,14 @@ public class CallLogActivity<T extends Persistable> extends ListActivity {
                 adapter = messages;
             } else {
                 if(calls == null) {
-                    calls = new CallRecordAdapter(this, managedQuery(android.provider.CallLog.Calls.CONTENT_URI,null, null, null, Calls.DATE + " DESC"));
+
+                    Cursor callCursor;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                        callCursor = new CursorLoader(this, android.provider.CallLog.Calls.CONTENT_URI, null, null, null, Calls.DATE + " DESC").loadInBackground();
+                    } else {
+                        callCursor = managedQuery(android.provider.CallLog.Calls.CONTENT_URI, null, null, null, Calls.DATE + " DESC");
+                    }
+                    calls = new CallRecordAdapter(this, callCursor);
                 }
                 adapter =calls;
             }

--- a/app/src/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/app/src/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -21,6 +21,7 @@ import org.odk.collect.android.utilities.WebUtils;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.CursorLoader;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -28,6 +29,7 @@ import android.content.SharedPreferences.Editor;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
@@ -275,8 +277,14 @@ public class PreferencesActivity extends PreferenceActivity implements
                     String[] projection = {
                         Images.Media.DATA
                     };
-                    Cursor c = managedQuery(uri, projection, null, null, null);
-                    startManagingCursor(c);
+
+                    Cursor c;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                        c = new CursorLoader(this, uri, projection, null, null, null).loadInBackground();
+                    } else {
+                        c = managedQuery(uri, projection, null, null, null);
+                        startManagingCursor(c);
+                    }
                     int i = c.getColumnIndexOrThrow(Images.Media.DATA);
                     c.moveToFirst();
                     sourceImagePath = c.getString(i);


### PR DESCRIPTION
Solving bug [172119](http://manage.dimagi.com/default.asp?172119), caused by using the deprecated method managedQuery() in APIs greater than Honeycomb.

Now using the recommended CursorLoader class instead.

See also https://github.com/dimagi/commcare-odk/pull/340