### PR TITLE
fix image resizing

### DIFF
--- a/app/src/org/commcare/android/util/CommCareInstanceInitializer.java
+++ b/app/src/org/commcare/android/util/CommCareInstanceInitializer.java
@@ -81,8 +81,7 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
                 return root;
                 
             } catch(IllegalStateException ise){
-                throw new RuntimeException("Could not load fixture for src: " + ref + ". This is possibly due " +
-                        "to the size of the fixture.");
+                throw new RuntimeException("Could not load fixture for src: " + ref);
                 
             }
             

--- a/app/src/org/commcare/android/util/CommCareInstanceInitializer.java
+++ b/app/src/org/commcare/android/util/CommCareInstanceInitializer.java
@@ -81,7 +81,8 @@ public class CommCareInstanceInitializer extends InstanceInitializationFactory {
                 return root;
                 
             } catch(IllegalStateException ise){
-                throw new RuntimeException("Could not load fixture for src: " + ref);
+                throw new RuntimeException("Could not load fixture for src: " + ref + ". This is possibly due " +
+                        "to the size of the fixture.");
                 
             }
             

--- a/app/src/org/odk/collect/android/views/ResizingImageView.java
+++ b/app/src/org/odk/collect/android/views/ResizingImageView.java
@@ -1,11 +1,5 @@
 package org.odk.collect.android.views;
 
-import java.io.File;
-
-import org.commcare.dalvik.R;
-import org.javarosa.core.reference.InvalidReferenceException;
-import org.javarosa.core.reference.ReferenceManager;
-
 import android.annotation.SuppressLint;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
@@ -20,6 +14,12 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.widget.ImageView;
 import android.widget.Toast;
+
+import org.commcare.dalvik.R;
+import org.javarosa.core.reference.InvalidReferenceException;
+import org.javarosa.core.reference.ReferenceManager;
+
+import java.io.File;
 
 /**
  * @author wspride
@@ -104,6 +104,7 @@ public class ResizingImageView extends ImageView {
          */
         @Override
         public boolean onDoubleTap(MotionEvent e) {
+            getSuggestedMinimumHeight();
             setFullScreen();
             return true;
         }
@@ -157,41 +158,22 @@ public class ResizingImageView extends ImageView {
         }
     }
 
-    public Pair<Integer,Integer> getWidthHeight(int widthMeasureSpec, int heightMeasureSpec, Drawable drawable, double scaleFactor){
+    public Pair<Integer,Integer> getWidthHeight(int widthMeasureSpec, int heightMeasureSpec, double scaleFactor){
 
         int wMode = MeasureSpec.getMode(widthMeasureSpec);
         int hMode = MeasureSpec.getMode(heightMeasureSpec);
 
-        // Calculate the most appropriate size for the view. Take into
-        // account minWidth, minHeight, maxWith, maxHeigh and allowed size
-        // for the view, then scale by the scaleFactor
-
         int maxWidth = wMode == MeasureSpec.AT_MOST
                 ? Math.min(MeasureSpec.getSize(widthMeasureSpec), mMaxWidth)
-                        : mMaxWidth;
-                int maxHeight = hMode == MeasureSpec.AT_MOST
-                        ? Math.min(MeasureSpec.getSize(heightMeasureSpec), mMaxHeight)
-                                : mMaxHeight;
+                    : mMaxWidth;
 
-                        float dWidth = dipToPixels(getContext(), drawable.getIntrinsicWidth());
-                        float dHeight = dipToPixels(getContext(), drawable.getIntrinsicHeight());
-                        float ratio = (dWidth) / dHeight;
+        int maxHeight = hMode == MeasureSpec.AT_MOST
+                ? Math.min(MeasureSpec.getSize(heightMeasureSpec), mMaxHeight)
+                    : mMaxHeight;
 
-                        int width = (int) Math.min(Math.max(dWidth, getSuggestedMinimumWidth()), maxWidth);
-                        int height = (int) (width / ratio);
+        Pair<Integer,Integer> mPair = new Pair<Integer,Integer>(new Double(maxWidth * scaleFactor).intValue(), new Double(maxHeight * scaleFactor).intValue());
 
-                        height = Math.min(Math.max(height, getSuggestedMinimumHeight()), maxHeight);
-                        width = (int) (height * ratio);
-
-                        if (width > maxWidth) {
-                            width = maxWidth;
-                            height = (int) (width / ratio);
-                        }
-
-                        Pair<Integer,Integer> mPair = new Pair<Integer,Integer>(new Double(width * scaleFactor).intValue(), new Double(height * scaleFactor).intValue());
-
-
-                        return mPair;
+        return mPair;
     }
 
     /*
@@ -216,7 +198,7 @@ public class ResizingImageView extends ImageView {
 
             Drawable drawable = getDrawable();
             if (drawable != null) {
-                Pair<Integer,Integer> mPair = this.getWidthHeight(widthMeasureSpec, heightMeasureSpec, drawable, 1);
+                Pair<Integer,Integer> mPair = this.getWidthHeight(widthMeasureSpec, heightMeasureSpec, 1);
                 setMeasuredDimension(mPair.first, mPair.second);
             }
         }
@@ -224,7 +206,7 @@ public class ResizingImageView extends ImageView {
 
             Drawable drawable = getDrawable();
             if (drawable != null) {
-                Pair<Integer,Integer> mPair = this.getWidthHeight(widthMeasureSpec, heightMeasureSpec, drawable, .5);
+                Pair<Integer,Integer> mPair = this.getWidthHeight(widthMeasureSpec, heightMeasureSpec, .5);
                 setMeasuredDimension(mPair.first, mPair.second);
             }
         }

--- a/app/src/org/odk/collect/android/views/ResizingImageView.java
+++ b/app/src/org/odk/collect/android/views/ResizingImageView.java
@@ -158,22 +158,18 @@ public class ResizingImageView extends ImageView {
         }
     }
 
-    public Pair<Integer,Integer> getWidthHeight(int widthMeasureSpec, int heightMeasureSpec, double scaleFactor){
+    private Pair<Integer,Integer> getWidthHeight(int widthMeasureSpec, int heightMeasureSpec, double imageScaleFactor){
 
-        int wMode = MeasureSpec.getMode(widthMeasureSpec);
-        int hMode = MeasureSpec.getMode(heightMeasureSpec);
+        int maxWidth = mMaxWidth;
+        int maxHeight = mMaxHeight;
 
-        int maxWidth = wMode == MeasureSpec.AT_MOST
-                ? Math.min(MeasureSpec.getSize(widthMeasureSpec), mMaxWidth)
-                    : mMaxWidth;
-
-        int maxHeight = hMode == MeasureSpec.AT_MOST
-                ? Math.min(MeasureSpec.getSize(heightMeasureSpec), mMaxHeight)
-                    : mMaxHeight;
-
-        Pair<Integer,Integer> mPair = new Pair<Integer,Integer>(new Double(maxWidth * scaleFactor).intValue(), new Double(maxHeight * scaleFactor).intValue());
-
-        return mPair;
+        if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.AT_MOST) {
+            maxWidth = Math.min(MeasureSpec.getSize(widthMeasureSpec), mMaxWidth);
+        }
+        if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.AT_MOST) {
+            maxHeight = Math.min(MeasureSpec.getSize(heightMeasureSpec), mMaxHeight);
+        }
+        return new Pair<Integer,Integer>(new Double(maxWidth * imageScaleFactor).intValue(), new Double(maxHeight * imageScaleFactor).intValue());
     }
 
     /*


### PR DESCRIPTION
Relates to this ticket:

http://manage.dimagi.com/default.asp?171248

Basically our old algorithm would not resize UP a very small image unless the getMinimumHeight() method of the parent view suggested it. This seems to go against the feature definition of full/half/width resizing which suggests that the image will be stretched to take up that amount of the screen.

I think this change does the correct thing (just use the max width/height of the screen for calculation baselines). However, the image resizing is tricky (figuring our how much screen real estate you actually have esp. given nav bar, keyboard, variable widget sizes, etc) so I don't know if there's a completely "correct" way to do this. Happy to hear comment. 