### PR TITLE
Fixing autocomplete issues with 'Raw' prefix

### DIFF
--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -7,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.support.v4.app.Fragment;
+import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
@@ -54,6 +55,21 @@ public class SetupEnterURLFragment extends Fragment {
         installButton = (Button) view.findViewById(R.id.start_install);
         installButton.setText(Localization.get("install.button.start"));
         prefixURLSpinner = (Spinner) view.findViewById(R.id.url_spinner);
+        prefixURLSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                String selectedText = profileLocation.getText().toString();
+                if((position == prefixURLSpinner.getCount() -1) &&
+                        (selectedText == null || selectedText.length() == 0)) {
+                    // automatically sets text to the default location for offline installs
+                    profileLocation.setText(R.string.default_app_server);
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
         profileLocation = (EditText) view.findViewById(R.id.edit_profile_location);
         TextView appProfile = (TextView) view.findViewById(R.id.app_profile_txt_view);
         appProfile.setText(Localization.get("install.appprofile"));

--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -111,15 +111,9 @@ public class SetupEnterURLFragment extends Fragment {
         }
         if(selectedPrefix < prefixURLSpinner.getCount() - 1) {
             url = prefixURLSpinner.getSelectedItem() + "/" + url;
-        } else { // prefix is "raw", autocomplete with http:// if needed
-            if (BuildConfig.DEBUG) {
-                if (!(prefixURLSpinner.getSelectedItem().toString().equalsIgnoreCase("raw"))) {
-                    throw new AssertionError("Last choice should be 'Raw'");
-                }
-            }
-            if(url.indexOf("://") == -1){ // if there is no (http|jr):// prefix, we'll assume it's a http:// URL
-                url = "http://" + url;
-            }
+        }
+        if(url.indexOf("://") == -1){ // if there is no (http|jr):// prefix, we'll assume it's a http:// URL
+            url = "http://" + url;
         }
         return url;
     }

--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -2,6 +2,7 @@ package org.commcare.android.fragments;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,6 +14,7 @@ import android.widget.TextView;
 
 import org.commcare.android.framework.ManagedUi;
 import org.commcare.android.framework.UiElement;
+import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.javarosa.core.services.locale.Localization;
 
@@ -22,6 +24,7 @@ import org.javarosa.core.services.locale.Localization;
  */
 @ManagedUi(R.layout.fragment_setup_enter_url)
 public class SetupEnterURLFragment extends Fragment {
+    public static final String TAG = SetupEnterURLFragment.class.getSimpleName();
 
     public interface URLInstaller {
         /**
@@ -87,9 +90,18 @@ public class SetupEnterURLFragment extends Fragment {
             return url;
         }
         // if it's not the last (which should be "Raw") choice, we'll use the prefix
+        if (BuildConfig.DEBUG) {
+            Log.v(TAG, "Selected prefix: " + selectedPrefix + ", selected item is: " + prefixURLSpinner.getSelectedItem());
+        }
         if(selectedPrefix < prefixURLSpinner.getCount() - 1) {
             url = prefixURLSpinner.getSelectedItem() + "/" + url;
-            if(!url.startsWith("http")){
+        } else { // prefix is "raw", autocomplete with http:// if needed
+            if (BuildConfig.DEBUG) {
+                if (!(prefixURLSpinner.getSelectedItem().toString().equalsIgnoreCase("raw"))) {
+                    throw new AssertionError("Last choice should be 'Raw'");
+                }
+            }
+            if(url.indexOf("://") == -1){ // if there is no (http|jr):// prefix, we'll assume it's a http:// URL
                 url = "http://" + url;
             }
         }


### PR DESCRIPTION
Autofilling the default location when user chooses 'Raw' prefix and automatically handling URLs without a :// prefix.

This complements #388.