### PR TITLE
TreeElement.populate remove unused method argument

### DIFF
--- a/app/src/org/odk/collect/android/logic/FormController.java
+++ b/app/src/org/odk/collect/android/logic/FormController.java
@@ -456,8 +456,6 @@ public class FormController {
 
     /**
      * Creates a new repeated instance of the group referenced by the current FormIndex.
-     * 
-     * @param questionIndex
      */
     public void newRepeat() {
         mFormEntryController.newRepeat();

--- a/app/src/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/app/src/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -239,7 +239,7 @@ public class FormLoaderTask extends AsyncTask<Uri, String, FormLoaderTask.FECWra
             // populate the data model
             TreeReference tr = TreeReference.rootRef();
             tr.add(templateRoot.getName(), TreeReference.INDEX_UNBOUND);
-            templateRoot.populate(savedRoot, fec.getModel().getForm());
+            templateRoot.populate(savedRoot);
 
             // populated model to current form
             fec.getModel().getForm().getInstance().setRoot(templateRoot);


### PR DESCRIPTION
The FormDef parameter was unused in TreeElement.populate, so remove it.

Cross-request: https://github.com/dimagi/javarosa/pull/123