### PR TITLE
Trigger text selectable only when 'appearance' hint is set to 'selectable'

### DIFF
--- a/app/src/org/odk/collect/android/widgets/TriggerWidget.java
+++ b/app/src/org/odk/collect/android/widgets/TriggerWidget.java
@@ -45,10 +45,12 @@ public class TriggerWidget extends QuestionWidget {
     /**
      * @param context    Used to get font settings
      * @param prompt     Contains question data
-     * @param appearance When 'minimal' just show text label, 'selectable' show
-     *                   a selectable text label useful for copy/pasting
-     *                   output, otherwise display interactively, showing a
-     *                   checkbox with text
+     * @param appearance Hint from form builder, when set to:
+     *                   - 'minimal' show text label
+     *                   - 'selectable' show a selectable text label useful for
+     *                     copy/pasting output
+     *                   - otherwise display interactively, showing a checkbox
+     *                     with text
      */
     public TriggerWidget(Context context, FormEntryPrompt prompt,
                          String appearance) {

--- a/app/src/org/odk/collect/android/widgets/TriggerWidget.java
+++ b/app/src/org/odk/collect/android/widgets/TriggerWidget.java
@@ -41,11 +41,29 @@ public class TriggerWidget extends QuestionWidget {
      */
     private static String mOK = "OK";
 
+
+    /**
+     * @param context    Used to get font settings
+     * @param prompt     Contains question data
+     * @param appearance When 'minimal' just show text label, 'selectable' show
+     *                   a selectable text label useful for copy/pasting
+     *                   output, otherwise display interactively, showing a
+     *                   checkbox with text
+     */
     public TriggerWidget(Context context, FormEntryPrompt prompt,
-                         boolean interactive) {
+                         String appearance) {
         super(context, prompt);
 
-        this.mInteractive = interactive;
+        // enable interactive mode if 'appearance' is an unrecognized string
+        mInteractive = !("minimal".equals(appearance) ||
+                "selectable".equals(appearance));
+
+        if ("selectable".equals(appearance)) {
+            if (android.os.Build.VERSION.SDK_INT >= 11) {
+                // Let users to copy form display outputs.
+                mQuestionText.setTextIsSelectable(true);
+            }
+        }
 
         if (mPrompt.getAppearanceHint() != null &&
                 mPrompt.getAppearanceHint().startsWith("floating-")) {
@@ -154,12 +172,5 @@ public class TriggerWidget extends QuestionWidget {
         super.cancelLongPress();
         mTriggerButton.cancelLongPress();
         mStringAnswer.cancelLongPress();
-    }
-
-    @Override
-    protected void addQuestionText(final FormEntryPrompt p) {
-        super.addQuestionText(p);
-        // Let users to copy form display outputs.
-        mQuestionText.setTextIsSelectable(true);
     }
 }

--- a/app/src/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/app/src/org/odk/collect/android/widgets/WidgetFactory.java
@@ -46,7 +46,7 @@ public class WidgetFactory {
      * @param context Android context
      */
     public QuestionWidget createWidgetFromPrompt(FormEntryPrompt fep, Context context) {
-        QuestionWidget questionWidget = null;
+        QuestionWidget questionWidget;
         String appearance = fep.getAppearanceHint();
         switch (fep.getControlType()) {
             case Constants.CONTROL_INPUT:
@@ -166,8 +166,6 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_SELECT_MULTI:
-                appearance = fep.getAppearanceHint();
-
                 if (appearance != null && appearance.contains("compact")) {
                     int numColumns = -1;
                     try {
@@ -192,7 +190,7 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_TRIGGER:
-                questionWidget = new TriggerWidget(context, fep, !"minimal".equals(appearance));
+                questionWidget = new TriggerWidget(context, fep, appearance);
                 break;
             default:
                 questionWidget = new StringWidget(context, fep, false);


### PR DESCRIPTION
In https://github.com/dimagi/commcare-odk/pull/313 I made all text in trigger widgets (output labels in form builder) selectable. Clayton & Amelia then decided that it would be bad to make text selectable since non-tech-savy users might get confused after long-pressing text on accident.

This PR makes trigger widget text only selectable if you set the appearance field (found under the Advanced tab) to 'selectable' in the form builder.