### PR TITLE
Fix app crash in LoginActivity & persistently log any task crashes

### DIFF
--- a/app/src/org/commcare/android/tasks/ConnectionDiagnosticTask.java
+++ b/app/src/org/commcare/android/tasks/ConnectionDiagnosticTask.java
@@ -74,6 +74,8 @@ public abstract class ConnectionDiagnosticTask<R> extends CommCareTask<Void, Str
         this.c = c;
         this.platform = platform;
         this.taskId = CONNECTION_ID;
+
+        TAG = ConnectionDiagnosticTask.class.getSimpleName();
     }
     
     //onProgressUpdate(<B>)

--- a/app/src/org/commcare/android/tasks/DataPullTask.java
+++ b/app/src/org/commcare/android/tasks/DataPullTask.java
@@ -70,8 +70,6 @@ import android.util.Log;
  * @author ctsims
  */
 public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Integer, R> implements CommCareOTARestoreListener {
-    private static final String TAG = DataPullTask.class.getSimpleName();
-
     String server;
     String keyProvider;
     String username;
@@ -116,7 +114,6 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
     private static final boolean DEBUG_LOAD_FROM_LOCAL = false;
     private InputStream mDebugStream;
 
-    
     public DataPullTask(String username, String password, String server, String keyProvider, Context c) {
         this.server = server;
         this.keyProvider = keyProvider;
@@ -124,6 +121,8 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
         this.password = password;
         this.c = c;
         this.taskId = DATA_PULL_TASK_ID;
+
+        TAG = DataPullTask.class.getSimpleName();
     }
 
     /* (non-Javadoc)

--- a/app/src/org/commcare/android/tasks/FormTransferTask.java
+++ b/app/src/org/commcare/android/tasks/FormTransferTask.java
@@ -34,6 +34,8 @@ public abstract class FormTransferTask extends CommCareTask<String, String, Bool
         this.host = host;
         this.filepath = filepath;
         this.port = port;
+
+        TAG = FormTransferTask.class.getSimpleName();
     }
     
     public InputStream getFormInputStream(String fPath) throws FileNotFoundException{

--- a/app/src/org/commcare/android/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/android/tasks/ResourceEngineTask.java
@@ -134,6 +134,8 @@ public abstract class ResourceEngineTask<R>
         this.startOverUpgrade = startOverUpgrade;
         this.taskId = taskId;
         this.shouldSleep = shouldSleep;
+
+        TAG = ResourceEngineTask.class.getSimpleName();
     }
 
     /* (non-Javadoc)

--- a/app/src/org/commcare/android/tasks/UnzipTask.java
+++ b/app/src/org/commcare/android/tasks/UnzipTask.java
@@ -32,6 +32,8 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
         public UnzipTask() {
             Log.d(CommCareWiFiDirectActivity.TAG, "UnZip task constructor");
             this.taskId = UNZIP_TASK_ID;
+
+            TAG = UnzipTask.class.getSimpleName();
         }
 
         /*

--- a/app/src/org/commcare/android/tasks/templates/HttpCalloutTask.java
+++ b/app/src/org/commcare/android/tasks/templates/HttpCalloutTask.java
@@ -45,6 +45,8 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, or
     
     public HttpCalloutTask(Context c) {
         this.c = c;
+
+        TAG = HttpCalloutTask.class.getSimpleName();
     }
     
     protected Context getContext() {

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -229,6 +229,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                     @Override
                     protected void deliverResult( LoginActivity receiver, Integer result) {
                         if (result == null) {
+                            // The task crashed unexpectedly
                             receiver.raiseLoginMessage(StockMessages.Restore_Unknown, true);
                             return;
                         }

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -226,13 +226,13 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                  prefs.getString("ota-restore-url", LoginActivity.this.getString(R.string.ota_restore_url)),
                  prefs.getString("key_server", LoginActivity.this.getString(R.string.key_server)),
                  LoginActivity.this) {
-
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                     */
                     @Override
                     protected void deliverResult( LoginActivity receiver, Integer result) {
+                        if (result == null) {
+                            receiver.raiseLoginMessage(StockMessages.Restore_Unknown, true);
+                            return;
+                        }
+
                         switch(result) {
                         case DataPullTask.AUTH_FAILED:
                             receiver.raiseLoginMessage(StockMessages.Auth_BadCredentials, false);
@@ -328,7 +328,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
     
     private void refreshView() {
     }
-    
+
     private String getUsername() {
         return username.getText().toString().toLowerCase().trim();
     }


### PR DESCRIPTION
Don't try to switch on a null value, which occurs when the DataPullTask launched by LoginActivity errors out. Noticed this when looking at this crash from the play store crash reports: 
```
java.lang.NullPointerException
at org.commcare.dalvik.activities.LoginActivity$3.deliverResult(LoginActivity.java:181)
at org.commcare.dalvik.activities.LoginActivity$3.deliverResult(LoginActivity.java:173)
at org.commcare.android.tasks.templates.CommCareTask.onPostExecute(CommCareTask.java:83)
at android.os.AsyncTask.finish(AsyncTask.java:417)
at android.os.AsyncTask.access$300(AsyncTask.java:127)
at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:429)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:130)
at android.app.ActivityThread.main(ActivityThread.java:3821)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:507)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:839)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:597)
at dalvik.system.NativeStart.main(Native Method)
```

Also log task crashes persistently.