### PR TITLE
Check multimedia file extension during form entry (oldui)

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -449,3 +449,5 @@ archive.install.button=Install App
 wifi.direct.transfer.forms=Transfer Forms
 wifi.direct.receive.forms=Receive Forms
 wifi.direct.submit.forms=Submit Forms
+
+form.attachment.invalid=Invalid filetype choosen. Please select a valid multimedia file.

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -107,6 +107,7 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="altitude">Altitude</string>
     <string name="app_name">ODK Collect</string>
     <string name="attachment_oversized">Warning: attached large file of size %s kb. This could cause problems with submitting to the server depending on your network conditions.</string>
+    <string name="attachment_invalid">Invalid filetype choosen. Please select a valid multimedia file.</string>
     <string name="audio_file_error">No audio file was specified.</string>
     <string name="audio_file_invalid">File: %s is not a valid audio file.</string>
     <string name="backup">back to\nprevious\nprompt</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -107,7 +107,6 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="altitude">Altitude</string>
     <string name="app_name">ODK Collect</string>
     <string name="attachment_oversized">Warning: attached large file of size %s kb. This could cause problems with submitting to the server depending on your network conditions.</string>
-    <string name="attachment_invalid">Invalid filetype choosen. Please select a valid multimedia file.</string>
     <string name="audio_file_error">No audio file was specified.</string>
     <string name="audio_file_invalid">File: %s is not a valid audio file.</string>
     <string name="backup">back to\nprevious\nprompt</string>

--- a/app/src/org/commcare/android/util/FormUploadUtil.java
+++ b/app/src/org/commcare/android/util/FormUploadUtil.java
@@ -61,7 +61,7 @@ public class FormUploadUtil {
     private static final String[] SUPPORTED_FILE_EXTS =
             {".xml", ".jpg", "jpeg", ".3gpp", ".3gp", ".3ga", ".3g2", ".mp3",
                     ".wav", ".amr", ".mp4", ".3gp2", ".mpg4", ".mpeg4",
-                    ".m4v", ".mpg", ".mpeg", ".qcp"};
+                    ".m4v", ".mpg", ".mpeg", ".qcp", ".ogg"};
 
     public static Cipher getDecryptCipher(SecretKeySpec key) {
         Cipher cipher;

--- a/app/src/org/commcare/android/util/FormUploadUtil.java
+++ b/app/src/org/commcare/android/util/FormUploadUtil.java
@@ -257,15 +257,8 @@ public class FormUploadUtil {
     private static long estimateUploadBytes(File[] files) {
         long bytes = 0;
         for (File file : files) {
-            //Make sure we'll be sending it
-            boolean supported = false;
-            for (String ext : SUPPORTED_FILE_EXTS) {
-                if (file.getName().endsWith(ext) || isAudioVisualMimeType(file)) {
-                    supported = true;
-                    break;
-                }
-            }
-            if (!supported) {
+            // Make sure we'll be sending it
+            if (!isSupportedMultimediaFile(file.getName())) {
                 continue;
             }
 
@@ -293,14 +286,6 @@ public class FormUploadUtil {
             throws FileNotFoundException {
         for (File f : files) {
             ContentBody fb;
-
-            boolean supported = false;
-            for (String ext : SUPPORTED_FILE_EXTS) {
-                if (f.getName().endsWith(ext)) {
-                    supported = true;
-                    break;
-                }
-            }
 
             if (f.getName().endsWith(".xml")) {
                 if (key != null) {
@@ -337,7 +322,7 @@ public class FormUploadUtil {
                 } else {
                     Log.i(TAG, "file " + f.getName() + " is too big");
                 }
-            } else if (supported || isAudioVisualMimeType(f)) {
+            } else if (isSupportedMultimediaFile(f.getName())) {
                 fb = new FileBody(f, "application/octet-stream");
                 if (fb.getContentLength() <= MAX_BYTES) {
                     entity.addPart(f.getName(), fb);
@@ -354,14 +339,27 @@ public class FormUploadUtil {
     }
 
     /**
+     * @return Is the filename's extension in the hard-coded list of supported
+     * files or have a media mimetype?
+     */
+    public static boolean isSupportedMultimediaFile(String filename) {
+        for (String ext : SUPPORTED_FILE_EXTS) {
+            if (filename.endsWith(ext)) {
+                return true;
+            }
+        }
+        return isAudioVisualMimeType(filename);
+    }
+
+    /**
      * Use the file's extension to determine if it has an audio,
      * video, or image mimetype.
      *
      * @return true if the file has an audio, image, or video mimetype
      */
-    private static boolean isAudioVisualMimeType(File file) {
+    private static boolean isAudioVisualMimeType(String filename) {
         MimeTypeMap mtm = MimeTypeMap.getSingleton();
-        String[] filenameSegments = file.getName().split("\\.");
+        String[] filenameSegments = filename.split("\\.");
         if (filenameSegments.length > 1) {
             // use the file extension to determine the mimetype
             String ext = filenameSegments[filenameSegments.length - 1];

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -795,7 +795,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                     // upload to the server
                     ((ODKView) mCurrentView).clearAnswer();
                     Toast.makeText(FormEntryActivity.this,
-                            StringUtils.getStringSpannableRobust(FormEntryActivity.this, R.string.attachment_invalid),
+                            Localization.get("form.attachment.invalid"),
                             Toast.LENGTH_LONG).show();
                 } else {
                     ((ODKView) mCurrentView).setBinaryData(media);

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -797,12 +797,11 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                     Toast.makeText(FormEntryActivity.this,
                             StringUtils.getStringSpannableRobust(FormEntryActivity.this, R.string.attachment_invalid),
                             Toast.LENGTH_LONG).show();
-                    return;
                 } else {
                     ((ODKView) mCurrentView).setBinaryData(media);
-                    saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
-                    refreshCurrentView();
                 }
+                saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
+                refreshCurrentView();
                 break;
             case LOCATION_CAPTURE:
                 String sl = intent.getStringExtra(LOCATION_RESULT);

--- a/app/src/org/odk/collect/android/views/ODKView.java
+++ b/app/src/org/odk/collect/android/views/ODKView.java
@@ -368,8 +368,6 @@ public class ODKView extends ScrollView implements OnLongClickListener, WidgetCh
 
     /**
      * Called when another activity returns information to answer this question.
-     * 
-     * @param answer
      */
     public void setBinaryData(Object answer) {
         

--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.odk.collect.android.widgets;
 
 import android.app.Activity;
@@ -28,6 +14,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 
+import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
@@ -215,6 +202,14 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         // get the file path and create a copy in the instance folder
         String binaryPath = UriToFilePath.getPathFromUri(CommCareApplication._(),
                 (Uri)binaryuri);
+
+        if (!FormUploadUtil.isSupportedMultimediaFile(binaryPath)) {
+            // don't let the user select a file that won't be included in the
+            // upload to the server
+            clearAnswer();
+            notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_invalid, "audio"));
+            return;
+        }
 
         String[] filenameSegments = binaryPath.split("\\.");
         String extension = "";

--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -14,7 +14,6 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 
-import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
@@ -203,14 +202,6 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         String binaryPath = UriToFilePath.getPathFromUri(CommCareApplication._(),
                 (Uri)binaryuri);
 
-        if (!FormUploadUtil.isSupportedMultimediaFile(binaryPath)) {
-            // don't let the user select a file that won't be included in the
-            // upload to the server
-            clearAnswer();
-            notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_invalid, "audio"));
-            return;
-        }
-
         String[] filenameSegments = binaryPath.split("\\.");
         String extension = "";
         if (filenameSegments.length > 1) {
@@ -226,7 +217,7 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         checkFileSize(newAudio);
 
         if (newAudio.exists()) {
-            // Add the copy to the content provier
+            // Add the copy to the content provider
             ContentValues values = new ContentValues(6);
             values.put(Audio.Media.TITLE, newAudio.getName());
             values.put(Audio.Media.DISPLAY_NAME, newAudio.getName());

--- a/app/src/org/odk/collect/android/widgets/ImageWidget.java
+++ b/app/src/org/odk/collect/android/widgets/ImageWidget.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.odk.collect.android.widgets;
 
 import android.app.Activity;
@@ -32,6 +18,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
 import org.javarosa.core.model.data.IAnswerData;
@@ -284,8 +271,17 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         if (mBinaryName != null) {
             deleteMedia();
         }
-        String binarypath = UrlUtils.getPathFromUri((Uri) binaryuri,getContext());
-        File f = new File(binarypath);
+        String binaryPath = UrlUtils.getPathFromUri((Uri) binaryuri,getContext());
+
+        if (!FormUploadUtil.isSupportedMultimediaFile(binaryPath)) {
+            // don't let the user select a file that won't be included in the
+            // upload to the server
+            clearAnswer();
+            notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_invalid, "image"));
+            return;
+        }
+
+        File f = new File(binaryPath);
         mBinaryName = f.getName();
         Log.i(t, "Setting current answer to " + f.getName());
 

--- a/app/src/org/odk/collect/android/widgets/ImageWidget.java
+++ b/app/src/org/odk/collect/android/widgets/ImageWidget.java
@@ -18,7 +18,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
 import org.javarosa.core.model.data.IAnswerData;
@@ -272,14 +271,6 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
             deleteMedia();
         }
         String binaryPath = UrlUtils.getPathFromUri((Uri) binaryuri,getContext());
-
-        if (!FormUploadUtil.isSupportedMultimediaFile(binaryPath)) {
-            // don't let the user select a file that won't be included in the
-            // upload to the server
-            clearAnswer();
-            notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_invalid, "image"));
-            return;
-        }
 
         File f = new File(binaryPath);
         mBinaryName = f.getName();

--- a/app/src/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/app/src/org/odk/collect/android/widgets/QuestionWidget.java
@@ -223,10 +223,6 @@ public abstract class QuestionWidget extends LinearLayout {
         notifyOnScreen(text, false);
     }
 
-    public void notifyInvalid(String text) {
-        notifyOnScreen(text, true);
-    }
-    
     public void notifyInvalid(String text, boolean requestFocus) {
         notifyOnScreen(text, true, requestFocus);
     }
@@ -611,10 +607,6 @@ public abstract class QuestionWidget extends LinearLayout {
         if(FileUtils.isFileOversized(file)){
             this.notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_oversized, FileUtils.getFileSize(file) + ""));
         }
-    }
-
-    public void checkFileSize(String filepath){
-        checkFileSize(new File(filepath));
     }
 
     /*

--- a/app/src/org/odk/collect/android/widgets/VideoWidget.java
+++ b/app/src/org/odk/collect/android/widgets/VideoWidget.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.odk.collect.android.widgets;
 
 import android.app.Activity;
@@ -29,6 +15,7 @@ import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.Toast;
 
+import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
@@ -229,6 +216,15 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
         // get the file path and create a copy in the instance folder
         String binaryPath = UriToFilePath.getPathFromUri(CommCareApplication._(),
                 (Uri)binaryuri);
+
+        if (!FormUploadUtil.isSupportedMultimediaFile(binaryPath)) {
+            // don't let the user select a file that won't be included in the
+            // upload to the server
+            clearAnswer();
+            notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_invalid, "video"));
+            return;
+        }
+
         String extension = binaryPath.substring(binaryPath.lastIndexOf("."));
         String destVideoPath = mInstanceFolder + "/" + System.currentTimeMillis() + extension;
 

--- a/app/src/org/odk/collect/android/widgets/VideoWidget.java
+++ b/app/src/org/odk/collect/android/widgets/VideoWidget.java
@@ -15,7 +15,6 @@ import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.Toast;
 
-import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.StringUtils;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
@@ -216,14 +215,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
         // get the file path and create a copy in the instance folder
         String binaryPath = UriToFilePath.getPathFromUri(CommCareApplication._(),
                 (Uri)binaryuri);
-
-        if (!FormUploadUtil.isSupportedMultimediaFile(binaryPath)) {
-            // don't let the user select a file that won't be included in the
-            // upload to the server
-            clearAnswer();
-            notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_invalid, "video"));
-            return;
-        }
 
         String extension = binaryPath.substring(binaryPath.lastIndexOf("."));
         String destVideoPath = mInstanceFolder + "/" + System.currentTimeMillis() + extension;


### PR DESCRIPTION
The old ui version of https://github.com/dimagi/commcare-odk/pull/399

Don't let user select multimedia files of invalid type during form entry.

Currently, when the user chooses a non-supported file for the audio/video/image widget during form entry, no warning is shown. Then the form fails to be uploaded to the server because of it.

This PR shows an error message and clears the user's file choice if they try to use a file that isn't supported for audio/video/image widget.

Fix for [this ticket](http://manage.dimagi.com/default.asp?173209)