### PR TITLE
Ensure reference is valid before continuing install

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -320,7 +320,8 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             // check if the reference can be derived without erroring out
             ReferenceManager._().DeriveReference(incomingRef);
         } catch (InvalidReferenceException ire) {
-            // Couldn't process reference, return to basic ui state
+            // Couldn't process reference, return to basic ui state to ask user
+            // for new install reference
             Toast.makeText(getApplicationContext(),
                     Localization.get("install.bad.ref"),
                     Toast.LENGTH_LONG).show();

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -322,6 +322,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         } catch (InvalidReferenceException ire) {
             // Couldn't process reference, return to basic ui state to ask user
             // for new install reference
+            incomingRef = null;
             Toast.makeText(getApplicationContext(),
                     Localization.get("install.bad.ref"),
                     Toast.LENGTH_LONG).show();

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -315,11 +315,17 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         if(result == null) return;
         incomingRef = result;
         this.uiState = UiState.ready;
-        //Definitely have a URI now.
+
         try {
+            // check if the reference can be derived without erroring out
             ReferenceManager._().DeriveReference(incomingRef);
         } catch (InvalidReferenceException ire) {
-            return;
+            // Couldn't process reference, return to basic ui state
+            Toast.makeText(getApplicationContext(),
+                    Localization.get("install.bad.ref"),
+                    Toast.LENGTH_LONG).show();
+            this.uiState = UiState.basic;
+            uiStateScreenTransition();
         }
     }
 


### PR DESCRIPTION
The UI refactors took out some error handling:
https://github.com/dimagi/commcare-odk/commit/07c1c36ad4af256e63b30758c7d569c8f8fc0773#diff-8ceab6edefa7a1717265df3ea8d93ffaL496

This PR restores the error handling that re-asks for the install reference if CommCare has trouble processing the reference.