### PR TITLE
Replace managedQuery/CursorLoader with getContentResolver().query

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -22,7 +22,6 @@ import android.content.BroadcastReceiver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
-import android.content.CursorLoader;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -440,79 +440,80 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                     Log.v(t, "Content type is: " + contentType);
                 }
                 
-                Uri formUri = null;;
+                Uri formUri = null;
 
                 if (contentType.equals(InstanceColumns.CONTENT_ITEM_TYPE)) {
-                    Cursor instanceCursor ;
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-                    {
-                        instanceCursor = new CursorLoader(this, uri, null, null, null, null).loadInBackground();
-                    } else {
-                        instanceCursor = this.managedQuery(uri, null, null, null, null);
-                    }
-                    if (instanceCursor.getCount() != 1) {
-                        CommCareActivity.createErrorDialog(this, "Bad URI: " + uri, EXIT);
-                        return;
-                    } else {
-                        instanceCursor.moveToFirst();
-                        mInstancePath =
-                            instanceCursor.getString(instanceCursor
-                                    .getColumnIndex(InstanceColumns.INSTANCE_FILE_PATH));
-
-                        String jrFormId =
-                            instanceCursor.getString(instanceCursor
-                                    .getColumnIndex(InstanceColumns.JR_FORM_ID));
-                        
-                        
-                        //If this form is both already completed 
-                        if(InstanceProviderAPI.STATUS_COMPLETE.equals(instanceCursor.getString(instanceCursor.getColumnIndex(InstanceColumns.STATUS)))) {
-                            if(!Boolean.parseBoolean(instanceCursor.getString(instanceCursor.getColumnIndex(InstanceColumns.CAN_EDIT_WHEN_COMPLETE)))) {
-                                readOnly = true;
-                            }
-                        }
-                        
-
-                        String[] selectionArgs = {
-                            jrFormId
-                        };
-                        String selection = FormsColumns.JR_FORM_ID + " like ?";
-
-                        Cursor formCursor ;
-                        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                            formCursor = new CursorLoader(this, formProviderContentURI, null, selection, selectionArgs, null).loadInBackground();
+                    Cursor instanceCursor = null;
+                    Cursor formCursor = null;
+                    try {
+                        instanceCursor = getContentResolver().query(uri, null, null, null, null);
+                        if (instanceCursor.getCount() != 1) {
+                            CommCareActivity.createErrorDialog(this, "Bad URI: " + uri, EXIT);
+                            return;
                         } else {
-                            formCursor = managedQuery(formProviderContentURI, null, selection, selectionArgs, null);
-                        }
-                        if (formCursor.getCount() == 1) {
-                            formCursor.moveToFirst();
-                            mFormPath =
-                                formCursor.getString(formCursor
-                                        .getColumnIndex(FormsColumns.FORM_FILE_PATH));
-                            formUri = ContentUris.withAppendedId(formProviderContentURI, formCursor.getLong(formCursor.getColumnIndex(FormsColumns._ID)));
-                        } else if (formCursor.getCount() < 1) {
-                            CommCareActivity.createErrorDialog(this, "Parent form does not exist", EXIT);
-                            return;
-                        } else if (formCursor.getCount() > 1) {
-                            CommCareActivity.createErrorDialog(this, "More than one possible parent form", EXIT);
-                            return;
-                        }
+                            instanceCursor.moveToFirst();
+                            mInstancePath =
+                                    instanceCursor.getString(instanceCursor
+                                            .getColumnIndex(InstanceColumns.INSTANCE_FILE_PATH));
 
+                            String jrFormId =
+                                    instanceCursor.getString(instanceCursor
+                                            .getColumnIndex(InstanceColumns.JR_FORM_ID));
+
+
+                            //If this form is both already completed
+                            if (InstanceProviderAPI.STATUS_COMPLETE.equals(instanceCursor.getString(instanceCursor.getColumnIndex(InstanceColumns.STATUS)))) {
+                                if (!Boolean.parseBoolean(instanceCursor.getString(instanceCursor.getColumnIndex(InstanceColumns.CAN_EDIT_WHEN_COMPLETE)))) {
+                                    readOnly = true;
+                                }
+                            }
+
+
+                            String[] selectionArgs = {
+                                    jrFormId
+                            };
+                            String selection = FormsColumns.JR_FORM_ID + " like ?";
+
+                            formCursor = getContentResolver().query(formProviderContentURI, null, selection, selectionArgs, null);
+                            if (formCursor.getCount() == 1) {
+                                formCursor.moveToFirst();
+                                mFormPath =
+                                        formCursor.getString(formCursor
+                                                .getColumnIndex(FormsColumns.FORM_FILE_PATH));
+                                formUri = ContentUris.withAppendedId(formProviderContentURI, formCursor.getLong(formCursor.getColumnIndex(FormsColumns._ID)));
+                            } else if (formCursor.getCount() < 1) {
+                                CommCareActivity.createErrorDialog(this, "Parent form does not exist", EXIT);
+                                return;
+                            } else if (formCursor.getCount() > 1) {
+                                CommCareActivity.createErrorDialog(this, "More than one possible parent form", EXIT);
+                                return;
+                            }
+
+                        }
+                    } finally {
+                        if (instanceCursor != null) {
+                            instanceCursor.close();
+                        }
+                        if (formCursor != null) {
+                            formCursor.close();
+                        }
                     }
-
                 } else if (contentType.equals(FormsColumns.CONTENT_ITEM_TYPE)) {
-                    Cursor c;
-                    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                        c = new CursorLoader(this, uri, null, null, null, null).loadInBackground();
-                    } else {
-                        c = this.managedQuery(uri, null, null, null, null);
-                    }
-                    if (c.getCount() != 1) {
-                        CommCareActivity.createErrorDialog(this, "Bad URI: " + uri, EXIT);
-                        return;
-                    } else {
-                        c.moveToFirst();
-                        mFormPath = c.getString(c.getColumnIndex(FormsColumns.FORM_FILE_PATH));
-                        formUri = uri;
+                    Cursor c = null;
+                    try {
+                        c = getContentResolver().query(uri, null, null, null, null);
+                        if (c.getCount() != 1) {
+                            CommCareActivity.createErrorDialog(this, "Bad URI: " + uri, EXIT);
+                            return;
+                        } else {
+                            c.moveToFirst();
+                            mFormPath = c.getString(c.getColumnIndex(FormsColumns.FORM_FILE_PATH));
+                            formUri = uri;
+                        }
+                    } finally {
+                        if (c != null) {
+                            c.close();
+                        }
                     }
                 } else {
                     Log.e(t, "unrecognized URI");
@@ -1507,20 +1508,21 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 String[] selectionArgs = {
                     mFormPath
                 };
-                Cursor c;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-                {
-                    c = new CursorLoader(this, formProviderContentURI, projection, selection, selectionArgs, null).loadInBackground();
-                } else {
-                    c = managedQuery(formProviderContentURI, projection, selection, selectionArgs, null);
-                }
+                Cursor c = null;
                 String mediaDir = null;
-                if (c.getCount() < 1) {
-                    CommCareActivity.createErrorDialog(this, "Form doesn't exist", EXIT);
-                    return new View(this);
-                } else {
-                    c.moveToFirst();
-                    mediaDir = c.getString(c.getColumnIndex(FormsColumns.FORM_MEDIA_PATH));
+                try {
+                    c = getContentResolver().query(formProviderContentURI, projection, selection, selectionArgs, null);
+                    if (c.getCount() < 1) {
+                        CommCareActivity.createErrorDialog(this, "Form doesn't exist", EXIT);
+                        return new View(this);
+                    } else {
+                        c.moveToFirst();
+                        mediaDir = c.getString(c.getColumnIndex(FormsColumns.FORM_MEDIA_PATH));
+                    }
+                } finally {
+                    if (c != null) {
+                        c.close();
+                    }
                 }
 
                 BitmapDrawable bitImage = null;
@@ -2197,16 +2199,19 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         String selection =
             InstanceColumns.INSTANCE_FILE_PATH + " like '"
                     + mInstancePath + "'";
-        Cursor c;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB)
-        {
-            c = new CursorLoader(this,  instanceProviderContentURI, null, selection, null, null).loadInBackground();
-        } else {
-            c = FormEntryActivity.this.managedQuery( instanceProviderContentURI, null, selection, null, null);
+        Cursor c = null;
+        int instanceCount = 0;
+        try {
+            c = getContentResolver().query(instanceProviderContentURI, null, selection, null, null);
+            instanceCount = c.getCount();
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
 
         // if it's not already saved, erase everything
-        if (c.getCount() < 1) {
+        if (instanceCount < 1) {
             int images = 0;
             int audio = 0;
             int video = 0;
@@ -2604,17 +2609,19 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         if (getContentResolver().getType(getIntent().getData()) == InstanceColumns.CONTENT_ITEM_TYPE) {
             Uri instanceUri = getIntent().getData();
 
-            Cursor instance;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                instance = new CursorLoader(this, instanceUri, null, null, null, null).loadInBackground();
-            } else {
-                instance = managedQuery(instanceUri, null, null, null, null);
-            }
-            if (instance.getCount() == 1) {
-                instance.moveToFirst();
-                saveName =
-                    instance.getString(instance
-                            .getColumnIndex(InstanceColumns.DISPLAY_NAME));
+            Cursor instance = null;
+            try {
+                instance = getContentResolver().query(instanceUri, null, null, null, null);
+                if (instance.getCount() == 1) {
+                    instance.moveToFirst();
+                    saveName =
+                        instance.getString(instance
+                                .getColumnIndex(InstanceColumns.DISPLAY_NAME));
+                }
+            } finally {
+                if (instance != null) {
+                    instance.close();
+                }
             }
         }
         return saveName;
@@ -2900,17 +2907,19 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
             mInstancePath
         };
 
-        Cursor c;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            c = new CursorLoader(this, instanceProviderContentURI, null, selection, selectionArgs, null).loadInBackground();
-        } else {
-            c = this.managedQuery(instanceProviderContentURI, null, selection, selectionArgs, null);
-        }
-        if (c != null && c.getCount() > 0) {
-            c.moveToFirst();
-            String status = c.getString(c.getColumnIndex(InstanceColumns.STATUS));
-            if (InstanceProviderAPI.STATUS_COMPLETE.compareTo(status) == 0) {
-                complete = true;
+        Cursor c = null;
+        try {
+            c = getContentResolver().query(instanceProviderContentURI, null, selection, selectionArgs, null);
+            if (c != null && c.getCount() > 0) {
+                c.moveToFirst();
+                String status = c.getString(c.getColumnIndex(InstanceColumns.STATUS));
+                if (InstanceProviderAPI.STATUS_COMPLETE.compareTo(status) == 0) {
+                    complete = true;
+                }
+            }
+        } finally {
+            if (c != null) {
+                c.close();
             }
         }
         return complete;
@@ -2945,25 +2954,27 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 mInstancePath
             };
 
-            Cursor c;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                c = new CursorLoader(this, instanceProviderContentURI, null, selection, selectionArgs, null).loadInBackground();
-            } else {
-                c = managedQuery(instanceProviderContentURI, null, selection, selectionArgs, null);
-            }
-            if (c.getCount() > 0) {
-                // should only be one...
-                c.moveToFirst();
-                String id = c.getString(c.getColumnIndex(InstanceColumns._ID));
-                Uri instance = Uri.withAppendedPath(instanceProviderContentURI, id);
+            Cursor c = null;
+            try {
+                c = getContentResolver().query(instanceProviderContentURI, null, selection, selectionArgs, null);
+                if (c.getCount() > 0) {
+                    // should only be one...
+                    c.moveToFirst();
+                    String id = c.getString(c.getColumnIndex(InstanceColumns._ID));
+                    Uri instance = Uri.withAppendedPath(instanceProviderContentURI, id);
 
-                Intent formReturnIntent = new Intent();
-                formReturnIntent.putExtra(IS_ARCHIVED_FORM, mFormController.isFormReadOnly());
+                    Intent formReturnIntent = new Intent();
+                    formReturnIntent.putExtra(IS_ARCHIVED_FORM, mFormController.isFormReadOnly());
 
-                if(reportSaved || hasSaved) {
-                    setResult(RESULT_OK, formReturnIntent.setData(instance));
-                } else {
-                    setResult(RESULT_CANCELED, formReturnIntent.setData(instance));
+                    if (reportSaved || hasSaved) {
+                        setResult(RESULT_OK, formReturnIntent.setData(instance));
+                    } else {
+                        setResult(RESULT_CANCELED, formReturnIntent.setData(instance));
+                    }
+                }
+            } finally {
+                if (c != null) {
+                    c.close();
                 }
             }
         }


### PR DESCRIPTION
Proposing a 2.21.2 hotfix because:

The issues persist with http://manage.dimagi.com/default.asp?171001#971103

Now getting something like:
```
java.lang.RuntimeException: Unable to resume activity {org.commcare.dalvik/org.odk.collect.android.activities.FormEntryActivity}: java.lang.IllegalStateException: database /data/data/org.commcare.dalvik/databases/instances.db already closed
at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2139)
at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:2154)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:966)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:130)
at android.app.ActivityThread.main(ActivityThread.java:3714)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:507)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:853)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:611)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.IllegalStateException: database /data/data/org.commcare.dalvik/databases/instances.db already closed
at android.database.sqlite.SQLiteProgram.bindString(SQLiteProgram.java:240)
at android.database.sqlite.SQLiteQuery.requery(SQLiteQuery.java:148)
at android.database.sqlite.SQLiteCursor.requery(SQLiteCursor.java:535)
at android.database.CursorWrapper.requery(CursorWrapper.java:211)
at android.app.Activity.performRestart(Activity.java:3830)
at android.app.Activity.performResume(Activity.java:3851)
at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2129)
... 10 more
```

This PR tries to fix this by replacing calls to managedQuery/CursorLoader with getContentResolver().query and make sure to manually close the cursor afterwards.

Sorta big change for a hotfix. I _quickly_ set breakpoints at each place where I removed mangedQuery calls and verified the new call to getContentResolver().query followed the expected code path. I also tested that 2.21.1 does crash on pre Android 4 (emulators), and that this PR prevents that crash.

**Background Context:**
Looking on the Play store, I see one crash report of this type on 2.21.1. It is for an Android 2.X device. I suspected that our 2.21.1 hotfix wouldn't actually resolve the crash for devices running Android 3 or earlier. Apologies for not verifying my suspicions.

I believe the crash is happening because managedQuery makes some automatic calls to requery that we aren't anticipating/handling correctly (hand-wavy intuition).

The way we are using managedQuery and CursorLoader in FormEntryActivity is vanilla (each query is made only once, in a UI-blocking fashion), we don't need the added complexity (at the moment, though using them correctly would enable non-UI blocking queries).