### PR TITLE
Allow uploading of all audio, image, and video filetypes to HQ (newui version)

### DIFF
--- a/app/src/org/commcare/android/net/HttpRequestGenerator.java
+++ b/app/src/org/commcare/android/net/HttpRequestGenerator.java
@@ -62,7 +62,6 @@ public class HttpRequestGenerator {
     /** No Authentication will be possible, there isn't a user account to authenticate this request */
     public static final String AUTH_REQUEST_TYPE_NO_AUTH = "noauth";
     
-    
     private Credentials credentials;
     PasswordAuthentication passwordAuthentication;
     private String username;
@@ -91,10 +90,6 @@ public class HttpRequestGenerator {
         //No authentication possible
     }
 
-    public HttpResponse makeCaseFetchRequest(String baseUri) throws ClientProtocolException, IOException {
-        return makeCaseFetchRequest(baseUri, true);
-    }
-    
     public HttpResponse get(String uri) throws ClientProtocolException, IOException {
         HttpClient client = client();
         
@@ -167,8 +162,6 @@ public class HttpRequestGenerator {
         return execute(client, get);
     }
 
-
-
     private void addHeaders(HttpRequestBase base, String lastToken){
         //base.addHeader("Accept-Language", lang)
         base.addHeader("X-OpenRosa-Version", "1.0");
@@ -232,10 +225,6 @@ public class HttpRequestGenerator {
      * with redirects. We don't want to just accept any redirect, though, since we may be directed
      * away from a secure connection. For now we'll only accept redirects from HTTP -> * servers,
      * or HTTPS -> HTTPS severs on the same domain
-     * 
-     * @param client
-     * @param request
-     * @return
      */
     private HttpResponse execute(HttpClient client, HttpUriRequest request) throws IOException {
         HttpContext context = new BasicHttpContext(); 
@@ -278,8 +267,7 @@ public class HttpRequestGenerator {
      * but this generates an input stream for a URL using the best package for your
      * application
      * 
-     * @param url
-     * @return a Stream to that URL 
+     * @return a Stream to that URL
      */
     public InputStream simpleGet(URL url) throws IOException {
         
@@ -350,11 +338,6 @@ public class HttpRequestGenerator {
         return get.getEntity().getContent();        
     }
     
-
-    /**
-     * @param con
-     * @throws IOException
-     */
     private void setup(HttpURLConnection con) throws IOException {
         con.setConnectTimeout(GlobalConstants.CONNECTION_TIMEOUT);
         con.setReadTimeout(GlobalConstants.CONNECTION_SO_TIMEOUT);

--- a/app/src/org/commcare/android/tasks/SendTask.java
+++ b/app/src/org/commcare/android/tasks/SendTask.java
@@ -31,8 +31,7 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
     Long[] results;
     
     DataSubmissionListener formSubmissionListener;
-    CommCarePlatform platform;
-    
+
     SqlStorage<FormRecord> storage;
     File dumpDirectory;
     
@@ -42,13 +41,12 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
     
      // 5MB less 1KB overhead
     
-    public SendTask(Context c, CommCarePlatform platform, String url, File dumpDirectory) throws SessionUnavailableException{
+    public SendTask(Context c, String url, File dumpDirectory) throws SessionUnavailableException{
         this.c = c;
         this.url = url;
         storage =  CommCareApplication._().getUserStorage(FormRecord.class);
         this.taskId = SendTask.BULK_SEND_ID;
         this.dumpDirectory = dumpDirectory;
-        platform = this.platform;
     }
     
     /* (non-Javadoc)

--- a/app/src/org/commcare/android/util/FormUploadUtil.java
+++ b/app/src/org/commcare/android/util/FormUploadUtil.java
@@ -367,9 +367,10 @@ public class FormUploadUtil {
             String ext = filenameSegments[filenameSegments.length - 1];
             String mimeType = mtm.getMimeTypeFromExtension(ext);
 
-            return (mimeType.startsWith("audio") ||
-                    mimeType.startsWith("image") ||
-                    mimeType.startsWith("video"));
+            return (mimeType != null) &&
+                    (mimeType.startsWith("audio") ||
+                            mimeType.startsWith("image") ||
+                            mimeType.startsWith("video"));
         }
 
         return false;

--- a/app/src/org/commcare/android/util/FormUploadUtil.java
+++ b/app/src/org/commcare/android/util/FormUploadUtil.java
@@ -354,7 +354,7 @@ public class FormUploadUtil {
     }
 
     /**
-     * Use the file extension or contents to determine if it has an audio,
+     * Use the file's extension to determine if it has an audio,
      * video, or image mimetype.
      *
      * @return true if the file has an audio, image, or video mimetype
@@ -362,32 +362,16 @@ public class FormUploadUtil {
     private static boolean isAudioVisualMimeType(File file) {
         MimeTypeMap mtm = MimeTypeMap.getSingleton();
         String[] filenameSegments = file.getName().split("\\.");
-        String mimeType;
         if (filenameSegments.length > 1) {
             // use the file extension to determine the mimetype
             String ext = filenameSegments[filenameSegments.length - 1];
-            mimeType = mtm.getMimeTypeFromExtension(ext);
-        } else {
-            // try to guess the mimetype from the file contents
-            InputStream in = null;
-            try {
-                try {
-                    in = new BufferedInputStream(new FileInputStream(file));
-                    mimeType = URLConnection.guessContentTypeFromStream(in);
-                } catch (FileNotFoundException e) {
-                    return false;
-                } finally {
-                    if (in != null) {
-                        in.close();
-                    }
-                }
-            } catch (IOException e) {
-                return false;
-            }
+            String mimeType = mtm.getMimeTypeFromExtension(ext);
+
+            return (mimeType.startsWith("audio") ||
+                    mimeType.startsWith("image") ||
+                    mimeType.startsWith("video"));
         }
 
-        return (mimeType.startsWith("audio") ||
-                mimeType.startsWith("image") ||
-                mimeType.startsWith("video"));
+        return false;
     }
 }

--- a/app/src/org/commcare/android/util/FormUploadUtil.java
+++ b/app/src/org/commcare/android/util/FormUploadUtil.java
@@ -11,7 +11,6 @@ import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.entity.mime.MultipartEntity;
@@ -31,30 +30,26 @@ import android.os.Environment;
 import android.util.Log;
 
 public class FormUploadUtil {
-    
+    private static final String TAG = FormUploadUtil.class.getSimpleName();
+
     /** Everything worked great! **/
     public static final long FULL_SUCCESS = 0;
-    
+
     /** There was a problem with the server's response **/
     public static final long FAILURE = 2;
-    
+
     /** There was a problem with the transport layer during transit **/
     public static final long TRANSPORT_FAILURE = 4;
-    
+
     /** There is a problem with this record that prevented submission success **/
     public static final long RECORD_FAILURE = 8;
-    
-    public static final long SUBMISSION_BEGIN = 16;
-    public static final long SUBMISSION_START = 32;
-    public static final long SUBMISSION_NOTIFY = 64;
-    public static final long SUBMISSION_DONE = 128;
-    
-    public static final long PROGRESS_LOGGED_OUT = 256;
-    public static final long PROGRESS_SDCARD_REMOVED = 512;
-    
+
     private static long MAX_BYTES = (5 * 1048576)-1024;
-    private static final String[] SUPPORTED_FILE_EXTS = {".xml", ".jpg", "jpeg", ".3gpp", ".3gp", ".3ga", ".3g2", ".mp3", ".wav", ".amr",".mp4", ".3gp2", ".mpg4", ".mpeg4", ".m4v", ".mpg", ".mpeg", ".qcp"};
-        
+    private static final String[] SUPPORTED_FILE_EXTS =
+    {".xml", ".jpg", "jpeg", ".3gpp", ".3gp", ".3ga", ".3g2", ".mp3", ".wav",
+        ".amr",".mp4", ".3gp2", ".mpg4", ".mpeg4", ".m4v", ".mpg", ".mpeg",
+        ".qcp"};
+
     public static Cipher getDecryptCipher(SecretKeySpec key) {
         Cipher cipher;
         try {
@@ -62,57 +57,32 @@ public class FormUploadUtil {
             cipher.init(Cipher.DECRYPT_MODE, key);
             return cipher;
             //TODO: Something smart here;
-        } catch (NoSuchAlgorithmException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (NoSuchPaddingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (InvalidKeyException e) {
-            // TODO Auto-generated catch block
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException e) {
             e.printStackTrace();
         }
         return null;
     }
 
-    
-    public static Cipher getDecryptCipher(byte[] key) {
-        Cipher cipher;
-        try {
-            cipher = Cipher.getInstance("AES");
-            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"));
-            return cipher;
-            //TODO: Something smart here;
-        } catch (NoSuchAlgorithmException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (NoSuchPaddingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (InvalidKeyException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-        return null;
-    }
-    
-    public static long sendInstance(int submissionNumber, File folder, String url, User user) throws FileNotFoundException {
+    public static long sendInstance(int submissionNumber, File folder,
+                                    String url, User user)
+            throws FileNotFoundException {
         return FormUploadUtil.sendInstance(submissionNumber, folder, null, url, null, user);
     }
-    
-    
-    public static long sendInstance(int submissionNumber, File folder, SecretKeySpec key, String url, AsyncTask listener, User user) throws FileNotFoundException {
-        
+
+    public static long sendInstance(int submissionNumber, File folder,
+                                    SecretKeySpec key, String url,
+                                    AsyncTask listener, User user)
+            throws FileNotFoundException {
         boolean hasListener = false;
         DataSubmissionListener myListener = null;
-        
+
         if(listener instanceof DataSubmissionListener){
             hasListener = true;
             myListener = (DataSubmissionListener)listener;
         }
-        
+
         File[] files = folder.listFiles();
-        
+
         if(files == null) {
             //make sure external storage is available to begin with.
             String state = Environment.getExternalStorageState();
@@ -120,128 +90,46 @@ public class FormUploadUtil {
                 //If so, just bail as if the user had logged out.
                 throw new SessionUnavailableException("External Storage Removed");
             } else {
-                throw new FileNotFoundException("No directory found at: " + folder.getAbsoluteFile());
+                throw new FileNotFoundException("No directory found at: " +
+                        folder.getAbsoluteFile());
             }
-        } 
+        }
 
         //If we're listening, figure out how much (roughly) we have to send
-        long bytes = 0;
-        for (int j = 0; j < files.length; j++) {
-            //Make sure we'll be sending it
-            boolean supported = false;
-            for(String ext : SUPPORTED_FILE_EXTS) {
-                if(files[j].getName().endsWith(ext)) {
-                    supported = true;
-                    break;
-                }
-            }
-            if(!supported) { continue;}
-            
-            bytes += files[j].length();
-            System.out.println("Added file: " + files[j].getName() +". Bytes to send: " + bytes);
-        }
-        
+        long bytes = estimateUploadBytes(files);
+
         if(hasListener){
             myListener.startSubmission(submissionNumber, bytes);
         }
-        
+
         HttpRequestGenerator generator;
         if(user.getUserType().equals(User.TYPE_DEMO)) {
-            generator = new HttpRequestGenerator(); 
+            generator = new HttpRequestGenerator();
         } else {
             generator = new HttpRequestGenerator(user);
         }
-        
-        String t = "p+a+s";
-        
-        if (files == null) {
-            Log.e(t, "no files to upload");
+
+        if (files.length == 0) {
+            Log.e(TAG, "no files to upload");
             listener.cancel(true);
         }
-        
+
         // mime post
         MultipartEntity entity = new DataSubmissionEntity(myListener, submissionNumber);
-        
-        for (int j = 0; j < files.length; j++) {
-            File f = files[j];
-            ContentBody fb;
-            
-            boolean supported = false;
-            for(String ext : SUPPORTED_FILE_EXTS) {
-                if(f.getName().endsWith(ext)) {
-                    supported = true;
-                    break;
-                }
-            }
-            
-            //TODO: Match this with some reasonable library, rather than silly file lines
-            if (f.getName().endsWith(".xml")) {
-                
-                //fb = new InputStreamBody(new CipherInputStream(new FileInputStream(f), getDecryptCipher(aesKey)), "text/xml", f.getName());
-                
-                if(key != null){
-                    if(!validateSubmissionFile(f, FormUploadUtil.getDecryptCipher(key))) {
-                        return RECORD_FAILURE;
-                    }
-                    fb = new EncryptedFileBody(f, FormUploadUtil.getDecryptCipher(key), "text/xml");
-                }
-                else{
-                    fb = new FileBody(f, "text/xml");
-                }
-                
-                entity.addPart("xml_submission_file", fb);
-                
-                //fb = new FileBody(f, "text/xml");
-                //Don't know if we can ask for the content length on the input stream, so skip it.
-//                if (fb.getContentLength() <= MAX_BYTES) {
-//                    Log.i(t, "added xml file " + f.getName());
-//                } else {
-//                    Log.i(t, "file " + f.getName() + " is too big");
-//                }
-            } else if (f.getName().endsWith(".jpg")) {
-                fb = new FileBody(f, "image/jpeg");
-                if (fb.getContentLength() <= MAX_BYTES) {
-                    entity.addPart(f.getName(), fb);
-                    Log.i(t, "added image file " + f.getName());
-                } else {
-                    Log.i(t, "file " + f.getName() + " is too big");
-                }
-            } else if (f.getName().endsWith(".3gpp")) {
-                fb = new FileBody(f, "audio/3gpp");
-                if (fb.getContentLength() <= MAX_BYTES) {
-                    entity.addPart(f.getName(), fb);
-                    Log.i(t, "added audio file " + f.getName());
-                } else {
-                    Log.i(t, "file " + f.getName() + " is too big");
-                }
-            } else if (f.getName().endsWith(".3gp")) {
-                fb = new FileBody(f, "video/3gpp");
-                if (fb.getContentLength() <= MAX_BYTES) {
-                    entity.addPart(f.getName(), fb);
-                    Log.i(t, "added video file " + f.getName());
-                } else {
-                    Log.i(t, "file " + f.getName() + " is too big");
-                }
-            } else if (supported) {
-                 fb = new FileBody(f, "application/octet-stream");
-                 if (fb.getContentLength() <= MAX_BYTES) {
-                     entity.addPart(f.getName(), fb);
-                     Log.i(t, "added unknown file " + f.getName());
-                 } else {
-                     Log.i(t, "file " + f.getName() + " is too big");
-                 }
-            } else {
-                Log.w(t, "unsupported file type, not adding file: " + f.getName());
-            }
+        if (!buildMultipartEntity(entity, key, files)) {
+            return RECORD_FAILURE;
         }
+
         // prepare response and return uploaded
-        HttpResponse response = null;
+        HttpResponse response;
         try {
             response = generator.postData(url, entity);
         } catch (InputIOException ioe ){
-            //This implies that there was a problem with the _source_ of the 
+            //This implies that there was a problem with the _source_ of the
             //transmission, not the processing or receiving end.
-            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Internal error reading form record during submission: " + ioe.getWrapped().getMessage());
+            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE,
+                    "Internal error reading form record during submission: " +
+                    ioe.getWrapped().getMessage());
             return RECORD_FAILURE;
         } catch (ClientProtocolException e) {
             e.printStackTrace();
@@ -254,36 +142,23 @@ public class FormUploadUtil {
             return TRANSPORT_FAILURE;
         }
 
-        String serverLocation = null;
-        Header[] h = response.getHeaders("Location");
-        if (h != null && h.length > 0) {
-            serverLocation = h[0].getValue();
-        } else {
-            // something should be done here...
-            Log.e(t, "Location header was absent");
-        }
         int responseCode = response.getStatusLine().getStatusCode();
-        Log.e(t, "Response code:" + responseCode);
+        Log.e(TAG, "Response code:" + responseCode);
         //If this response code wasn't legit
         if(!(responseCode >= 200 && responseCode < 300)) {
             //Log that so we can figure out what's up!
             Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Response Code: " + responseCode);
         }
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        
+
         try {
             AndroidStreamUtil.writeFromInputToOutput(response.getEntity().getContent(), bos);
-        } catch (IllegalStateException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
+        } catch (IllegalStateException | IOException e) {
             e.printStackTrace();
         }
-        
+
         String responseString = new String(bos.toByteArray());
-        System.out.println(responseString);
-        
+        Log.d(TAG, responseString);
 
         if(responseCode >= 200 && responseCode < 300) {
             return FULL_SUCCESS;
@@ -295,20 +170,19 @@ public class FormUploadUtil {
 
     /**
      * Validate the content body of the XML submission file.
-     * 
-     * TODO: this should really be the responsibility of the form record, not of the 
+     *
+     * TODO: this should really be the responsibility of the form record, not of the
      * submission process, persay.
-     * 
+     *
      * NOTE: this is a shallow validation (everything should be more or else constant time).
      * Throws an exception if the file is gone because that's a common issue that gets caught
-     * to check if storage got removed 
-     * 
+     * to check if storage got removed
+     *
      * @param f
-     * @param decryptCipher
      * @return
-     * @throws FileNotFoundException 
+     * @throws FileNotFoundException
      */
-    public static boolean validateSubmissionFile(File f, Cipher decryptCipher) throws FileNotFoundException {
+    private static boolean validateSubmissionFile(File f) throws FileNotFoundException {
         if(!f.exists()) {
             throw new FileNotFoundException("Submission file: " + f.getAbsolutePath());
         }
@@ -317,7 +191,100 @@ public class FormUploadUtil {
             Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Submission body has no content at: " + f.getAbsolutePath());
             return false;
         }
-        
+
+        return true;
+    }
+
+    private static long estimateUploadBytes(File[] files) {
+        long bytes = 0;
+        for (File file : files) {
+            //Make sure we'll be sending it
+            boolean supported = false;
+            for (String ext : SUPPORTED_FILE_EXTS) {
+                if (file.getName().endsWith(ext)) {
+                    supported = true;
+                    break;
+                }
+            }
+            if (!supported) {
+                continue;
+            }
+
+            bytes += file.length();
+            Log.d(TAG, "Added file: " + file.getName() + ". Bytes to send: " + bytes);
+        }
+        return bytes;
+    }
+
+    /**
+     * @param entity
+     * @param key
+     * @param files
+     * @return
+     * @throws FileNotFoundException
+     */
+    private static boolean buildMultipartEntity(MultipartEntity entity,
+                                                SecretKeySpec key,
+                                                File[] files)
+            throws FileNotFoundException {
+        for (File f : files) {
+            ContentBody fb;
+
+            boolean supported = false;
+            for (String ext : SUPPORTED_FILE_EXTS) {
+                if (f.getName().endsWith(ext)) {
+                    supported = true;
+                    break;
+                }
+            }
+
+            if (f.getName().endsWith(".xml")) {
+                if (key != null) {
+                    if (!validateSubmissionFile(f)) {
+                        return false;
+                    }
+                    fb = new EncryptedFileBody(f, FormUploadUtil.getDecryptCipher(key),
+                            "text/xml");
+                } else {
+                    fb = new FileBody(f, "text/xml");
+                }
+                entity.addPart("xml_submission_file", fb);
+            } else if (f.getName().endsWith(".jpg")) {
+                fb = new FileBody(f, "image/jpeg");
+                if (fb.getContentLength() <= MAX_BYTES) {
+                    entity.addPart(f.getName(), fb);
+                    Log.i(TAG, "added image file " + f.getName());
+                } else {
+                    Log.i(TAG, "file " + f.getName() + " is too big");
+                }
+            } else if (f.getName().endsWith(".3gpp")) {
+                fb = new FileBody(f, "audio/3gpp");
+                if (fb.getContentLength() <= MAX_BYTES) {
+                    entity.addPart(f.getName(), fb);
+                    Log.i(TAG, "added audio file " + f.getName());
+                } else {
+                    Log.i(TAG, "file " + f.getName() + " is too big");
+                }
+            } else if (f.getName().endsWith(".3gp")) {
+                fb = new FileBody(f, "video/3gpp");
+                if (fb.getContentLength() <= MAX_BYTES) {
+                    entity.addPart(f.getName(), fb);
+                    Log.i(TAG, "added video file " + f.getName());
+                } else {
+                    Log.i(TAG, "file " + f.getName() + " is too big");
+                }
+            } else if (supported) {
+                fb = new FileBody(f, "application/octet-stream");
+                if (fb.getContentLength() <= MAX_BYTES) {
+                    entity.addPart(f.getName(), fb);
+                    Log.i(TAG, "added unknown file " + f.getName());
+                } else {
+                    Log.i(TAG, "file " + f.getName() + " is too big");
+                }
+            } else {
+                Log.w(TAG, "unsupported file type, not adding file: " + f.getName());
+            }
+        }
         return true;
     }
 }

--- a/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
@@ -95,7 +95,7 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
                 }
                 
                 SharedPreferences settings = CommCareApplication._().getCurrentApp().getAppPreferences();
-                SendTask<CommCareFormDumpActivity> mSendTask = new SendTask<CommCareFormDumpActivity>(getApplicationContext(), CommCareApplication._().getCurrentApp().getCommCarePlatform(), 
+                SendTask<CommCareFormDumpActivity> mSendTask = new SendTask<CommCareFormDumpActivity>(getApplicationContext(),
                         settings.getString("PostURL", url), getFolderPath()){
                                         
                     /*

--- a/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
@@ -514,7 +514,7 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         }
 
         SharedPreferences settings = CommCareApplication._().getCurrentApp().getAppPreferences();
-        SendTask<CommCareWiFiDirectActivity> mSendTask = new SendTask<CommCareWiFiDirectActivity>(getApplicationContext(), CommCareApplication._().getCurrentApp().getCommCarePlatform(), 
+        SendTask<CommCareWiFiDirectActivity> mSendTask = new SendTask<CommCareWiFiDirectActivity>(getApplicationContext(),
                 settings.getString("PostURL", url), receiveFolder){
 
             /*

--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -27,7 +27,6 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.Toast;
-import android.webkit.MimeTypeMap;
 
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
@@ -110,16 +109,8 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         mChooseButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                MimeTypeMap mtm = MimeTypeMap.getSingleton();
-                String [] extraMimes =
-                    new String[] {
-                            // mtm.getMimeTypeFromExtension("mp3"),
-                            mtm.getMimeTypeFromExtension("flac")
-                        };
                 Intent i = new Intent(Intent.ACTION_GET_CONTENT);
                 i.setType("audio/*");
-                i.putExtra(Intent.EXTRA_MIME_TYPES, extraMimes);
-                // i.setType("audio/mpeg3|audio/wav|audio/mpeg|audio/ogg|audio/flac");
                 mWaitingForData = true;
                 try {
                     ((Activity)getContext())

--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -27,6 +27,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.Toast;
+import android.webkit.MimeTypeMap;
 
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
@@ -49,7 +50,7 @@ import java.io.File;
  */
 
 public class AudioWidget extends QuestionWidget implements IBinaryWidget {
-    private final static String t = "MediaWidget";
+    private static final String TAG = AudioWidget.class.getSimpleName();
 
     private final Button mCaptureButton;
     private final Button mPlayButton;
@@ -98,19 +99,27 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
             }
         });
 
-        // setup capture button
+        // setup audio filechooser button
         mChooseButton = new Button(getContext());
         WidgetUtils.setupButton(mChooseButton,
                 StringUtils.getStringSpannableRobust(getContext(), R.string.choose_sound),
                 mAnswerFontsize,
                 !prompt.isReadOnly());
 
-        // launch capture intent on click
+        // launch audio filechooser intent on click
         mChooseButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                MimeTypeMap mtm = MimeTypeMap.getSingleton();
+                String [] extraMimes =
+                    new String[] {
+                            // mtm.getMimeTypeFromExtension("mp3"),
+                            mtm.getMimeTypeFromExtension("flac")
+                        };
                 Intent i = new Intent(Intent.ACTION_GET_CONTENT);
                 i.setType("audio/*");
+                i.putExtra(Intent.EXTRA_MIME_TYPES, extraMimes);
+                // i.setType("audio/mpeg3|audio/wav|audio/mpeg|audio/ogg|audio/flac");
                 mWaitingForData = true;
                 try {
                     ((Activity)getContext())
@@ -176,7 +185,7 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         // get the file path and delete the file
         File f = new File(mInstanceFolder + "/" + mBinaryName);
         if (!f.delete()) {
-            Log.i(t, "Failed to delete " + f);
+            Log.i(TAG, "Failed to delete " + f);
         }
 
         // clean up variables
@@ -234,9 +243,9 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
 
             Uri AudioURI =
                     getContext().getContentResolver().insert(Audio.Media.EXTERNAL_CONTENT_URI, values);
-            Log.i(t, "Inserting AUDIO returned uri = " + AudioURI.toString());
+            Log.i(TAG, "Inserting AUDIO returned uri = " + AudioURI.toString());
         } else {
-            Log.e(t, "Inserting Audio file FAILED");
+            Log.e(TAG, "Inserting Audio file FAILED");
         }
 
         mBinaryName = newAudio.getName();

--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -137,7 +137,7 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
             @Override
             public void onClick(View v) {
                 Intent i = new Intent("android.intent.action.VIEW");
-                File f = new File(mInstanceFolder + "/" + mBinaryName);
+                File f = new File(mInstanceFolder + mBinaryName);
                 i.setDataAndType(Uri.fromFile(f), "audio/*");
                 try {
                     ((Activity)getContext()).startActivity(i);
@@ -155,7 +155,7 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         mBinaryName = prompt.getAnswerText();
         if (mBinaryName != null) {
             mPlayButton.setEnabled(true);
-            File f = new File(mInstanceFolder + "/" + mBinaryName);
+            File f = new File(mInstanceFolder + mBinaryName);
 
             checkFileSize(f);
         } else {
@@ -174,7 +174,7 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
 
     private void deleteMedia() {
         // get the file path and delete the file
-        File f = new File(mInstanceFolder + "/" + mBinaryName);
+        File f = new File(mInstanceFolder + mBinaryName);
         if (!f.delete()) {
             Log.i(TAG, "Failed to delete " + f);
         }
@@ -215,8 +215,14 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         // get the file path and create a copy in the instance folder
         String binaryPath = UriToFilePath.getPathFromUri(CommCareApplication._(),
                 (Uri)binaryuri);
-        String extension = binaryPath.substring(binaryPath.lastIndexOf("."));
-        String destAudioPath = mInstanceFolder + "/" + System.currentTimeMillis() + extension;
+
+        String[] filenameSegments = binaryPath.split("\\.");
+        String extension = "";
+        if (filenameSegments.length > 1) {
+            extension = "." + filenameSegments[filenameSegments.length - 1];
+        }
+
+        String destAudioPath = mInstanceFolder + System.currentTimeMillis() + extension;
 
         File source = new File(binaryPath);
         File newAudio = new File(destAudioPath);


### PR DESCRIPTION
Fix for [this ticket](http://manage.dimagi.com/default.asp?173209)

NewUi version of this PR: https://github.com/dimagi/commcare-odk/pull/358

There was a bug where the sync process wasn't sending certain case audio attachments up to HQ. The problem was that only a handful of hard coded filetypes were accepted as valid.

This PR allows for all files that have an audio, video, or image mimetype to be uploaded as case attachments to HQ.

Note: currently if a case is uploaded to HQ that expects an attachment but the phone didn't include that attachment, the only info HQ returns is a 500 error.

Also includes:
 - made AudioWidget stop adding double backslashes to filepaths
 - removed unneeded platform parameter from SendTask constructor
 - Refactored FormUploadUtil to use helper methods
 - make CommCare not crash if you select an audio file in AudioWidget that doesn't have an extension (even though this should never really happen, good to be safe)