### PR TITLE
Remove deprecated use of startManagingCursor (old ui)

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -277,8 +277,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                     "Couldn't register form save callback because session doesn't exist");
         }
 
-
-        // TODO: can this be moved into setupUI?
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             String fragmentClass = this.getIntent().getStringExtra("odk_title_fragment");
             if(fragmentClass != null) {
@@ -1557,8 +1555,8 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 final CheckBox instanceComplete = ((CheckBox) endView.findViewById(R.id.mark_finished));
                 instanceComplete.setText(StringUtils.getStringSpannableRobust(this, R.string.mark_finished));
 
-                        //If incomplete is not enabled, make sure this box is checked.
-                        instanceComplete.setChecked(!mIncompleteEnabled || isInstanceComplete(true));
+                //If incomplete is not enabled, make sure this box is checked.
+                instanceComplete.setChecked(!mIncompleteEnabled || isInstanceComplete(true));
                 
                 if(mFormController.isFormReadOnly() || !mIncompleteEnabled) {
                     instanceComplete.setVisibility(View.GONE);
@@ -2903,10 +2901,13 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         String[] selectionArgs = {
             mInstancePath
         };
-        Cursor c =
-            getContentResolver().query(instanceProviderContentURI, null, selection, selectionArgs,
-                null);
-        startManagingCursor(c);
+
+        Cursor c;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            c = new CursorLoader(this, instanceProviderContentURI, null, selection, selectionArgs, null).loadInBackground();
+        } else {
+            c = FormEntryActivity.this.managedQuery(instanceProviderContentURI, null, selection, selectionArgs, null);
+        }
         if (c != null && c.getCount() > 0) {
             c.moveToFirst();
             String status = c.getString(c.getColumnIndex(InstanceColumns.STATUS));

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2906,7 +2906,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             c = new CursorLoader(this, instanceProviderContentURI, null, selection, selectionArgs, null).loadInBackground();
         } else {
-            c = FormEntryActivity.this.managedQuery(instanceProviderContentURI, null, selection, selectionArgs, null);
+            c = this.managedQuery(instanceProviderContentURI, null, selection, selectionArgs, null);
         }
         if (c != null && c.getCount() > 0) {
             c.moveToFirst();


### PR DESCRIPTION
OldUI fix for [this ticket](http://manage.dimagi.com/default.asp?174380)

How to reproduce the crash (thanks to Clark):
 - Open a form to edit
 - save your progress using the right-hand settings menu.
 - In the same settings menu, click "Go to prompt" and then "Go to beginning" or "Go to end"
 - Experience the wondrous crash

Cross-requested with new ui: https://github.com/dimagi/commcare-odk/pull/355