### PR TITLE
Specifying Java 1.7 in ant.properties

### DIFF
--- a/app/ant.properties
+++ b/app/ant.properties
@@ -39,3 +39,6 @@ adb.device.arg=-s emulator-5554
 dir.test.project=../commcare-odk-test/
 
 test.dir=../unit-tests/
+# specifying that we need java 7 for this build
+java.source=7
+java.target=7


### PR DESCRIPTION
Jenkins build is broken without this configuration.