### PR TITLE
Spelling error in permission of Android Manifest

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.BROADCAST_STICKY" />
 
     <application


### PR DESCRIPTION
Correct spelling error in "android.permission.ACESS_NETWORK_STATE"

Not sure how this error in this ticket came up though:
http://manage.dimagi.com/default.asp?175355