### PR TITLE
Update unit test to correctly override getParser

### DIFF
--- a/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -60,7 +60,8 @@ public class TestUtils {
      */
     private static TransactionParserFactory getFactory(final SQLiteDatabase db) {
         return new TransactionParserFactory() {
-            
+
+            @Override
             public TransactionParser getParser(KXmlParser parser) {
                 if(CaseXmlParser.CASE_XML_NAMESPACE.equals(parser.getNamespace()) && "case".equalsIgnoreCase(parser.getName())) {
                     return new AndroidCaseXmlParser(parser, getCaseStorage(db), new EntityStorageCache("case", db), new CaseIndexTable(db)) {

--- a/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.util;
 
 import java.io.IOException;
@@ -27,7 +24,6 @@ import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.model.test.TreeReferenceTest;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
@@ -37,7 +33,6 @@ import org.xmlpull.v1.XmlPullParserException;
 
 /**
  * @author ctsims
- *
  */
 public class TestUtils {
     
@@ -66,8 +61,8 @@ public class TestUtils {
     private static TransactionParserFactory getFactory(final SQLiteDatabase db) {
         return new TransactionParserFactory() {
             
-            public TransactionParser getParser(String name, String namespace, KXmlParser parser) {
-                if(CaseXmlParser.CASE_XML_NAMESPACE.equals(namespace) && name.toLowerCase().equals("case")) {
+            public TransactionParser getParser(KXmlParser parser) {
+                if(CaseXmlParser.CASE_XML_NAMESPACE.equals(parser.getNamespace()) && "case".equalsIgnoreCase(parser.getName())) {
                     return new AndroidCaseXmlParser(parser, getCaseStorage(db), new EntityStorageCache("case", db), new CaseIndexTable(db)) {
                         @Override
                         protected SQLiteDatabase getDbHandle() {


### PR DESCRIPTION
The TransactionParserFactory.getParser interface changed a while ago. This PR updates the unit test to match that new interface.