### PR TITLE
Remove 'non-javadoc' comments

### DIFF
--- a/app/src/org/commcare/android/adapters/CallRecordAdapter.java
+++ b/app/src/org/commcare/android/adapters/CallRecordAdapter.java
@@ -53,52 +53,38 @@ public class CallRecordAdapter implements ListAdapter {
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#areAllItemsEnabled()
-     */
+    @Override
     public boolean areAllItemsEnabled() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#isEnabled(int)
-     */
+    @Override
     public boolean isEnabled(int position) {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
+    @Override
     public int getCount() {
         return enabled.size();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
+    @Override
     public Object getItem(int position) {
         cursor.moveToPosition(enabled.get(position));
         return cursor.getString(cursor.getColumnIndex(Calls.NUMBER));
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
+    @Override
     public long getItemId(int position) {
         return enabled.get(position);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemViewType(int)
-     */
+    @Override
     public int getItemViewType(int position) {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
+    @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         cursor.moveToPosition(enabled.get(position));
         
@@ -140,38 +126,26 @@ public class CallRecordAdapter implements ListAdapter {
         
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getViewTypeCount()
-     */
+    @Override
     public int getViewTypeCount() {
         return 1;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#hasStableIds()
-     */
+    @Override
     public boolean hasStableIds() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         return this.getCount() > 0;
     }
     
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#registerDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void registerDataSetObserver(DataSetObserver observer) {
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#unregisterDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
     }
-
-
 }

--- a/app/src/org/commcare/android/adapters/EntityDetailAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntityDetailAdapter.java
@@ -58,51 +58,37 @@ public class EntityDetailAdapter implements ListAdapter {
         this.detailIndex = detailIndex;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#areAllItemsEnabled()
-     */
+    @Override
     public boolean areAllItemsEnabled() {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#isEnabled(int)
-     */
+    @Override
     public boolean isEnabled(int position) {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
+    @Override
     public int getCount() {
         return valid.size();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
+    @Override
     public Object getItem(int position) {
         return entity.getField(valid.get(position));
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
+    @Override
     public long getItemId(int position) {
         return valid.get(position);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemViewType(int)
-     */
+    @Override
     public int getItemViewType(int position) {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
+    @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         EntityDetailView dv =(EntityDetailView)convertView;
         if (dv == null) {
@@ -120,36 +106,26 @@ public class EntityDetailAdapter implements ListAdapter {
         return dv;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getViewTypeCount()
-     */
+    @Override
     public int getViewTypeCount() {
         return 1;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#hasStableIds()
-     */
+    @Override
     public boolean hasStableIds() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         return getCount() > 0;
     }
     
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#registerDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void registerDataSetObserver(DataSetObserver observer) {
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#unregisterDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
     }
 

--- a/app/src/org/commcare/android/adapters/EntityDetailPagerAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntityDetailPagerAdapter.java
@@ -36,10 +36,6 @@ public class EntityDetailPagerAdapter extends FragmentStatePagerAdapter {
         this.modifier = modifier;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentStatePagerAdapter#getItem(int)
-     */
     @Override
     public Fragment getItem(int i) {
         EntityDetailFragment fragment = new EntityDetailFragment();
@@ -60,10 +56,6 @@ public class EntityDetailPagerAdapter extends FragmentStatePagerAdapter {
         return (detail.isCompound() ? detail.getDetails()[position] : detail).getTitle().getText().evaluate();
     }
 
-    /*
-         * (non-Javadoc)
-         * @see android.support.v4.view.PagerAdapter#getCount()
-         */
     @Override
     public int getCount() {
         return detail.isCompound() ? detail.getDetails().length : 1;

--- a/app/src/org/commcare/android/adapters/EntityListAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntityListAdapter.java
@@ -419,26 +419,20 @@ public class EntityListAdapter implements ListAdapter {
         });
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#areAllItemsEnabled()
-     */
+    @Override
     public boolean areAllItemsEnabled() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#isEnabled(int)
-     */
+    @Override
     public boolean isEnabled(int position) {
         return true;
     }
 
-    /*
+    /**
      * Includes action, if enabled, as an item.
-     * 
-     * (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
      */
+    @Override
     public int getCount() {
         return getCount(false, false);
     }
@@ -458,16 +452,12 @@ public class EntityListAdapter implements ListAdapter {
         return (fullCount ? full.size() : current.size()) + (actionEnabled && !ignoreAction ? 1 : 0);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
+    @Override
     public TreeReference getItem(int position) {
         return current.get(position).getElement();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
+    @Override
     public long getItemId(int position) {
         if(actionEnabled) {
             if(position == actionPosition) {
@@ -477,9 +467,7 @@ public class EntityListAdapter implements ListAdapter {
         return references.indexOf(current.get(position).getElement());
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemViewType(int)
-     */
+    @Override
     public int getItemViewType(int position) {
         if(actionEnabled) {
             if(position == actionPosition) {
@@ -489,12 +477,11 @@ public class EntityListAdapter implements ListAdapter {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
-    /* Note that position gives a unique "row" id, EXCEPT that the header row AND the first content row
+    /**
+     * Note that position gives a unique "row" id, EXCEPT that the header row AND the first content row
      * are both assigned position 0 -- this is not an issue for current usage, but it could be in future
      */
+    @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         if(actionEnabled && position == actionPosition) {
             HorizontalMediaView tiav =(HorizontalMediaView)convertView;
@@ -542,23 +529,17 @@ public class EntityListAdapter implements ListAdapter {
 
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getViewTypeCount()
-     */
+    @Override
     public int getViewTypeCount() {
         return actionEnabled? 2 : 1;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#hasStableIds()
-     */
+    @Override
     public boolean hasStableIds() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         return getCount() > 0;
     }
@@ -585,16 +566,12 @@ public class EntityListAdapter implements ListAdapter {
         return reverseSort;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#registerDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void registerDataSetObserver(DataSetObserver observer) {
         this.observers.add(observer);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#unregisterDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
         this.observers.remove(observer);
     }

--- a/app/src/org/commcare/android/adapters/GridMenuAdapter.java
+++ b/app/src/org/commcare/android/adapters/GridMenuAdapter.java
@@ -23,9 +23,6 @@ public class GridMenuAdapter extends MenuAdapter {
         super(context, platform, menuID);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
     @Override
     public View getView(int i, View v, ViewGroup vg) {
 

--- a/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
@@ -195,10 +195,6 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
         return -1;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.BaseAdapter#notifyDataSetChanged()
-     */
     @Override
     public void notifyDataSetChanged() {
         super.notifyDataSetChanged();
@@ -207,10 +203,6 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.widget.BaseAdapter#notifyDataSetInvalidated()
-     */
     @Override
     public void notifyDataSetInvalidated() {
         super.notifyDataSetInvalidated();
@@ -220,52 +212,38 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#areAllItemsEnabled()
-     */
+    @Override
     public boolean areAllItemsEnabled() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#isEnabled(int)
-     */
+    @Override
     public boolean isEnabled(int i) {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
+    @Override
     public int getCount() {
         return current.size();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
+    @Override
     public Object getItem(int i) {
         return current.get(i);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
+    @Override
     public long getItemId(int i) {
         //Skeeeeetccchhyyyy maybe?
         return current.get(i).getID();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemViewType(int)
-     */
+    @Override
     public int getItemViewType(int i) {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
+    @Override
     public View getView(int i, View v, ViewGroup vg) {
         FormRecord r = current.get(i);
         IncompleteFormRecordView ifrv = (IncompleteFormRecordView)v;
@@ -289,23 +267,17 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
         return ifrv;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getViewTypeCount()
-     */
+    @Override
     public int getViewTypeCount() {
         return 1;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#hasStableIds()
-     */
+    @Override
     public boolean hasStableIds() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         return getCount() > 0;
     }
@@ -400,15 +372,11 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
     }
 
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#registerDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void registerDataSetObserver(DataSetObserver observer) {
         this.observers.add(observer);
     }
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#unregisterDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
         this.observers.remove(observer);
     }

--- a/app/src/org/commcare/android/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/android/adapters/MenuAdapter.java
@@ -154,37 +154,27 @@ public class MenuAdapter implements ListAdapter {
         displayableData = new MenuDisplayable[items.size()];
         items.copyInto(displayableData);
     }
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#areAllItemsEnabled()
-     */
+    @Override
     public boolean areAllItemsEnabled() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#isEnabled(int)
-     */
+    @Override
     public boolean isEnabled(int arg0) {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
+    @Override
     public int getCount() {
         return (displayableData.length);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
+    @Override
     public Object getItem(int i) {
         return displayableData[i];
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
+    @Override
     public long getItemId(int i) {
 
         Object tempItem = displayableData[i];
@@ -198,10 +188,7 @@ public class MenuAdapter implements ListAdapter {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.Adapter#getItemViewType(int)
-     */
+    @Override
     public int getItemViewType(int i) {
         return 0;
     }
@@ -212,9 +199,7 @@ public class MenuAdapter implements ListAdapter {
        ,JUMP
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
+    @Override
     public View getView(int i, View v, ViewGroup vg) {
         
         MenuDisplayable mObject = displayableData[i];
@@ -322,37 +307,27 @@ public class MenuAdapter implements ListAdapter {
 
 
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getViewTypeCount()
-     */
+    @Override
     public int getViewTypeCount() {
         return 1;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#hasStableIds()
-     */
+    @Override
     public boolean hasStableIds() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#registerDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void registerDataSetObserver(DataSetObserver arg0) {
 
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#unregisterDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void unregisterDataSetObserver(DataSetObserver arg0) {
 
     }

--- a/app/src/org/commcare/android/adapters/MessageRecordAdapter.java
+++ b/app/src/org/commcare/android/adapters/MessageRecordAdapter.java
@@ -64,52 +64,38 @@ public class MessageRecordAdapter implements ListAdapter {
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#areAllItemsEnabled()
-     */
+    @Override
     public boolean areAllItemsEnabled() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.ListAdapter#isEnabled(int)
-     */
+    @Override
     public boolean isEnabled(int position) {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
+    @Override
     public int getCount() {
         return enabled.size();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
+    @Override
     public Object getItem(int position) {
         cursor.moveToPosition(enabled.get(position));
         return cursor.getString(cursor.getColumnIndex("address"));
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
+    @Override
     public long getItemId(int position) {
         return enabled.get(position);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemViewType(int)
-     */
+    @Override
     public int getItemViewType(int position) {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
+    @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         cursor.moveToPosition(enabled.get(position));
         
@@ -148,36 +134,26 @@ public class MessageRecordAdapter implements ListAdapter {
         
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getViewTypeCount()
-     */
+    @Override
     public int getViewTypeCount() {
         return 1;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#hasStableIds()
-     */
+    @Override
     public boolean hasStableIds() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         return this.getCount() > 0;
     }
     
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#registerDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void registerDataSetObserver(DataSetObserver observer) {
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#unregisterDataSetObserver(android.database.DataSetObserver)
-     */
+    @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
     }
 

--- a/app/src/org/commcare/android/api/ExternalApiReceiver.java
+++ b/app/src/org/commcare/android/api/ExternalApiReceiver.java
@@ -46,70 +46,42 @@ public class ExternalApiReceiver extends BroadcastReceiver {
     
     CommCareTaskConnector dummyconnector = new CommCareTaskConnector() {
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTaskConnector#connectTask(org.commcare.android.tasks.templates.CommCareTask)
-         */
         @Override
         public void connectTask(CommCareTask task) {
             // TODO Auto-generated method stub
             
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTaskConnector#startBlockingForTask(int)
-         */
         @Override
         public void startBlockingForTask(int id) {
             // TODO Auto-generated method stub
             
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTaskConnector#stopBlockingForTask(int)
-         */
         @Override
         public void stopBlockingForTask(int id) {
             // TODO Auto-generated method stub
             
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTaskConnector#taskCancelled(int)
-         */
         @Override
         public void taskCancelled(int id) {
             // TODO Auto-generated method stub
             
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTaskConnector#getReceiver()
-         */
         @Override
         public Object getReceiver() {
             // TODO Auto-generated method stub
             return null;
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTaskConnector#startTaskTransition()
-         */
         @Override
         public void startTaskTransition() {
             // TODO Auto-generated method stub
             
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTaskConnector#stopTaskTransition()
-         */
         @Override
         public void stopTaskTransition() {
             // TODO Auto-generated method stub
@@ -118,9 +90,6 @@ public class ExternalApiReceiver extends BroadcastReceiver {
         
     };
 
-    /* (non-Javadoc)
-     * @see android.content.BroadcastReceiver#onReceive(android.content.Context, android.content.Intent)
-     */
     @Override
     public void onReceive(Context context, Intent intent) {
         if(!intent.hasExtra(AndroidSharedKeyRecord.EXTRA_KEY_ID)) {
@@ -174,10 +143,6 @@ public class ExternalApiReceiver extends BroadcastReceiver {
             }
             SharedPreferences settings = CommCareApplication._().getCurrentApp().getAppPreferences();
             ProcessAndSendTask<Object> mProcess = new ProcessAndSendTask<Object>(context, settings.getString("PostURL", context.getString(R.string.PostURL))) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                 */
                 @Override
                 protected void deliverResult(Object receiver, Integer result) {
                     if(result == FormUploadUtil.FULL_SUCCESS) {
@@ -191,20 +156,12 @@ public class ExternalApiReceiver extends BroadcastReceiver {
                     }
                 }
 
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                 */
                 @Override
                 protected void deliverUpdate(Object receiver, Long... update) {
                     // TODO Auto-generated method stub
                     
                 }
 
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                 */
                 @Override
                 protected void deliverError(Object receiver, Exception e) {
                     // TODO Auto-generated method stub
@@ -241,10 +198,6 @@ public class ExternalApiReceiver extends BroadcastReceiver {
 
         DataPullTask<Object> mDataPullTask = new DataPullTask<Object>(u.getUsername(), u.getCachedPwd(), prefs.getString("ota-restore-url",c.getString(R.string.ota_restore_url)), "", c) {
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult(Object receiver, Integer result) {
                 if(result != DataPullTask.DOWNLOAD_SUCCESS) {
@@ -254,20 +207,12 @@ public class ExternalApiReceiver extends BroadcastReceiver {
                 }
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(Object receiver, Integer... update) {
                 // TODO Auto-generated method stub
                 
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(Object receiver, Exception e) {
                 // TODO Auto-generated method stub
@@ -337,10 +282,6 @@ public class ExternalApiReceiver extends BroadcastReceiver {
                 }
 
             }) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                 */
                 @Override
                 protected void deliverUpdate(Object r, String... update) {
                 }

--- a/app/src/org/commcare/android/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/android/cases/AndroidCaseInstanceTreeElement.java
@@ -61,10 +61,6 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         Log.d(TAG, "Case iterate took: " + value + "ms");
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.cases.util.StorageBackedTreeRoot#union(java.util.Vector, java.util.Vector)
-     */
     @Override
     protected Vector<Integer> union(Vector<Integer> selectedCases, Vector<Integer> cases) {
         return DataUtil.union(selectedCases, cases);
@@ -199,10 +195,6 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
     
     String[][] mMostRecentBatchFetch = null;
     
-    /*
-     * ](non-Javadoc)
-     * @see org.javarosa.core.model.utils.CacheHost#guessCachePrimer()
-     */
     @Override
     public String[][] getCachePrimeGuess() { 
         return mMostRecentBatchFetch;

--- a/app/src/org/commcare/android/cases/AndroidLedgerInstanceTreeElement.java
+++ b/app/src/org/commcare/android/cases/AndroidLedgerInstanceTreeElement.java
@@ -57,10 +57,6 @@ public class AndroidLedgerInstanceTreeElement extends LedgerInstanceTreeElement 
     }
     
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.cases.util.StorageBackedTreeRoot#union(java.util.Vector, java.util.Vector)
-     */
     @Override
     protected Vector<Integer> union(Vector<Integer> selectedCases, Vector<Integer> cases) {
         //This is kind of (ok, so really) awkward looking, but we can't use sets in 

--- a/app/src/org/commcare/android/database/ConcreteDbHelper.java
+++ b/app/src/org/commcare/android/database/ConcreteDbHelper.java
@@ -18,10 +18,6 @@ public class ConcreteDbHelper extends DbHelper {
         this.handle = handle;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.database.DbHelper#getHandle()
-     */
     @Override
     public SQLiteDatabase getHandle() {
         return handle;

--- a/app/src/org/commcare/android/database/DirectDbHelper.java
+++ b/app/src/org/commcare/android/database/DirectDbHelper.java
@@ -17,10 +17,6 @@ public class DirectDbHelper extends DbHelper {
         handle = database;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.database.DbHelper#getHandle()
-     */
     @Override
     public SQLiteDatabase getHandle() {
         return handle;

--- a/app/src/org/commcare/android/database/IndexSpanningIterator.java
+++ b/app/src/org/commcare/android/database/IndexSpanningIterator.java
@@ -79,9 +79,7 @@ public class IndexSpanningIterator<T extends Persistable> extends SqlStorageIter
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#hasMore()
-     */
+    @Override
     public boolean hasMore() {
         //See whether we're ahead of the next gap. If we are, there are valid
         //ids remaining
@@ -150,9 +148,7 @@ public class IndexSpanningIterator<T extends Persistable> extends SqlStorageIter
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#nextID()
-     */
+    @Override
     public int nextID() {
         int ret = current;
         current++;
@@ -165,9 +161,7 @@ public class IndexSpanningIterator<T extends Persistable> extends SqlStorageIter
         return ret;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#nextRecord()
-     */
+    @Override
     public T nextRecord() {
         T t = storage.read(this.peekID());
         nextID();
@@ -175,9 +169,7 @@ public class IndexSpanningIterator<T extends Persistable> extends SqlStorageIter
         return t;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#numRecords()
-     */
+    @Override
     public int numRecords() {
         return count;
     }

--- a/app/src/org/commcare/android/database/SqlStorage.java
+++ b/app/src/org/commcare/android/database/SqlStorage.java
@@ -66,9 +66,6 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtilityIndexed#getIDsForValue(java.lang.String, java.lang.Object)
-     */
     @Override
     public Vector<Integer> getIDsForValue(String fieldName, Object value) {
         return getIDsForValues(new String[] {fieldName}, new Object[] { value} );
@@ -180,9 +177,6 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return newObject(data);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtilityIndexed#getRecordForValue(java.lang.String, java.lang.Object)
-     */
     @Override
     public T getRecordForValue(String rawFieldName, Object value) throws NoSuchElementException, InvalidIndexException {
         SQLiteDatabase db;
@@ -239,9 +233,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return re;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#add(org.javarosa.core.util.externalizable.Externalizable)
-     */
+    @Override
     public int add(Externalizable e) throws StorageFullException {
         SQLiteDatabase db;
         try {
@@ -268,9 +260,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return i;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#close()
-     */
+    @Override
     public void close() {
         try {
             helper.getHandle().close();
@@ -279,16 +269,12 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#destroy()
-     */
+    @Override
     public void destroy() {
         //nothing;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#exists(int)
-     */
+    @Override
     public boolean exists(int id) {
         Cursor c;
         try {
@@ -309,9 +295,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getAccessLock()
-     */
+    @Override
     public SQLiteDatabase getAccessLock() {
         try {
             return helper.getHandle();
@@ -320,9 +304,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getNumRecords()
-     */
+    @Override
     public int getNumRecords() {
         Cursor c;
         try {
@@ -335,25 +317,19 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return records;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getRecordSize(int)
-     */
+    @Override
     public int getRecordSize(int id) {
         //serialize and test blah blah.
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getTotalSize()
-     */
+    @Override
     public int getTotalSize() {
         //serialize and test blah blah.
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         if(getNumRecords() == 0) {
             return true;
@@ -361,9 +337,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#iterate()
-     */
+    @Override
     public SqlStorageIterator<T> iterate() {
         return iterate(true);
     }
@@ -453,16 +427,12 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return iterate();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#read(int)
-     */
+    @Override
     public T read(int id) {
         return newObject(readBytes(id));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#readBytes(int)
-     */
+    @Override
     public byte[] readBytes(int id) {
         Cursor c;
         try {
@@ -477,9 +447,6 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return blob;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#remove(int)
-     */
     @Override
     public void remove(int id) {
         SQLiteDatabase db;
@@ -517,17 +484,11 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         }    
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#remove(org.javarosa.core.services.storage.Persistable)
-     */
     @Override
     public void remove(Persistable p) {
         this.remove(p.getID());
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#removeAll()
-     */
     @Override
     public void removeAll() {
         SQLiteDatabase db;
@@ -545,9 +506,6 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#removeAll(org.javarosa.core.services.storage.EntityFilter)
-     */
     @Override
     public Vector<Integer> removeAll(EntityFilter ef) {
         Vector<Integer> removed = new Vector<Integer>();
@@ -589,25 +547,16 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return removed;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#repack()
-     */
     @Override
     public void repack() {
         //Unecessary!
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#repair()
-     */
     @Override
     public void repair() {
         //Unecessary!
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#update(int, org.javarosa.core.util.externalizable.Externalizable)
-     */
     @Override
     public void update(int id, Externalizable e) throws StorageFullException {
         SQLiteDatabase db;
@@ -625,9 +574,6 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#write(org.javarosa.core.services.storage.Persistable)
-     */
     @Override
     public void write(Persistable p) throws StorageFullException {
         if(p.getID() != -1) {

--- a/app/src/org/commcare/android/database/SqlStorageIterator.java
+++ b/app/src/org/commcare/android/database/SqlStorageIterator.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.database;
 
 import java.util.Iterator;
@@ -56,9 +53,7 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
         }
     }
     
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#hasMore()
-     */
+    @Override
     public boolean hasMore() {
         if(!c.isClosed()) {
             return !c.isAfterLast();
@@ -73,9 +68,7 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#nextID()
-     */
+    @Override
     public int nextID() {
         int id = c.getInt(c.getColumnIndexOrThrow(DbUtil.ID_COL));
         c.moveToNext();
@@ -86,9 +79,7 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
         return id;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#nextRecord()
-     */
+    @Override
     public T nextRecord() {
         byte[] data = c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
         
@@ -97,9 +88,7 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
         return storage.newObject(data);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#numRecords()
-     */
+    @Override
     public int numRecords() {
         return count;
     }
@@ -123,9 +112,6 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
 
     //TESTING ONLY
     
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageIterator#nextRecord()
-     */
     private byte[] getBlob() {
         byte[] data = c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
 

--- a/app/src/org/commcare/android/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/android/database/app/DatabaseAppOpenHelper.java
@@ -50,9 +50,6 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
         return DB_LOCATOR_PREF_APP + appId;
     }
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onCreate(android.database.sqlite.SQLiteDatabase)
-     */
     @Override
     public void onCreate(SQLiteDatabase database) {
         try {
@@ -99,9 +96,6 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
     }
 
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onUpgrade(android.database.sqlite.SQLiteDatabase, int, int)
-     */
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         new AppDatabaseUpgrader(context).upgrade(db, oldVersion, newVersion);

--- a/app/src/org/commcare/android/database/app/models/ResourceModelUpdater.java
+++ b/app/src/org/commcare/android/database/app/models/ResourceModelUpdater.java
@@ -39,9 +39,6 @@ public class ResourceModelUpdater extends Resource {
         
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.Resource#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         this.recordId = ExtUtil.readInt(in);
@@ -55,10 +52,7 @@ public class ResourceModelUpdater extends Resource {
         this.initializer = (ResourceInstaller)ExtUtil.read(in, new ExtWrapTagged(), pf);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out,recordId);
         ExtUtil.writeNumeric(out,version);

--- a/app/src/org/commcare/android/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/android/database/global/DatabaseGlobalOpenHelper.java
@@ -39,9 +39,6 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
         this.mContext = context;
     }
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onCreate(android.database.sqlite.SQLiteDatabase)
-     */
     @Override
     public void onCreate(SQLiteDatabase database) {
         
@@ -80,9 +77,6 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
     
     
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onUpgrade(android.database.sqlite.SQLiteDatabase, int, int)
-     */
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         new GlobalDatabaseUpgrader(mContext).upgrade(db, oldVersion, newVersion);

--- a/app/src/org/commcare/android/database/user/CommCareUserOpenHelper.java
+++ b/app/src/org/commcare/android/database/user/CommCareUserOpenHelper.java
@@ -59,9 +59,6 @@ public class CommCareUserOpenHelper extends SQLiteOpenHelper {
         return USER_DB_LOCATOR + sandboxId;
     }
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onCreate(android.database.sqlite.SQLiteDatabase)
-     */
     @Override
     public void onCreate(SQLiteDatabase database) {
 
@@ -133,9 +130,6 @@ public class CommCareUserOpenHelper extends SQLiteOpenHelper {
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onUpgrade(android.database.sqlite.SQLiteDatabase, int, int)
-     */
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         boolean inSenseMode = false;

--- a/app/src/org/commcare/android/database/user/UserSandboxUtils.java
+++ b/app/src/org/commcare/android/database/user/UserSandboxUtils.java
@@ -66,10 +66,6 @@ public class UserSandboxUtils {
             
             //If we were able to iterate over the users, the key was fine, so let's use it to open our db
             DbHelper dbh = new DbHelper(c) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.database.DbHelper#getHandle()
-                 */
                 @Override
                 public SQLiteDatabase getHandle() {
                     return db;
@@ -202,10 +198,6 @@ public class UserSandboxUtils {
         
         try {
             DbHelper dbh = new DbHelper(context) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.database.DbHelper#getHandle()
-                 */
                 @Override
                 public SQLiteDatabase getHandle() {
                     return db;

--- a/app/src/org/commcare/android/database/user/models/ACasePreV6Model.java
+++ b/app/src/org/commcare/android/database/user/models/ACasePreV6Model.java
@@ -40,9 +40,6 @@ public class ACasePreV6Model extends ACase {
         
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.Resource#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         typeId = ExtUtil.readString(in);
@@ -55,10 +52,6 @@ public class ACasePreV6Model extends ACase {
         data = (Hashtable)ExtUtil.read(in, new ExtWrapMapPoly(String.class, true), pf);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, typeId);
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(id));
@@ -79,9 +72,7 @@ public class ACasePreV6Model extends ACase {
             
         }
 
-        /* (non-Javadoc)
-         * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-         */
+        @Override
         public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
             mName = ExtUtil.readString(in);
             mTargetId = ExtUtil.readString(in);
@@ -89,9 +80,7 @@ public class ACasePreV6Model extends ACase {
             mRelationship = CaseIndex.RELATIONSHIP_CHILD;
         }
 
-        /* (non-Javadoc)
-         * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-         */
+        @Override
         public void writeExternal(DataOutputStream out) throws IOException {
             ExtUtil.writeString(out, mName);
             ExtUtil.writeString(out, mTargetId);

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -160,10 +160,6 @@ public class FormRecord extends Persisted implements EncryptedModel {
         return c.getString(c.getColumnIndex(InstanceColumns.INSTANCE_FILE_PATH));
     }
     
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return String.format("Form Record[%s][Status: %s]\n[Form: %s]\n[Last Modified: %s]", this.recordId, this.status, this.xmlns, this.lastModified.toString());

--- a/app/src/org/commcare/android/db/legacy/DecryptingCursor.java
+++ b/app/src/org/commcare/android/db/legacy/DecryptingCursor.java
@@ -27,10 +27,6 @@ public class DecryptingCursor extends SQLiteCursor {
         this.cipher = pool.borrow();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.database.AbstractWindowedCursor#getBlob(int)
-     */
     @Override
     public byte[] getBlob(int columnIndex) {
         if(!isEncrypted(columnIndex)) {
@@ -40,10 +36,6 @@ public class DecryptingCursor extends SQLiteCursor {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.database.AbstractWindowedCursor#getDouble(int)
-     */
     @Override
     public double getDouble(int columnIndex) {
         if(!isEncrypted(columnIndex)) {
@@ -53,10 +45,6 @@ public class DecryptingCursor extends SQLiteCursor {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.database.AbstractWindowedCursor#getFloat(int)
-     */
     @Override
     public float getFloat(int columnIndex) {
         if(!isEncrypted(columnIndex)) {
@@ -66,10 +54,6 @@ public class DecryptingCursor extends SQLiteCursor {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.database.AbstractWindowedCursor#getInt(int)
-     */
     @Override
     public int getInt(int columnIndex) {
         if(!isEncrypted(columnIndex)) {
@@ -79,10 +63,6 @@ public class DecryptingCursor extends SQLiteCursor {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.database.AbstractWindowedCursor#getLong(int)
-     */
     @Override
     public long getLong(int columnIndex) {
         if(!isEncrypted(columnIndex)) {
@@ -92,10 +72,6 @@ public class DecryptingCursor extends SQLiteCursor {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.database.AbstractWindowedCursor#getShort(int)
-     */
     @Override
     public short getShort(int columnIndex) {
         if(!isEncrypted(columnIndex)) {
@@ -105,10 +81,6 @@ public class DecryptingCursor extends SQLiteCursor {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.database.AbstractWindowedCursor#getString(int)
-     */
     @Override
     public String getString(int columnIndex) {
         if(!isEncrypted(columnIndex)) {
@@ -171,9 +143,6 @@ public class DecryptingCursor extends SQLiteCursor {
     }
     
     
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteCursor#close()
-     */
     @Override
     public void close() {
         super.close();

--- a/app/src/org/commcare/android/db/legacy/LegacyCommCareDBCursorFactory.java
+++ b/app/src/org/commcare/android/db/legacy/LegacyCommCareDBCursorFactory.java
@@ -36,9 +36,7 @@ public class LegacyCommCareDBCursorFactory implements CursorFactory {
         this.models = models;
     }
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteDatabase.CursorFactory#newCursor(android.database.sqlite.SQLiteDatabase, android.database.sqlite.SQLiteCursorDriver, java.lang.String, android.database.sqlite.SQLiteQuery)
-     */
+    @Override
     public Cursor newCursor(SQLiteDatabase db, SQLiteCursorDriver masterQuery, String editTable, SQLiteQuery query) {
         if(models == null || !models.containsKey(editTable)) {
             return new SQLiteCursor(db, masterQuery, editTable, query);

--- a/app/src/org/commcare/android/db/legacy/LegacyCommCareOpenHelper.java
+++ b/app/src/org/commcare/android/db/legacy/LegacyCommCareOpenHelper.java
@@ -43,9 +43,6 @@ public class LegacyCommCareOpenHelper extends SQLiteOpenHelper {
         this.context = context;
     }
     
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onCreate(android.database.sqlite.SQLiteDatabase)
-     */
     @Override
     public void onCreate(SQLiteDatabase database) {
         try {
@@ -102,9 +99,6 @@ public class LegacyCommCareOpenHelper extends SQLiteOpenHelper {
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.database.sqlite.SQLiteOpenHelper#onUpgrade(android.database.sqlite.SQLiteDatabase, int, int)
-     */
     @Override
     public void onUpgrade(SQLiteDatabase database, int oldVersion, int newVersion) {
         LegacyCommCareUpgrader upgrader = new LegacyCommCareUpgrader(context);

--- a/app/src/org/commcare/android/db/legacy/LegacyInstallUtils.java
+++ b/app/src/org/commcare/android/db/legacy/LegacyInstallUtils.java
@@ -126,10 +126,6 @@ public class LegacyInstallUtils {
         //get the legacy storage
         final android.database.sqlite.SQLiteDatabase olddb = new LegacyCommCareOpenHelper(c).getReadableDatabase();
         LegacyDbHelper ldbh = new LegacyDbHelper(c) {
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.db.legacy.LegacyDbHelper#getHandle()
-             */
             @Override
             public android.database.sqlite.SQLiteDatabase getHandle() {
                 return olddb;
@@ -381,10 +377,6 @@ public class LegacyInstallUtils {
                 Object lock = new Object();
                 byte[] key = oldKey;
     
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.crypt.CipherPool#generateNewCipher()
-                 */
                 @Override
                 public Cipher generateNewCipher() {
                     synchronized(lock) {
@@ -423,10 +415,6 @@ public class LegacyInstallUtils {
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, "LegacyUser| Legacy DB Opened");
             
             LegacyDbHelper ldbh = new LegacyDbHelper(c, pool.borrow()) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.db.legacy.LegacyDbHelper#getHandle()
-                 */
                 @Override
                 public android.database.sqlite.SQLiteDatabase getHandle() {
                     return olddb;
@@ -468,10 +456,6 @@ public class LegacyInstallUtils {
             final SQLiteDatabase currentUserDatabase = ourDb;
             
             DbHelper newDbHelper = new DbHelper(c) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.database.DbHelper#getHandle()
-                 */
                 @Override
                 public SQLiteDatabase getHandle() {
                     return currentUserDatabase;

--- a/app/src/org/commcare/android/db/legacy/LegacySqlIndexedStorageUtility.java
+++ b/app/src/org/commcare/android/db/legacy/LegacySqlIndexedStorageUtility.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.db.legacy;
 
 import java.io.ByteArrayInputStream;
@@ -59,9 +56,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtilityIndexed#getIDsForValue(java.lang.String, java.lang.Object)
-     */
+    @Override
     public Vector getIDsForValue(String fieldName, Object value) {
         return getIDsForValues(new String[] {fieldName}, new Object[] { value} );
     }
@@ -121,9 +116,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
 
     }
     
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtilityIndexed#getRecordForValue(java.lang.String, java.lang.Object)
-     */
+    @Override
     public T getRecordForValues(String[] rawFieldNames, Object[] values) throws NoSuchElementException, InvalidIndexException {
         Pair<String, String[]> whereClause = helper.createWhere(rawFieldNames, values, em, t);
         Cursor c = helper.getHandle().query(table, new String[] {DbUtil.ID_COL, DbUtil.DATA_COL} , whereClause.first, whereClause.second,null, null, null);
@@ -139,9 +132,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return newObject(data);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtilityIndexed#getRecordForValue(java.lang.String, java.lang.Object)
-     */
+    @Override
     public T getRecordForValue(String rawFieldName, Object value) throws NoSuchElementException, InvalidIndexException {
         Pair<String, String[]> whereClause = helper.createWhere(new String[] {rawFieldName}, new Object[] {value}, em, t);
         String scrubbedName = TableBuilder.scrubName(rawFieldName);
@@ -183,9 +174,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#add(org.javarosa.core.util.externalizable.Externalizable)
-     */
+    @Override
     public int add(Externalizable e) throws StorageFullException {
         SQLiteDatabase db = helper.getHandle();
         int i = -1;
@@ -207,23 +196,17 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return i;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#close()
-     */
+    @Override
     public void close() {
         helper.getHandle().close();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#destroy()
-     */
+    @Override
     public void destroy() {
         //nothing;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#exists(int)
-     */
+    @Override
     public boolean exists(int id) {
         Cursor c = helper.getHandle().query(table, new String[] {DbUtil.ID_COL} , DbUtil.ID_COL +"= ? ", new String[] {String.valueOf(id)}, null, null, null);
         if(c.getCount() == 0) {
@@ -238,17 +221,13 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getAccessLock()
-     */
+    @Override
     public net.sqlcipher.database.SQLiteDatabase getAccessLock() {
         // TODO Auto-generated method stub
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getNumRecords()
-     */
+    @Override
     public int getNumRecords() {
         Cursor c = helper.getHandle().query(table, new String[] {DbUtil.ID_COL} , null, null, null, null, null);
         int records = c.getCount();
@@ -256,25 +235,19 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return records;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getRecordSize(int)
-     */
+    @Override
     public int getRecordSize(int id) {
         //serialize and test blah blah.
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#getTotalSize()
-     */
+    @Override
     public int getTotalSize() {
         //serialize and test blah blah.
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#isEmpty()
-     */
+    @Override
     public boolean isEmpty() {
         if(getNumRecords() == 0) {
             return true;
@@ -282,9 +255,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#iterate()
-     */
+    @Override
     public SqlStorageIterator<T> iterate() {
         Cursor c = helper.getHandle().query(table, new String[] {DbUtil.ID_COL, DbUtil.DATA_COL} , null, null, null, null, DbUtil.ID_COL);
         return new SqlStorageIterator<T>(c, this);
@@ -294,16 +265,12 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return iterate();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#read(int)
-     */
+    @Override
     public T read(int id) {
         return newObject(readBytes(id));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#readBytes(int)
-     */
+    @Override
     public byte[] readBytes(int id) {
         Cursor c = helper.getHandle().query(table, new String[] {DbUtil.ID_COL, DbUtil.DATA_COL} , DbUtil.ID_COL +"=?", new String[] {String.valueOf(id)}, null, null, null);
         
@@ -313,9 +280,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return blob;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#remove(int)
-     */
+    @Override
     public void remove(int id) {
         SQLiteDatabase db = helper.getHandle();
         db.beginTransaction();
@@ -327,9 +292,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         }    
     }
     
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#remove(int)
-     */
+    @Override
     public void remove(List ids) {
         if(ids.size() == 0 ) { return; }
         SQLiteDatabase db = helper.getHandle();
@@ -345,16 +308,12 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         }    
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#remove(org.javarosa.core.services.storage.Persistable)
-     */
+    @Override
     public void remove(Persistable p) {
         this.remove(p.getID());
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#removeAll()
-     */
+    @Override
     public void removeAll() {
         SQLiteDatabase db = helper.getHandle();
         db.beginTransaction();
@@ -366,9 +325,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#removeAll(org.javarosa.core.services.storage.EntityFilter)
-     */
+    @Override
     public Vector<Integer> removeAll(EntityFilter ef) {
         Vector<Integer> removed = new Vector<Integer>();
         for(IStorageIterator iterator = this.iterate() ; iterator.hasMore() ;) {
@@ -404,23 +361,17 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         return removed;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#repack()
-     */
+    @Override
     public void repack() {
         //Unecessary!
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#repair()
-     */
+    @Override
     public void repair() { 
         //Unecessary!
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#update(int, org.javarosa.core.util.externalizable.Externalizable)
-     */
+    @Override
     public void update(int id, Externalizable e) throws StorageFullException {
         SQLiteDatabase db = helper.getHandle();
         db.beginTransaction();
@@ -432,9 +383,7 @@ public class LegacySqlIndexedStorageUtility<T extends Persistable> extends SqlSt
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IStorageUtility#write(org.javarosa.core.services.storage.Persistable)
-     */
+    @Override
     public void write(Persistable p) throws StorageFullException {
         if(p.getID() != -1) {
             update(p.getID(), p);

--- a/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
@@ -57,10 +57,7 @@ public class BreadcrumbBarFragment extends Fragment {
     private boolean isTopNavEnabled = false;
     private int localIdPart = -1;
      
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onCreate(android.os.Bundle)
-     * 
+    /**
      * This method will only be called once when the retained
      * Fragment is first created.
      */
@@ -74,11 +71,7 @@ public class BreadcrumbBarFragment extends Fragment {
      
       
     boolean breadCrumbsEnabled = true;
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.support.v4.app.Fragment#onAttach(android.app.Activity)
-     * 
+    /**
      * Hold a reference to the parent Activity so we can report the task's
      * current progress and results. The Android framework will pass us a
      * reference to the newly created Activity after each configuration change.
@@ -315,9 +308,6 @@ public class BreadcrumbBarFragment extends Fragment {
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onResume()
-     */
     @Override
     public void onResume() {
         super.onResume();
@@ -407,10 +397,6 @@ public class BreadcrumbBarFragment extends Fragment {
             
             RelativeLayout layout = new RelativeLayout(activity);
             HorizontalScrollView scroller = new HorizontalScrollView(activity) {
-                /*
-                 * (non-Javadoc)
-                 * @see android.widget.HorizontalScrollView#onLayout(boolean, int, int, int, int)
-                 */
                 @Override
                 protected void onLayout(boolean changed, int l, int t, int r, int b) {
                     super.onLayout(changed, l, t, r, b);
@@ -482,10 +468,6 @@ public class BreadcrumbBarFragment extends Fragment {
                 
                     OnClickListener stepBackListener = new OnClickListener() {
 
-                        /*
-                         * (non-Javadoc)
-                         * @see android.view.View.OnClickListener#onClick(android.view.View)
-                         */
                         @Override
                         public void onClick(View arg0) {
                             
@@ -539,10 +521,6 @@ public class BreadcrumbBarFragment extends Fragment {
             //Finally add the "top level" breadcrumb that represents the application's home. 
             addElementToTitle(li, layout, topLevel, org.commcare.dalvik.R.layout.component_title_breadcrumb, currentId, new OnClickListener() {
 
-                /*
-                 * (non-Javadoc)
-                 * @see android.view.View.OnClickListener#onClick(android.view.View)
-                 */
                 @Override
                 public void onClick(View arg0) {
                     try{

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -78,10 +78,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public static final String KEY_LAST_QUERY_STRING = "LAST_QUERY_STRING";
     protected String lastQueryString;
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onCreate(android.os.Bundle)
-     */
     @Override
     @TargetApi(14)
     protected void onCreate(Bundle savedInstanceState) {
@@ -128,10 +124,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -202,9 +194,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         return false;
     }
     
-    /* (non-Javadoc)
-     * @see android.app.Activity#onResume()
-     */
     @Override
     @TargetApi(11)
     protected void onResume() {
@@ -218,9 +207,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         AudioController.INSTANCE.playPreviousAudio();
     }
     
-    /* (non-Javadoc)
-     * @see android.app.Activity#onPause()
-     */
     @Override
     protected void onPause() {
         super.onPause();
@@ -228,9 +214,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         AudioController.INSTANCE.systemInducedPause();
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#connectTask(org.commcare.android.tasks.templates.CommCareTask)
-     */
     @Override
     public <A, B, C> void connectTask(CommCareTask<A, B, C, R> task) {
         //If stateHolder is null here, it's because it is restoring itself, it doesn't need
@@ -246,18 +229,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#getReceiver()
-     */
     @Override
     public R getReceiver() {
         return (R)this;
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#startBlockingForTask()
-     * 
+    /**
      * Override these to control the UI for your task
      */
     @Override
@@ -271,9 +248,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#stopBlockingForTask()
-     */
     @Override
     public void stopBlockingForTask(int id) {
         if (id >= 0) { 
@@ -287,19 +261,11 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         unlock();
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#startTaskTransition()
-     */
     @Override
     public void startTaskTransition() {
         inTaskTransition = true;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#stopTaskTransition()
-     */
     @Override
     public void stopTaskTransition() {
         inTaskTransition = false;
@@ -337,10 +303,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         mAlertDialog.setTitle(Localization.get("notification.case.predicate.title"));
         mAlertDialog.setMessage(Localization.get("notification.case.predicate.action", new String[] {mErrorMessage}));
         DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-             */
             @Override
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {
@@ -355,9 +317,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         mAlertDialog.show();
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#taskCancelled(int)
-     */
     @Override
     public void taskCancelled(int id) {
         
@@ -367,10 +326,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         stateHolder.cancelTask();
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onStop()
-     */
     @Override
     public void onStop() {
         super.onStop();
@@ -493,10 +448,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         dialog.setTitle(StringUtils.getStringRobust(activity, org.commcare.dalvik.R.string.error_occured));
         dialog.setMessage(errorMsg);
         DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-             */
             @Override
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {
@@ -517,10 +468,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     /** All methods for implementation of DialogController **/
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.dalvik.dialogs.DialogController#updateProgress(java.lang.String, int)
-     */
     @Override
     public void updateProgress(String updateText, int taskId) {
         CustomProgressDialog mProgressDialog = getCurrentDialog();
@@ -536,10 +483,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.dalvik.dialogs.DialogController#updateProgressBar(int, int, int)
-     */
     @Override
     public void updateProgressBar(int progress, int max, int taskId) {
         CustomProgressDialog mProgressDialog = getCurrentDialog();
@@ -555,10 +498,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.dalvik.dialogs.DialogController#showProgressDialog(int)
-     */
     @Override
     public void showProgressDialog(int taskId) {
         CustomProgressDialog dialog = generateProgressDialog(taskId);
@@ -567,20 +506,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.dalvik.dialogs.DialogController#getCurrentDialog()
-     */
     @Override
     public CustomProgressDialog getCurrentDialog() {
         return (CustomProgressDialog) getSupportFragmentManager().
                 findFragmentByTag(KEY_DIALOG_FRAG);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.dalvik.dialogs.DialogController#dismissProgressDialog()
-     */
     @Override
     public void dismissProgressDialog() {
         CustomProgressDialog mProgressDialog = getCurrentDialog();
@@ -589,10 +520,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.dalvik.dialogs.DialogController#generateProgressDialog(int)
-     */
     @Override
     public CustomProgressDialog generateProgressDialog(int taskId) {
         //dummy method for compilation, implementation handled in those subclasses that need it
@@ -663,29 +590,17 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         return true;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#dispatchTouchEvent(android.view.MotionEvent)
-     */
     @Override
     public boolean dispatchTouchEvent(MotionEvent mv) {
         return !(mGestureDetector == null || !mGestureDetector.onTouchEvent(mv)) || super.dispatchTouchEvent(mv);
 
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onDown(android.view.MotionEvent)
-     */
     @Override
     public boolean onDown(MotionEvent arg0) {
         return false;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onFling(android.view.MotionEvent, android.view.MotionEvent, float, float)
-     */
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
         if (isHorizontalSwipe(this, e1, e2)) {
@@ -714,37 +629,21 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         return false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onLongPress(android.view.MotionEvent)
-     */
     @Override
     public void onLongPress(MotionEvent arg0) {
         // ignore
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onScroll(android.view.MotionEvent, android.view.MotionEvent, float, float)
-     */
     @Override
     public boolean onScroll(MotionEvent arg0, MotionEvent arg1, float arg2, float arg3) {
         return false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onShowPress(android.view.MotionEvent)
-     */
     @Override
     public void onShowPress(MotionEvent arg0) {
         // ignore
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onSingleTapUp(android.view.MotionEvent)
-     */
     @Override
     public boolean onSingleTapUp(MotionEvent arg0) {
         return false;

--- a/app/src/org/commcare/android/framework/DeviceDetailFragment.java
+++ b/app/src/org/commcare/android/framework/DeviceDetailFragment.java
@@ -49,29 +49,17 @@ public class DeviceDetailFragment extends Fragment implements ConnectionInfoList
     final String targetDirectory = baseDirectory + "/target";
     final String zipDirectory = baseDirectory + "/zipfolder.zip";
 
-	/*
-	 * (non-Javadoc)
-	 * @see android.support.v4.app.Fragment#onActivityCreated(android.os.Bundle)
-	 */
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)
-     */
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         mContentView = inflater.inflate(R.layout.device_detail, container);
         return mContentView;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.net.wifi.p2p.WifiP2pManager.ConnectionInfoListener#onConnectionInfoAvailable(android.net.wifi.p2p.WifiP2pInfo)
-     */
     @Override
     public void onConnectionInfoAvailable(final WifiP2pInfo info) {
         Log.d(CommCareWiFiDirectActivity.TAG, "onConnectionInfoAvailable");

--- a/app/src/org/commcare/android/framework/DeviceListFragment.java
+++ b/app/src/org/commcare/android/framework/DeviceListFragment.java
@@ -53,10 +53,6 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
     View mContentView = null;
     private WifiP2pDevice device;
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onActivityCreated(android.os.Bundle)
-     */
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
@@ -64,10 +60,6 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
 
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.ListFragment#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)
-     */
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         Log.d(CommCareWiFiDirectActivity.TAG, "onCreateView DeviceListFragment");
@@ -101,10 +93,7 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.ListFragment#onListItemClick(android.widget.ListView, android.view.View, int, long)
-     * 
+    /**
      * Initiate a connection with the peer.
      */
     @Override
@@ -146,10 +135,6 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
 
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#getView(int, android.view.View, android.view.ViewGroup)
-         */
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
             View v = convertView;
@@ -189,10 +174,6 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
         view.setText(getDeviceStatus(device.status));
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.net.wifi.p2p.WifiP2pManager.PeerListListener#onPeersAvailable(android.net.wifi.p2p.WifiP2pDeviceList)
-     */
     @Override
     public void onPeersAvailable(WifiP2pDeviceList peerList) {
         Log.d(CommCareWiFiDirectActivity.TAG, "onPeersAvailable");
@@ -214,9 +195,6 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
         ((WiFiPeerListAdapter) getListAdapter()).notifyDataSetChanged();
     }
 
-    /**
-     * 
-     */
     public void onInitiateDiscovery() {
         Log.d(CommCareWiFiDirectActivity.TAG, "onInitiateDiscovery");
         if (progressDialog != null && progressDialog.isShowing()) {
@@ -225,13 +203,9 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
         progressDialog = ProgressDialog.show(getActivity(), "Press back to cancel", "finding peers", true,
                 true, new DialogInterface.OnCancelListener() {
 
-	        	/*
-	        	 * (non-Javadoc)
-	        	 * @see android.content.DialogInterface.OnCancelListener#onCancel(android.content.DialogInterface)
-	        	 */
                     @Override
                     public void onCancel(DialogInterface dialog) {
-                        
+
                     }
                 });
     }

--- a/app/src/org/commcare/android/framework/EntityDetailFragment.java
+++ b/app/src/org/commcare/android/framework/EntityDetailFragment.java
@@ -59,10 +59,6 @@ public class EntityDetailFragment extends Fragment {
         }
     }
 
-    /*
-         * (non-Javadoc)
-         * @see android.support.v4.app.Fragment#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)
-         */
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         if(savedInstanceState != null){

--- a/app/src/org/commcare/android/framework/FileServerFragment.java
+++ b/app/src/org/commcare/android/framework/FileServerFragment.java
@@ -61,19 +61,11 @@ public class FileServerFragment extends Fragment {
 
     private FileServerAsyncTask mFileServer;
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onActivityCreated(android.os.Bundle)
-     */
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onAttach(android.app.Activity)
-     */
     @Override
     public void onAttach(Activity activity){
         super.onAttach(activity);
@@ -85,10 +77,6 @@ public class FileServerFragment extends Fragment {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)
-     */
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
@@ -149,10 +137,6 @@ public class FileServerFragment extends Fragment {
 
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.os.AsyncTask#doInBackground(java.lang.Object[])
-         */
         @Override
         protected String doInBackground(Void... params) {
 
@@ -208,10 +192,6 @@ public class FileServerFragment extends Fragment {
             }
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.os.AsyncTask#onPostExecute(java.lang.Object)
-         */
         @Override
         protected void onPostExecute(String result) {
             Log.e(CommCareWiFiDirectActivity.TAG, "file server task post execute");
@@ -228,20 +208,12 @@ public class FileServerFragment extends Fragment {
             mListener.startServer(receiveZipDirectory);
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.os.AsyncTask#onPreExecute()
-         */
         @Override
         protected void onPreExecute() {
             Logger.log(CommCareWiFiDirectActivity.TAG, "pre-execute of file server launch");
             // statusText.setText("Opening a server socket");
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.os.AsyncTask#onPreExecute()
-         */
         @Override
         protected void onProgressUpdate(String ... params){
             mStatusText.setText(params[0]);

--- a/app/src/org/commcare/android/framework/StateFragment.java
+++ b/app/src/org/commcare/android/framework/StateFragment.java
@@ -20,10 +20,7 @@ public class StateFragment extends Fragment {
     CommCareActivity lastActivity;
     
     CommCareTask currentTask;
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onAttach(android.app.Activity)
-     * 
+    /**
      * Hold a reference to the parent Activity so we can report the
      * task's current progress and results. The Android framework 
      * will pass us a reference to the newly created Activity after 
@@ -49,10 +46,7 @@ public class StateFragment extends Fragment {
           this.currentTask = task;
       }
      
-      /*
-       * (non-Javadoc)
-       * @see android.support.v4.app.Fragment#onCreate(android.os.Bundle)
-       * 
+      /**
        * This method will only be called once when the retained
        * Fragment is first created.
        */
@@ -64,10 +58,7 @@ public class StateFragment extends Fragment {
         setRetainInstance(true);
       }
      
-      /*
-       * (non-Javadoc)
-       * @see android.support.v4.app.Fragment#onDetach()
-       * 
+      /**
        * Set the callback to null so we don't accidentally leak the 
        * Activity instance.
        */

--- a/app/src/org/commcare/android/framework/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/android/framework/WiFiDirectManagementFragment.java
@@ -67,19 +67,11 @@ public class WiFiDirectManagementFragment extends Fragment implements Connection
     public Channel mChannel;
     WiFiDirectBroadcastReceiver mReceiver;
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onActivityCreated(android.os.Bundle)
-     */
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onAttach(android.app.Activity)
-     */
     @Override
     public void onAttach(Activity activity){
         super.onAttach(activity);
@@ -90,10 +82,6 @@ public class WiFiDirectManagementFragment extends Fragment implements Connection
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)
-     */
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
@@ -187,10 +175,6 @@ public class WiFiDirectManagementFragment extends Fragment implements Connection
         this.mManager = mManager;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.net.wifi.p2p.WifiP2pManager.ConnectionInfoListener#onConnectionInfoAvailable(android.net.wifi.p2p.WifiP2pInfo)
-     */
     @Override
     public void onConnectionInfoAvailable(WifiP2pInfo info) {
         
@@ -252,30 +236,18 @@ public class WiFiDirectManagementFragment extends Fragment implements Connection
         this.isWifiP2pEnabled = isWifiP2pEnabled;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onFailure(int)
-     */
     @Override
     public void onFailure(int reason) {
         //setStatusText("Failed to create group for rason: " + reason);
         
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onSuccess()
-     */
     @Override
     public void onSuccess() {
         //setStatusText("Successfully created group");
         
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.net.wifi.p2p.WifiP2pManager.ChannelListener#onChannelDisconnected()
-     */
     @Override
     public void onChannelDisconnected() {
         // we will try once more

--- a/app/src/org/commcare/android/framework/WrappingSpinnerAdapter.java
+++ b/app/src/org/commcare/android/framework/WrappingSpinnerAdapter.java
@@ -23,41 +23,26 @@ public class WrappingSpinnerAdapter implements SpinnerAdapter {
         this.displayVals= displayVals;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
     @Override
     public int getCount() {
         return wrapped.getCount();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
     @Override
     public Object getItem(int position) {
         return wrapped.getItem(position);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
     @Override
     public long getItemId(int position) {
         return wrapped.getItemId(position);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getItemViewType(int)
-     */
     @Override
     public int getItemViewType(int position) {
         return wrapped.getItemViewType(position);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         View v = wrapped.getView(position, convertView, parent);
@@ -67,49 +52,31 @@ public class WrappingSpinnerAdapter implements SpinnerAdapter {
         return v;
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#getViewTypeCount()
-     */
     @Override
     public int getViewTypeCount() {
         return wrapped.getViewTypeCount();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#hasStableIds()
-     */
     @Override
     public boolean hasStableIds() {
         return wrapped.hasStableIds();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#isEmpty()
-     */
     @Override
     public boolean isEmpty() {
         return wrapped.isEmpty();
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#registerDataSetObserver(android.database.DataSetObserver)
-     */
     @Override
     public void registerDataSetObserver(DataSetObserver observer) {
         wrapped.registerDataSetObserver(observer);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.Adapter#unregisterDataSetObserver(android.database.DataSetObserver)
-     */
     @Override
     public void unregisterDataSetObserver(DataSetObserver observer) {
         wrapped.unregisterDataSetObserver(observer);
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.SpinnerAdapter#getDropDownView(int, android.view.View, android.view.ViewGroup)
-     */
     @Override
     public View getDropDownView(int position, View convertView, ViewGroup parent) {
         return wrapped.getDropDownView(position, convertView, parent);

--- a/app/src/org/commcare/android/io/DataSubmissionEntity.java
+++ b/app/src/org/commcare/android/io/DataSubmissionEntity.java
@@ -25,18 +25,10 @@ public class DataSubmissionEntity extends MultipartEntity {
         this.submissionId = submissionId;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.apache.http.entity.mime.MultipartEntity#isRepeatable()
-     */
     @Override
     public boolean isRepeatable() {
         return true;
     }
-
-    /* (non-Javadoc)
-     * @see org.apache.http.entity.mime.MultipartEntity#writeTo(java.io.OutputStream)
-     */
     @Override
     public void writeTo(OutputStream outstream) throws IOException {
         if(attempt != 1) {

--- a/app/src/org/commcare/android/javarosa/AndroidLogEntry.java
+++ b/app/src/org/commcare/android/javarosa/AndroidLogEntry.java
@@ -46,9 +46,6 @@ public class AndroidLogEntry extends LogEntry implements Persistable, IMetaData 
         this.date = date;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         recordId = ExtUtil.readInt(in);
@@ -58,9 +55,6 @@ public class AndroidLogEntry extends LogEntry implements Persistable, IMetaData 
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, recordId);
@@ -90,17 +84,11 @@ public class AndroidLogEntry extends LogEntry implements Persistable, IMetaData 
         return message;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IMetaData#getMetaDataFields()
-     */
     @Override
     public String[] getMetaDataFields() {
         return new String[] {META_TYPE, META_DATE};
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.IMetaData#getMetaData(java.lang.String)
-     */
     @Override
     public Object getMetaData(String fieldName) {
         if(META_DATE.equals(fieldName)) {
@@ -112,17 +100,11 @@ public class AndroidLogEntry extends LogEntry implements Persistable, IMetaData 
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.Persistable#setID(int)
-     */
     @Override
     public void setID(int ID) {
         this.recordId = ID;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.Persistable#getID()
-     */
     @Override
     public int getID() {
         return this.recordId;

--- a/app/src/org/commcare/android/javarosa/AndroidLogSerializer.java
+++ b/app/src/org/commcare/android/javarosa/AndroidLogSerializer.java
@@ -32,10 +32,6 @@ public class AndroidLogSerializer extends StreamLogSerializer implements DeviceR
         
         this.setPurger(new Purger() {
 
-            /*
-             * (non-Javadoc)
-             * @see org.javarosa.core.log.StreamLogSerializer.Purger#purge(org.javarosa.core.util.SortedIntSet)
-             */
             @Override
             public void purge(final SortedIntSet IDs) {
                 storage.removeAll(new EntityFilter<LogEntry> () {
@@ -53,10 +49,6 @@ public class AndroidLogSerializer extends StreamLogSerializer implements DeviceR
         });
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.log.StreamLogSerializer#serializeLog(org.javarosa.core.log.LogEntry)
-     */
     @Override
     protected void serializeLog(LogEntry entry) throws IOException {
         String dateString = DateUtils.formatDateTime(entry.getTime(), DateUtils.FORMAT_ISO8601);
@@ -84,10 +76,6 @@ public class AndroidLogSerializer extends StreamLogSerializer implements DeviceR
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.javarosa.DeviceReportElement#writeToDeviceReport(org.xmlpull.v1.XmlSerializer)
-     */
     @Override
     public void writeToDeviceReport(XmlSerializer serializer) throws IOException {
         //TODO: Stop doing what the special case here is for

--- a/app/src/org/commcare/android/javarosa/AndroidLogger.java
+++ b/app/src/org/commcare/android/javarosa/AndroidLogger.java
@@ -75,10 +75,6 @@ public class AndroidLogger implements ILogger {
         this.storage = storage;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#log(java.lang.String, java.lang.String, java.util.Date)
-     */
     @Override
     public void log(String type, String message, Date logDate) {
         try {
@@ -89,20 +85,12 @@ public class AndroidLogger implements ILogger {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#clearLogs()
-     */
     @Override
     public void clearLogs() {
         if(serializing) {
             storage.removeAll();
         } else {
             storage.removeAll(new EntityFilter<AndroidLogEntry>() {
-                    /*
-                     * (non-Javadoc)
-                     * @see org.javarosa.core.services.storage.EntityFilter#matches(java.lang.Object)
-                     */
                     @Override
                     public boolean matches(AndroidLogEntry e) {
                         if(e.getID() <= lastEntry) {
@@ -117,10 +105,6 @@ public class AndroidLogger implements ILogger {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#serializeLogs(org.javarosa.core.log.IFullLogSerializer)
-     */
     @Override
     public <T> T serializeLogs(IFullLogSerializer<T> serializer) {
         ArrayList<LogEntry> logs = new ArrayList<LogEntry>(); 
@@ -135,10 +119,6 @@ public class AndroidLogger implements ILogger {
         return serializer.serializeLogs(logs.toArray(new LogEntry[0]));
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#serializeLogs(org.javarosa.core.log.StreamLogSerializer)
-     */
     @Override
     public void serializeLogs(StreamLogSerializer serializer) throws IOException {
         for(AndroidLogEntry entry : storage) {
@@ -151,10 +131,6 @@ public class AndroidLogger implements ILogger {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#serializeLogs(org.javarosa.core.log.StreamLogSerializer, int)
-     */
     @Override
     public void serializeLogs(StreamLogSerializer serializer, int limit) throws IOException {
         int count = 0;
@@ -170,28 +146,16 @@ public class AndroidLogger implements ILogger {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#panic()
-     */
     @Override
     public void panic() {
         //Unclear
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#logSize()
-     */
     @Override
     public int logSize() {
         return storage.getNumRecords();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#halt()
-     */
     @Override
     public void halt() {
         //Meh.

--- a/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
+++ b/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
@@ -65,19 +65,11 @@ public class DeviceReportRecord extends Persisted implements EncryptedModel{
         return slr;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.database.EncryptedModel#isEncrypted(java.lang.String)
-     */
     @Override
     public boolean isEncrypted(String data) {
         return false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.database.EncryptedModel#isBlobEncrypted()
-     */
     @Override
     public boolean isBlobEncrypted() {
         return true;

--- a/app/src/org/commcare/android/javarosa/PreInitLogger.java
+++ b/app/src/org/commcare/android/javarosa/PreInitLogger.java
@@ -24,9 +24,6 @@ public class PreInitLogger implements ILogger {
     public PreInitLogger() {
         
     }
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#log(java.lang.String, java.lang.String, java.util.Date)
-     */
     @Override
     public void log(String type, String message, Date logDate) {
         logs.add(new AndroidLogEntry(type, message, logDate));
@@ -41,60 +38,39 @@ public class PreInitLogger implements ILogger {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#clearLogs()
-     */
     @Override
     public void clearLogs() {
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#serializeLogs(org.javarosa.core.log.IFullLogSerializer)
-     */
     @Override
     public <T> T serializeLogs(IFullLogSerializer<T> serializer) {
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#serializeLogs(org.javarosa.core.log.StreamLogSerializer)
-     */
     @Override
     public void serializeLogs(StreamLogSerializer serializer) throws IOException {
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#serializeLogs(org.javarosa.core.log.StreamLogSerializer, int)
-     */
     @Override
     public void serializeLogs(StreamLogSerializer serializer, int limit) throws IOException {
         // TODO Auto-generated method stub
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#panic()
-     */
     @Override
     public void panic() {
         // TODO Auto-generated method stub
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#logSize()
-     */
     @Override
     public int logSize() {
         // TODO Auto-generated method stub
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.api.ILogger#halt()
-     */
     @Override
     public void halt() {
         // TODO Auto-generated method stub

--- a/app/src/org/commcare/android/mime/EncryptedFileBody.java
+++ b/app/src/org/commcare/android/mime/EncryptedFileBody.java
@@ -50,10 +50,6 @@ public class EncryptedFileBody extends AbstractContentBody {
         return MIME.ENC_BINARY;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.apache.james.mime4j.message.SingleBody#writeTo(java.io.OutputStream)
-     */
     @Override
     public void writeTo(OutputStream out) throws IOException {
         //The only time this can cause issues is if the body has disappeared since construction. Don't worry about that, since

--- a/app/src/org/commcare/android/models/AsyncEntity.java
+++ b/app/src/org/commcare/android/models/AsyncEntity.java
@@ -122,10 +122,6 @@ public class AsyncEntity extends Entity<TreeReference>{
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.models.Entity#getNormalizedField(int)
-     */
     @Override
     public String getNormalizedField(int i) {
         String normalized = this.getSortField(i);
@@ -198,10 +194,6 @@ public class AsyncEntity extends Entity<TreeReference>{
         return fields.length;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.models.Entity#isValidField(int)
-     */
     @Override
     public boolean isValidField(int i) {
         //NOTE: This totally jacks the asynchronicity. It's only used in

--- a/app/src/org/commcare/android/models/RangeXYValueSeries.java
+++ b/app/src/org/commcare/android/models/RangeXYValueSeries.java
@@ -17,10 +17,6 @@ public class RangeXYValueSeries extends XYValueSeries {
         super(title);
     }
         
-    /*
-     * (non-Javadoc)
-     * @see org.achartengine.model.XYValueSeries#getMaxValue()
-     */
     @Override
     public double getMaxValue() {
         return max == null ? super.getMaxValue() : max;

--- a/app/src/org/commcare/android/models/notifications/NotificationClearReceiver.java
+++ b/app/src/org/commcare/android/models/notifications/NotificationClearReceiver.java
@@ -17,9 +17,6 @@ import android.content.Intent;
  */
 public class NotificationClearReceiver extends BroadcastReceiver {
 
-    /* (non-Javadoc)
-     * @see android.content.BroadcastReceiver#onReceive(android.content.Context, android.content.Intent)
-     */
     @Override
     public void onReceive(Context context, Intent intent) {
         CommCareApplication._().purgeNotifications();

--- a/app/src/org/commcare/android/models/notifications/NotificationMessage.java
+++ b/app/src/org/commcare/android/models/notifications/NotificationMessage.java
@@ -18,19 +18,11 @@ public class NotificationMessage implements Parcelable {
     private String category, title, details, actions;
     private Date date;
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.Parcelable#describeContents()
-     */
     @Override
     public int describeContents() {
         return 0;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.Parcelable#writeToParcel(android.os.Parcel, int)
-     */
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeStringArray(new String[] {category, title, details, actions});
@@ -39,10 +31,6 @@ public class NotificationMessage implements Parcelable {
 
     public static final Parcelable.Creator<NotificationMessage> CREATOR = new Parcelable.Creator<NotificationMessage>() {
 
-        /*
-         * (non-Javadoc)
-         * @see android.os.Parcelable.Creator#createFromParcel(android.os.Parcel)
-         */
         @Override
         public NotificationMessage createFromParcel(Parcel source) {
             String[] array = new String[3];
@@ -52,10 +40,6 @@ public class NotificationMessage implements Parcelable {
             
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.os.Parcelable.Creator#newArray(int)
-         */
         @Override
         public NotificationMessage[] newArray(int size) {
             return new NotificationMessage[size]; 
@@ -86,10 +70,6 @@ public class NotificationMessage implements Parcelable {
         return details;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object o) {
         if(!(o instanceof NotificationMessage)) { return false; }

--- a/app/src/org/commcare/android/net/HttpRequestGenerator.java
+++ b/app/src/org/commcare/android/net/HttpRequestGenerator.java
@@ -288,10 +288,6 @@ public class HttpRequestGenerator {
             
             if(passwordAuthentication != null) {
                  Authenticator.setDefault(new Authenticator() {
-                     /*
-                      * (non-Javadoc)
-                      * @see java.net.Authenticator#getPasswordAuthentication()
-                      */
                        @Override
                       protected PasswordAuthentication getPasswordAuthentication() {
                           return passwordAuthentication;

--- a/app/src/org/commcare/android/references/JavaHttpReference.java
+++ b/app/src/org/commcare/android/references/JavaHttpReference.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.references;
 
 import java.io.IOException;
@@ -26,46 +23,34 @@ public class JavaHttpReference implements Reference {
     }
     
     
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#doesBinaryExist()
-     */
+    @Override
     public boolean doesBinaryExist() throws IOException {
         //For now....
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#getOutputStream()
-     */
+    @Override
     public OutputStream getOutputStream() throws IOException {
         throw new IOException("Http references are read only!");
     }
-    
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#getStream()
-     */
+
+    @Override
     public InputStream getStream() throws IOException {
         URL url = new URL(uri);
         return generator.simpleGet(url);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#getURI()
-     */
+    @Override
     public String getURI() {
         return uri;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#isReadOnly()
-     */
+    @Override
     public boolean isReadOnly() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#remove()
-     */
+    @Override
     public void remove() throws IOException {
         throw new IOException("Http references are read only!");
     }

--- a/app/src/org/commcare/android/references/JavaHttpRoot.java
+++ b/app/src/org/commcare/android/references/JavaHttpRoot.java
@@ -12,24 +12,18 @@ public class JavaHttpRoot implements ReferenceFactory {
     
     HttpRequestGenerator generator = new HttpRequestGenerator();
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.RawRoot#derive(java.lang.String)
-     */
+    @Override
     public Reference derive(String URI) throws InvalidReferenceException {
         return new JavaHttpReference(URI, generator);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.RawRoot#derive(java.lang.String, java.lang.String)
-     */
+    @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
         context = context.substring(0, context.lastIndexOf('/')+1);
         return new JavaHttpReference(context + URI, generator);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.reference.RawRoot#derives(java.lang.String)
-     */
+    @Override
     public boolean derives(String URI) {
         URI = URI.toLowerCase();
         return URI.startsWith("http://") || URI.startsWith("https://");

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -60,24 +60,15 @@ public abstract class FileSystemInstaller implements ResourceInstaller<AndroidCo
         this.upgradeDestination = upgradeDestination;
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#cleanup()
-     */
     @Override
     public void cleanup() {
         // TODO Auto-generated method stub
 
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#initialize(org.commcare.util.CommCareInstance)
-     */
     @Override
     public abstract boolean initialize(AndroidCommCarePlatform instance) throws ResourceInitializationException;
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#install(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceLocation, org.javarosa.core.reference.Reference, org.commcare.resources.model.ResourceTable, org.commcare.util.CommCareInstance, boolean)
-     */
     @Override
     public boolean install(Resource r, ResourceLocation location, Reference ref, ResourceTable table, AndroidCommCarePlatform instance, boolean upgrade) throws UnresolvedResourceException, UnfullfilledRequirementsException {
         try {
@@ -194,15 +185,9 @@ public abstract class FileSystemInstaller implements ResourceInstaller<AndroidCo
      */
     protected abstract int customInstall(Resource r, Reference local, boolean upgrade) throws IOException, UnresolvedResourceException;
     
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#requiresRuntimeInitialization()
-     */
     @Override
     public abstract boolean requiresRuntimeInitialization();
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#uninstall(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable, org.commcare.resources.model.ResourceTable)
-     */
     @Override
     public boolean uninstall(Resource r) throws UnresolvedResourceException {
         try{
@@ -212,9 +197,6 @@ public abstract class FileSystemInstaller implements ResourceInstaller<AndroidCo
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#upgrade(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable)
-     */
     @Override
     public boolean upgrade(Resource r) {
         try {             
@@ -279,10 +261,6 @@ public abstract class FileSystemInstaller implements ResourceInstaller<AndroidCo
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#unstage(org.commcare.resources.model.Resource, int)
-     */
     @Override
     public boolean unstage(Resource r, int newStatus) {
         try {
@@ -320,10 +298,6 @@ public abstract class FileSystemInstaller implements ResourceInstaller<AndroidCo
         
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#revert(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable)
-     */
     @Override
     public boolean revert(Resource r, ResourceTable table) {
         String finalLocation = null;
@@ -436,9 +410,6 @@ public abstract class FileSystemInstaller implements ResourceInstaller<AndroidCo
         } 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         this.localLocation = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
@@ -446,9 +417,6 @@ public abstract class FileSystemInstaller implements ResourceInstaller<AndroidCo
         this.upgradeDestination = ExtUtil.readString(in);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(localLocation));

--- a/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
@@ -35,9 +35,7 @@ public class LocaleAndroidInstaller extends FileSystemInstaller {
     }
     
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#initialize(org.commcare.util.CommCareInstance)
-     */
+    @Override
     public boolean initialize(AndroidCommCarePlatform instance) throws ResourceInitializationException {
         Localization.registerLanguageReference(locale, localLocation);
         return true;
@@ -47,24 +45,18 @@ public class LocaleAndroidInstaller extends FileSystemInstaller {
         return upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#requiresRuntimeInitialization()
-     */
+    @Override
     public boolean requiresRuntimeInitialization() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
         this.locale = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(locale));

--- a/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
@@ -35,9 +35,7 @@ public class MediaFileAndroidInstaller extends FileSystemInstaller {
         this.path = path;
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#uninstall(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable, org.commcare.resources.model.ResourceTable)
-     */
+    @Override
     public boolean uninstall(Resource r) throws UnresolvedResourceException {
         boolean success = super.uninstall(r);
         if( success == false ) { return false; }
@@ -45,9 +43,7 @@ public class MediaFileAndroidInstaller extends FileSystemInstaller {
         return FileUtil.cleanFilePath(this.localDestination, path);
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#upgrade(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable)
-     */
+    @Override
     public boolean upgrade(Resource r) {
         return super.upgrade(r);
     }
@@ -56,42 +52,28 @@ public class MediaFileAndroidInstaller extends FileSystemInstaller {
         return upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#requiresRuntimeInitialization()
-     */
+    @Override
     public boolean requiresRuntimeInitialization() {
         return false;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.resource.installers.FileSystemInstaller#initialize(org.commcare.android.util.AndroidCommCarePlatform)
-     */
     @Override
     public boolean initialize(AndroidCommCarePlatform instance) throws ResourceInitializationException {
         return false;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
         path = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(path));
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.resource.installers.FileSystemInstaller#getResourceName(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceLocation)
-     */
     @Override
     public Pair<String, String> getResourceName(Resource r, ResourceLocation loc) {
         int index = loc.getLocation().lastIndexOf("/");

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -47,9 +47,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
     }
     
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#initialize(org.commcare.util.CommCareInstance)
-     */
+    @Override
     public boolean initialize(AndroidCommCarePlatform instance) throws ResourceInitializationException {
         try {
         
@@ -126,9 +124,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
         editor.commit();
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#upgrade(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable)
-     */
+    @Override
     public boolean upgrade(Resource r) {
         if(!super.upgrade(r)) {
             return false;
@@ -169,26 +165,18 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
         return Resource.RESOURCE_STATUS_LOCAL;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#requiresRuntimeInitialization()
-     */
+    @Override
     public boolean requiresRuntimeInitialization() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
     }
-
-
 }

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -50,9 +50,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
     }
     
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#initialize(org.commcare.util.CommCareInstance)
-     */
+    @Override
     public boolean initialize(final AndroidCommCarePlatform instance) throws ResourceInitializationException {
         
         try {
@@ -62,10 +60,6 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
             Reference local = ReferenceManager._().DeriveReference(localLocation);
     
             SuiteParser parser = new SuiteParser(local.getStream(), instance.getGlobalResourceTable(),null) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.xml.SuiteParser#getFixtureStorage()
-                 */
                 @Override
                 protected IStorageUtilityIndexed<FormInstance> getFixtureStorage() {
                     return instance.getFixtureStorage();
@@ -104,10 +98,6 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
             Reference local = ReferenceManager._().DeriveReference(localLocation);
             
             SuiteParser parser = new SuiteParser(local.getStream(), table, r.getRecordGuid()) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.xml.SuiteParser#getFixtureStorage()
-                 */
                 @Override
                 protected IStorageUtilityIndexed<FormInstance> getFixtureStorage() {
                     return instance.getFixtureStorage();
@@ -143,23 +133,17 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
     }
 
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#requiresRuntimeInitialization()
-     */
+    @Override
     public boolean requiresRuntimeInitialization() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
     }
@@ -168,19 +152,11 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
         try{
             Reference local = ReferenceManager._().DeriveReference(localLocation);
             Suite mSuite = (new SuiteParser(local.getStream(), new DummyResourceTable(), null) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.xml.SuiteParser#getFixtureStorage()
-                 */
                 @Override
                 protected IStorageUtilityIndexed<FormInstance> getFixtureStorage() {
                     //shouldn't be necessary
                     return null;
                 }
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.xml.SuiteParser#inValidationMode()
-                 */
                 @Override
                 protected boolean inValidationMode(){
                     return true;

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -61,20 +61,13 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     public XFormAndroidInstaller(String localDestination, String upgradeDestination) {
         super(localDestination, upgradeDestination);
     }
-    
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#initialize(org.commcare.util.CommCareInstance)
-     */
+    @Override
     public boolean initialize(AndroidCommCarePlatform instance) throws ResourceInitializationException {
         instance.registerXmlns(namespace, contentUri);
         return true;
     }
-    
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.resource.installers.FileSystemInstaller#customInstall(org.commcare.resources.model.Resource, org.javarosa.core.reference.Reference, boolean)
-     */
+
     @Override
     protected int customInstall(Resource r, Reference local, boolean upgrade) throws IOException, UnresolvedResourceException {
         //Ugh. Really need to sync up the Xform libs between ccodk and odk.
@@ -143,9 +136,6 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         return upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.resource.installers.FileSystemInstaller#upgrade(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable)
-     */
     @Override
     public boolean upgrade(Resource r) {
         boolean fileUpgrade = super.upgrade(r);
@@ -207,25 +197,19 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     }
 
 
-    /* (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceInstaller#requiresRuntimeInitialization()
-     */
+    @Override
     public boolean requiresRuntimeInitialization() {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
         this.namespace = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         this.contentUri = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(namespace));

--- a/app/src/org/commcare/android/storage/framework/Persisted.java
+++ b/app/src/org/commcare/android/storage/framework/Persisted.java
@@ -31,9 +31,6 @@ public class Persisted implements Persistable, IMetaData {
     
     protected int recordId = -1; 
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         recordId = ExtUtil.readInt(in);
@@ -81,9 +78,6 @@ public class Persisted implements Persistable, IMetaData {
         
     };
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, recordId);
@@ -96,17 +90,11 @@ public class Persisted implements Persistable, IMetaData {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.Persistable#setID(int)
-     */
     @Override
     public void setID(int ID) {
         recordId = ID;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.Persistable#getID()
-     */
     @Override
     public int getID() {
         return recordId;

--- a/app/src/org/commcare/android/tasks/ConnectionDiagnosticTask.java
+++ b/app/src/org/commcare/android/tasks/ConnectionDiagnosticTask.java
@@ -77,20 +77,7 @@ public abstract class ConnectionDiagnosticTask<R> extends CommCareTask<Void, Str
 
         TAG = ConnectionDiagnosticTask.class.getSimpleName();
     }
-    
-    //onProgressUpdate(<B>)
-    
-    //onPostExecute(<C>)
-    
-    //onCancelled()
 
-    
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     * 
-     * doTaskBackground(<A>) returns <C>
-     */
     @Override
     protected Test doTaskBackground(Void... params) 
     {    

--- a/app/src/org/commcare/android/tasks/DataPullTask.java
+++ b/app/src/org/commcare/android/tasks/DataPullTask.java
@@ -125,9 +125,6 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
         TAG = DataPullTask.class.getSimpleName();
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onCancelled()
-     */
     @Override
     protected void onCancelled() {
         super.onCancelled();
@@ -140,10 +137,6 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     */
     @Override
     protected Integer doTaskBackground(Void... params) {
         // Don't try to sync if logging out is occuring
@@ -187,10 +180,6 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
         
         CommCareTransactionParserFactory factory = new CommCareTransactionParserFactory(c, requestor) {
             boolean publishedAuth = false;
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.xml.CommCareTransactionParserFactory#reportProgress(int)
-             */
             @Override
             public void reportProgress(int progress) {
                 if(!publishedAuth) {

--- a/app/src/org/commcare/android/tasks/DumpTask.java
+++ b/app/src/org/commcare/android/tasks/DumpTask.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.tasks;
 
 import java.io.ByteArrayOutputStream;
@@ -67,9 +64,7 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
         taskId = DumpTask.BULK_DUMP_ID;
     }
     
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
+    @Override
     protected void onProgressUpdate(String... values) {
         super.onProgressUpdate(values);
     }
@@ -78,10 +73,6 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
         this.formSubmissionListener = submissionListener;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(Boolean result) {
         super.onPostExecute(result);
@@ -155,10 +146,6 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
         return FormUploadUtil.FULL_SUCCESS;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     */
     @SuppressLint("NewApi")
     @Override
     protected Boolean doTaskBackground(String... params) {
@@ -321,9 +308,6 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
         }
     }
     
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onCancelled()
-     */
     @Override
     protected void onCancelled() {
         super.onCancelled();

--- a/app/src/org/commcare/android/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/EntityLoaderTask.java
@@ -46,18 +46,12 @@ public class EntityLoaderTask extends ManagedAsyncTask<TreeReference, Integer, P
         listener.attach(this);
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
     @Override
     protected void onProgressUpdate(Integer... values) {
         super.onProgressUpdate(values);
     }
     
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(Pair<List<Entity<TreeReference>>, List<TreeReference>> result) {
         super.onPostExecute(result);
@@ -104,10 +98,6 @@ public class EntityLoaderTask extends ManagedAsyncTask<TreeReference, Integer, P
         
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(java.lang.Object[])
-     */
     @Override
     protected Pair<List<Entity<TreeReference>>, List<TreeReference>> doInBackground(TreeReference... nodeset) {
 

--- a/app/src/org/commcare/android/tasks/ExceptionReportTask.java
+++ b/app/src/org/commcare/android/tasks/ExceptionReportTask.java
@@ -34,10 +34,6 @@ import android.util.Log;
  **/
 public class ExceptionReportTask extends AsyncTask<Throwable, String, String> {
     private static final String TAG = ExceptionReportTask.class.getSimpleName();
-    /*
-     * (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(java.lang.Object[])
-     */
     @Override
     protected String doInBackground(Throwable... values) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -92,10 +88,6 @@ public class ExceptionReportTask extends AsyncTask<Throwable, String, String> {
             //Apparently if you don't have a filename in the multipart wrapper, some receivers
             //don't properly receive this post.
             StringBody body = new StringBody(payload, "text/xml", MIME.DEFAULT_CHARSET) {
-                /*
-                 * (non-Javadoc)
-                 * @see org.apache.http.entity.mime.content.StringBody#getFilename()
-                 */
                 @Override
                 public String getFilename() {
                     return "exceptionreport.xml";

--- a/app/src/org/commcare/android/tasks/FormRecordCleanupTask.java
+++ b/app/src/org/commcare/android/tasks/FormRecordCleanupTask.java
@@ -70,10 +70,6 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
         this.taskId = taskId;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     */
     @Override
     protected Integer doTaskBackground(Void... params) {
         SqlStorage<FormRecord> storage = CommCareApplication._().getUserStorage(FormRecord.class);
@@ -187,10 +183,6 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
                     //If we have a proper 2.0 namespace, good.
                     if (CaseXmlParser.CASE_XML_NAMESPACE.equals(parser.getNamespace())) {
                         return new AndroidCaseXmlParser(parser, CommCareApplication._().getUserStorage(ACase.STORAGE_KEY, ACase.class)) {
-                            /*
-                             * (non-Javadoc)
-                             * @see org.commcare.xml.CaseXmlParser#commit(org.commcare.cases.model.Case)
-                             */
                             @Override
                             public void commit(Case parsed) throws IOException {
                                 String incoming = parsed.getCaseId();
@@ -199,10 +191,6 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
                                 }
                             }
         
-                            /*
-                             * (non-Javadoc)
-                             * @see org.commcare.xml.CaseXmlParser#retrieve(java.lang.String)
-                             */
                             @Override
                             public ACase retrieve(String entityId) {
                                 caseIDs[0] = entityId;
@@ -215,10 +203,6 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
                     //Otherwise, this gets more tricky. Ideally we'd want to skip this block for compatibility purposes,
                     //but we can at least try to get a caseID (which is all we want)
                     return new BestEffortBlockParser(parser, null, null, new String[] {"case_id"}) {
-                        /*
-                         * (non-Javadoc)
-                         * @see org.commcare.xml.BestEffortBlockParser#commit(java.util.Hashtable)
-                         */
                         @Override
                         public void commit(Hashtable<String, String> values) {
                             if(values.containsKey("case_id")) {
@@ -228,10 +212,6 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
                     };}
                 } else if("meta".equalsIgnoreCase(name)) {
                     return new MetaDataXmlParser(parser) {
-                        /*
-                         * (non-Javadoc)
-                         * @see org.commcare.xml.MetaDataXmlParser#commit(java.lang.String[])
-                         */
                         @Override
                         public void commit(String[] meta) throws IOException {
                             if(meta[0] != null) {

--- a/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
+++ b/app/src/org/commcare/android/tasks/FormRecordLoaderTask.java
@@ -111,10 +111,6 @@ public class FormRecordLoaderTask extends ManagedAsyncTask<FormRecord, Pair<Form
         this.listeners.add(listener);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(java.lang.Object[])
-     */
     @Override
     protected Integer doInBackground(FormRecord... params) {
         int loadedFormCount = 0;
@@ -214,9 +210,6 @@ public class FormRecordLoaderTask extends ManagedAsyncTask<FormRecord, Pair<Form
         return this.loadingComplete;
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(Integer result) {
         super.onPostExecute(result);
@@ -234,9 +227,6 @@ public class FormRecordLoaderTask extends ManagedAsyncTask<FormRecord, Pair<Form
         formNames = null;
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
     @Override
     protected void onProgressUpdate(Pair<FormRecord, ArrayList<String>>... values) {
         super.onProgressUpdate(values);

--- a/app/src/org/commcare/android/tasks/FormTransferTask.java
+++ b/app/src/org/commcare/android/tasks/FormTransferTask.java
@@ -48,10 +48,6 @@ public abstract class FormTransferTask extends CommCareTask<String, String, Bool
         
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     */
     @Override
     protected Boolean doTaskBackground(String... params) {
         

--- a/app/src/org/commcare/android/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/android/tasks/LogSubmissionTask.java
@@ -78,10 +78,6 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
         this.submissionUrl = submissionUrl;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(java.lang.Object[])
-     */
     @Override
     protected LogSubmitOutcomes doInBackground(Void... params) {
         try {
@@ -288,46 +284,27 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.DataSubmissionListener#beginSubmissionProcess(int)
-     */
     @Override
     public void beginSubmissionProcess(int totalItems) {
         this.publishProgress(new Long[] {LogSubmissionTask.SUBMISSION_BEGIN, (long)totalItems});        
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.DataSubmissionListener#startSubmission(int, long)
-     */
     @Override
     public void startSubmission(int itemNumber, long length) {
         this.publishProgress(new Long[] {LogSubmissionTask.SUBMISSION_START, (long)itemNumber, length});
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.DataSubmissionListener#notifyProgress(int, long)
-     */
     @Override
     public void notifyProgress(int itemNumber, long progress) {
         this.publishProgress(new Long[] {LogSubmissionTask.SUBMISSION_NOTIFY, (long)itemNumber, progress});
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.DataSubmissionListener#endSubmissionProcess()
-     */
     @Override
     public void endSubmissionProcess() {
         this.publishProgress(new Long[] {LogSubmissionTask.SUBMISSION_DONE});
     }
     
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
     @Override
     protected void onProgressUpdate(Long... values) {
         super.onProgressUpdate(values);
@@ -343,9 +320,6 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
         } 
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(LogSubmitOutcomes result) {
         super.onPostExecute(result);

--- a/app/src/org/commcare/android/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/android/tasks/ManageKeyRecordTask.java
@@ -77,18 +77,12 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
         this.taskId = taskId;
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onCancelled()
-     */
     @Override
     protected void onCancelled() {
         super.onCancelled();
     }
     
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-     */
     @Override
     protected void deliverResult(R receiver, HttpCalloutOutcomes result) {        
         //If this task completed and we logged in.
@@ -134,9 +128,6 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
     }
 
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#doSetupTaskBeforeRequest()
-     */
     @Override
     protected HttpCalloutOutcomes doSetupTaskBeforeRequest() {
         //This step needs to determine three things
@@ -248,36 +239,22 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
     
     //CTS: These will be fleshed out to comply with the server's Key Request/response protocol
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#doHttpRequest()
-     */
     @Override
     protected HttpResponse doHttpRequest() throws ClientProtocolException, IOException {
         HttpRequestGenerator requestor = new HttpRequestGenerator(username, password);
         return requestor.makeKeyFetchRequest(keyServerUrl, null);
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#getTransactionParserFactory()
-     */
     @Override
     protected TransactionParserFactory getTransactionParserFactory() {
         TransactionParserFactory factory = new TransactionParserFactory() {
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.data.xml.TransactionParserFactory#getParser(org.kxml2.io.KXmlParser)
-             */
             @Override
             public TransactionParser getParser(KXmlParser parser) {
                 String name = parser.getName();
                 if("auth_keys".equals(name)) {
                     return new KeyRecordParser(parser, username, password, keyRecords) {
 
-                        /*
-                         * (non-Javadoc)
-                         * @see org.commcare.data.xml.TransactionParser#commit(java.lang.Object)
-                         */
                         @Override
                         public void commit(ArrayList<UserKeyRecord> parsed) throws IOException {
                             ManageKeyRecordTask.this.keyRecords = parsed;
@@ -292,27 +269,17 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
         return factory;
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#HttpCalloutNeeded()
-     */
     @Override
     protected boolean HttpCalloutNeeded() {
         return calloutNeeded;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#HttpCalloutRequired()
-     */
     @Override
     protected boolean HttpCalloutRequired() {
         return calloutRequired;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#processSuccesfulRequest()
-     */
     @Override
     protected boolean processSuccesfulRequest() {
         if(keyRecords == null || keyRecords.size() == 0) {
@@ -351,10 +318,6 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#doPostCalloutTask(boolean)
-     */
     @Override
     protected HttpCalloutTask.HttpCalloutOutcomes doPostCalloutTask(boolean calloutFailed) {
         //Now we need to complete our login 
@@ -521,10 +484,6 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
         if(acceptExpired) { return validIsh; }
         return null;
     }
-
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.HttpCalloutTask#doResponseOther(org.apache.http.HttpResponse)
-     */
     @Override
     protected HttpCalloutOutcomes doResponseOther(HttpResponse response) {
         return HttpCalloutOutcomes.BadResponse;

--- a/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
@@ -100,10 +100,8 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
             this.taskId = -1;
         }
     }
-    
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(Params[])
-     */
+
+    @Override
     protected Integer doTaskBackground(FormRecord... records) {
         boolean needToSendLogs = false;
 
@@ -342,9 +340,7 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
         }
     }
     
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
+    @Override
     protected void onProgressUpdate(Long... values) {
         if(values.length == 1 && values[0] == ProcessAndSendTask.PROGRESS_ALL_PROCESSED) {
             this.transitionPhase(sendTaskId);
@@ -376,10 +372,6 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
         this.formSubmissionListener = submissionListener;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(Integer result) {
         super.onPostExecute(result);
@@ -427,9 +419,6 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onCancelled()
-     */
     @Override
     protected void onCancelled() {
         super.onCancelled();

--- a/app/src/org/commcare/android/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/android/tasks/ResourceEngineTask.java
@@ -138,9 +138,7 @@ public abstract class ResourceEngineTask<R>
         TAG = ResourceEngineTask.class.getSimpleName();
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(Params[])
-     */
+    @Override
     protected ResourceEngineOutcomes doTaskBackground(String... profileRefs) {
         String profileRef = profileRefs[0];
         AndroidCommCarePlatform platform = app.getCommCarePlatform();

--- a/app/src/org/commcare/android/tasks/SendTask.java
+++ b/app/src/org/commcare/android/tasks/SendTask.java
@@ -47,6 +47,7 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
         this.dumpDirectory = dumpDirectory;
     }
     
+    @Override
     protected void onProgressUpdate(String... values) {
         super.onProgressUpdate(values);
     }

--- a/app/src/org/commcare/android/tasks/SendTask.java
+++ b/app/src/org/commcare/android/tasks/SendTask.java
@@ -47,9 +47,6 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
         this.dumpDirectory = dumpDirectory;
     }
     
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
     protected void onProgressUpdate(String... values) {
         super.onProgressUpdate(values);
     }
@@ -59,10 +56,6 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
         this.formSubmissionListener = submissionListener;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(Boolean result) {
         super.onPostExecute(result);
@@ -72,9 +65,6 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
         results = null;
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onCancelled()
-     */
     @Override
     protected void onCancelled() {
         super.onCancelled();
@@ -84,10 +74,6 @@ public abstract class SendTask<R> extends CommCareTask<Void, String, Boolean, R>
         CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.LoggedOut));
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     */
     @Override
     protected Boolean doTaskBackground(Void... params) {
         

--- a/app/src/org/commcare/android/tasks/UnzipTask.java
+++ b/app/src/org/commcare/android/tasks/UnzipTask.java
@@ -36,10 +36,6 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
             TAG = UnzipTask.class.getSimpleName();
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-         */
         @Override
         protected Integer doTaskBackground(String... params) {
             

--- a/app/src/org/commcare/android/tasks/VerificationTask.java
+++ b/app/src/org/commcare/android/tasks/VerificationTask.java
@@ -71,10 +71,6 @@ public class VerificationTask extends AsyncTask<String, int[], SizeBoundVector<M
         this.publishProgress(new int[] {complete, total});
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.TableStateListener#resourceStateUpdated(org.commcare.resources.model.ResourceTable)
-     */
     @Override
     public void resourceStateUpdated(ResourceTable table) {
         // TODO Auto-generated method stub

--- a/app/src/org/commcare/android/tasks/WipeTask.java
+++ b/app/src/org/commcare/android/tasks/WipeTask.java
@@ -36,9 +36,7 @@ public abstract class WipeTask extends CommCareTask<String, String, Boolean, Com
         this.records = records;
     }
     
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
+    @Override
     protected void onProgressUpdate(String... values) {
         super.onProgressUpdate(values);
     }
@@ -47,10 +45,6 @@ public abstract class WipeTask extends CommCareTask<String, String, Boolean, Com
         this.formSubmissionListener = submissionListener;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(Boolean result) {
         super.onPostExecute(result);
@@ -59,10 +53,6 @@ public abstract class WipeTask extends CommCareTask<String, String, Boolean, Com
         results = null;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     */
     @Override
     protected Boolean doTaskBackground(String... params) {
         

--- a/app/src/org/commcare/android/tasks/ZipTask.java
+++ b/app/src/org/commcare/android/tasks/ZipTask.java
@@ -70,9 +70,7 @@ public abstract class ZipTask extends CommCareTask<String, String, FormRecord[],
         taskId = ZIP_TASK_ID;
     }
     
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
+    @Override
     protected void onProgressUpdate(String... values) {
         super.onProgressUpdate(values);
     }
@@ -81,10 +79,6 @@ public abstract class ZipTask extends CommCareTask<String, String, FormRecord[],
         this.formSubmissionListener = submissionListener;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(FormRecord[] result) {
         super.onPostExecute(result);
@@ -223,10 +217,6 @@ public abstract class ZipTask extends CommCareTask<String, String, FormRecord[],
         return false;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTask#doTaskBackground(java.lang.Object[])
-     */
     @Override
     protected FormRecord[] doTaskBackground(String... params) {
         
@@ -395,9 +385,6 @@ public abstract class ZipTask extends CommCareTask<String, String, FormRecord[],
         }
     }
     
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onCancelled()
-     */
     @Override
     protected void onCancelled() {
         super.onCancelled();

--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -23,9 +23,6 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
         TAG = CommCareTask.class.getSimpleName();
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(Params[])
-     */
     @Override
     protected final C doInBackground(A... params) {
         //Never have to wrap the entirety of your task.
@@ -48,9 +45,6 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
      */
     protected abstract C doTaskBackground(A... params);
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onCancelled()
-     */
     @Override
     protected void onCancelled() {
         super.onCancelled();
@@ -67,9 +61,6 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(C result) {
         super.onPostExecute(result);
@@ -97,9 +88,6 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
     
     protected abstract void deliverError(R receiver, Exception e);
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onPreExecute()
-     */
     @Override
     protected void onPreExecute() {
         super.onPreExecute();
@@ -113,9 +101,6 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.os.AsyncTask#onProgressUpdate(Progress[])
-     */
     @Override
     protected void onProgressUpdate(B... values) {
         super.onProgressUpdate(values);

--- a/app/src/org/commcare/android/util/AndroidResourceInstallerFactory.java
+++ b/app/src/org/commcare/android/util/AndroidResourceInstallerFactory.java
@@ -25,46 +25,26 @@ public class AndroidResourceInstallerFactory extends InstallerFactory {
         this.app = app;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.InstallerFactory#getXFormInstaller()
-     */
     @Override
     public ResourceInstaller getXFormInstaller() {
         return new XFormAndroidInstaller(GlobalConstants.INSTALL_REF, GlobalConstants.UPGRADE_REF);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.InstallerFactory#getProfileInstaller(boolean)
-     */
     @Override
     public ResourceInstaller getProfileInstaller(boolean forceInstall) {
         return new ProfileAndroidInstaller(GlobalConstants.INSTALL_REF, GlobalConstants.UPGRADE_REF);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.InstallerFactory#getSuiteInstaller()
-     */
     @Override
     public ResourceInstaller getSuiteInstaller() {
         return new SuiteAndroidInstaller(GlobalConstants.INSTALL_REF, GlobalConstants.UPGRADE_REF);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.InstallerFactory#getLocaleFileInstaller(java.lang.String)
-     */
     @Override
     public ResourceInstaller getLocaleFileInstaller(String locale) {
         return new LocaleAndroidInstaller(GlobalConstants.INSTALL_REF, GlobalConstants.UPGRADE_REF, locale);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.InstallerFactory#getMediaInstaller(java.lang.String)
-     */
     @Override
     public ResourceInstaller getMediaInstaller(String path) {
         return new MediaFileAndroidInstaller(GlobalConstants.MEDIA_REF, GlobalConstants.UPGRADE_REF, path);

--- a/app/src/org/commcare/android/util/CallInPhoneListener.java
+++ b/app/src/org/commcare/android/util/CallInPhoneListener.java
@@ -59,10 +59,6 @@ public class CallInPhoneListener extends PhoneStateListener {
 
     static final boolean disabled = true;
 
-    /*
-     * (non-Javadoc)
-     * @see android.telephony.PhoneStateListener#onCallStateChanged(int, java.lang.String)
-     */
     @Override
     public void onCallStateChanged(int state, String incomingNumber) {
         super.onCallStateChanged(state, incomingNumber);
@@ -108,10 +104,6 @@ public class CallInPhoneListener extends PhoneStateListener {
         if(disabled) {return;}
         AsyncTask<Void, Void, Void> loader = new AsyncTask<Void, Void, Void>() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.os.AsyncTask#doInBackground(java.lang.Object[])
-             */
             @Override
             protected Void doInBackground(Void... params) {
                     synchronized(cachedNumbers) {

--- a/app/src/org/commcare/android/util/CommCareExceptionHandler.java
+++ b/app/src/org/commcare/android/util/CommCareExceptionHandler.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.util;
 
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -12,7 +9,6 @@ import org.commcare.android.tasks.ExceptionReportTask;
  * completeness and usefulness.
  * 
  * @author ctsims
- *
  */
 public class CommCareExceptionHandler implements UncaughtExceptionHandler {
 
@@ -21,9 +17,7 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
     public CommCareExceptionHandler(UncaughtExceptionHandler parent) {
         this.parent = parent;
     }
-    /* (non-Javadoc)
-     * @see java.lang.Thread.UncaughtExceptionHandler#uncaughtException(java.lang.Thread, java.lang.Throwable)
-     */
+    @Override
     public void uncaughtException(Thread thread, Throwable ex) {
         ExceptionReportTask task = new ExceptionReportTask();
         task.execute(ex);

--- a/app/src/org/commcare/android/util/DummyResourceTable.java
+++ b/app/src/org/commcare/android/util/DummyResourceTable.java
@@ -25,19 +25,11 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  */
 public class DummyResourceTable extends ResourceTable {
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#isEmpty()
-     */
     @Override
     public boolean isEmpty() {
         return false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#getInstallers()
-     */
     @Override
     public InstallerFactory getInstallers() {
         return new InstallerFactory() {
@@ -106,10 +98,6 @@ public class DummyResourceTable extends ResourceTable {
                         throw new RuntimeException("Basic Installer resources can't rolled back");
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.resources.model.ResourceInstaller#uninstall(org.commcare.resources.model.Resource)
-                     */
                     @Override
                     public boolean uninstall(Resource r)
                             throws UnresolvedResourceException {
@@ -117,30 +105,18 @@ public class DummyResourceTable extends ResourceTable {
                         return true;
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.resources.model.ResourceInstaller#unstage(org.commcare.resources.model.Resource, int)
-                     */
                     @Override
                     public boolean unstage(Resource r, int newStatus) {
                         // TODO Auto-generated method stub
                         return true;
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.resources.model.ResourceInstaller#revert(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceTable)
-                     */
                     @Override
                     public boolean revert(Resource r, ResourceTable table) {
                         // TODO Auto-generated method stub
                         return true;
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.resources.model.ResourceInstaller#upgrade(org.commcare.resources.model.Resource)
-                     */
                     @Override
                     public boolean upgrade(Resource r)
                             throws UnresolvedResourceException {
@@ -164,149 +140,81 @@ public class DummyResourceTable extends ResourceTable {
         };
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#removeResource(org.commcare.resources.model.Resource)
-     */
     @Override
     public void removeResource(Resource resource) {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#addResource(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceInstaller, java.lang.String, int)
-     */
     @Override
     public void addResource(Resource resource, ResourceInstaller initializer, String parentId, int status) throws StorageFullException {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#addResource(org.commcare.resources.model.Resource, org.commcare.resources.model.ResourceInstaller, java.lang.String)
-     */
     @Override
     public void addResource(Resource resource, ResourceInstaller initializer,
             String parentId) throws StorageFullException {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#addResource(org.commcare.resources.model.Resource, int)
-     */
     @Override
     public void addResource(Resource resource, int status)
             throws StorageFullException {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#getResourcesForParent(java.lang.String)
-     */
     @Override
     public Vector<Resource> getResourcesForParent(String parent) {
         return new Vector<Resource>();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#getResourceWithId(java.lang.String)
-     */
     @Override
     public Resource getResourceWithId(String id) {
         return null;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#getResourceWithGuid(java.lang.String)
-     */
     @Override
     public Resource getResourceWithGuid(String guid) {
         return null;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#isReady()
-     */
     @Override
     public boolean isReady() {
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#commit(org.commcare.resources.model.Resource, int, int)
-     */
     @Override
     public void commit(Resource r, int status, int version) throws UnresolvedResourceException {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#commit(org.commcare.resources.model.Resource, int)
-     */
     @Override
     public void commit(Resource r, int status) {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#commit(org.commcare.resources.model.Resource)
-     */
     @Override
     public void commit(Resource r) {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#prepareResources(org.commcare.resources.model.ResourceTable, org.commcare.util.CommCareInstance)
-     */
     @Override
     public void prepareResources(ResourceTable master, CommCareInstance instance)
             throws UnresolvedResourceException,
             UnfullfilledRequirementsException {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#upgradeTable(org.commcare.resources.model.ResourceTable)
-     */
     @Override
     public boolean upgradeTable(ResourceTable incoming)
             throws UnresolvedResourceException {
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#toString()
-     */
     @Override
     public String toString() {
         return "Dummy Table";
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#destroy()
-     */
     @Override
     public void destroy() {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#clear()
-     */
     @Override
     public void clear() {
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.resources.model.ResourceTable#initializeResources(org.commcare.util.CommCareInstance)
-     */
     @Override
     public void initializeResources(CommCareInstance instance)
             throws ResourceInitializationException {

--- a/app/src/org/commcare/android/util/ODKPropertyManager.java
+++ b/app/src/org/commcare/android/util/ODKPropertyManager.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.util;
 
 import java.util.Vector;
@@ -10,56 +7,40 @@ import org.javarosa.core.services.properties.IPropertyRules;
 
 /**
  * @author ctsims
- *
  */
 public class ODKPropertyManager implements IPropertyManager {
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#addRules(org.javarosa.core.services.properties.IPropertyRules)
-     */
+    @Override
     public void addRules(IPropertyRules rules) {
         // TODO Auto-generated method stub
-
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#getProperty(java.lang.String)
-     */
+    @Override
     public Vector getProperty(String propertyName) {
         // TODO Auto-generated method stub
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#getRules()
-     */
+    @Override
     public Vector getRules() {
         // TODO Auto-generated method stub
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#getSingularProperty(java.lang.String)
-     */
+    @Override
     public String getSingularProperty(String propertyName) {
         // TODO Auto-generated method stub
         return null;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#setProperty(java.lang.String, java.lang.String)
-     */
+    @Override
     public void setProperty(String propertyName, String propertyValue) {
         // TODO Auto-generated method stub
 
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#setProperty(java.lang.String, java.util.Vector)
-     */
+    @Override
     public void setProperty(String propertyName, Vector propertyValue) {
         // TODO Auto-generated method stub
-
     }
-
 }

--- a/app/src/org/commcare/android/util/bitcache/FileBitCache.java
+++ b/app/src/org/commcare/android/util/bitcache/FileBitCache.java
@@ -38,9 +38,7 @@ public class FileBitCache implements BitCache {
         this.context = context;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.util.bitcache.BitCache#initializeCache()
-     */
+    @Override
     public void initializeCache() throws IOException {
         File cacheLocation = context.getCacheDir();
         
@@ -49,9 +47,7 @@ public class FileBitCache implements BitCache {
         key = CryptUtil.generateSemiRandomKey();
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.util.bitcache.BitCache#getCacheStream()
-     */
+    @Override
     public OutputStream getCacheStream() throws IOException{
         //generate write key/cipher
         try {
@@ -77,9 +73,7 @@ public class FileBitCache implements BitCache {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.util.bitcache.BitCache#retrieveCache()
-     */
+    @Override
     public InputStream retrieveCache() throws IOException {
         try{
             //generate read key/cipher

--- a/app/src/org/commcare/android/util/bitcache/MemoryBitCache.java
+++ b/app/src/org/commcare/android/util/bitcache/MemoryBitCache.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.commcare.android.util.bitcache;
 
 import java.io.ByteArrayInputStream;
@@ -10,7 +7,6 @@ import java.io.OutputStream;
 
 /**
  * @author ctsims
- *
  */
 public class MemoryBitCache implements BitCache {
     
@@ -21,24 +17,18 @@ public class MemoryBitCache implements BitCache {
         
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.util.bitcache.BitCache#initializeCache()
-     */
+    @Override
     public void initializeCache() {
         bos = new ByteArrayOutputStream();
         data = null;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.util.bitcache.BitCache#getCacheStream()
-     */
+    @Override
     public OutputStream getCacheStream() {
         return bos;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.util.bitcache.BitCache#retrieveCache()
-     */
+    @Override
     public InputStream retrieveCache() {
         if(data == null) {
             data = bos.toByteArray();
@@ -46,6 +36,7 @@ public class MemoryBitCache implements BitCache {
         }
         return new ByteArrayInputStream(data);
     }
+
     public void release() {
         bos = null;
         data = null;

--- a/app/src/org/commcare/android/view/EntityView.java
+++ b/app/src/org/commcare/android/view/EntityView.java
@@ -231,10 +231,6 @@ public class EntityView extends LinearLayout {
 
         btn.setOnClickListener(new OnClickListener(){
 
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 String textToRead = text;
@@ -502,10 +498,6 @@ public class EntityView extends LinearLayout {
         return widths;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.LinearLayout#onMeasure(int, int)
-     */
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);

--- a/app/src/org/commcare/android/view/HorizontalMediaView.java
+++ b/app/src/org/commcare/android/view/HorizontalMediaView.java
@@ -190,10 +190,6 @@ public class HorizontalMediaView extends RelativeLayout {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.View#onWindowVisibilityChanged(int)
-     */
     @Override
     protected void onWindowVisibilityChanged(int visibility) {
         super.onWindowVisibilityChanged(visibility);

--- a/app/src/org/commcare/dalvik/activities/CallLogActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallLogActivity.java
@@ -34,10 +34,6 @@ public class CallLogActivity<T extends Persistable> extends ListActivity {
     
     boolean isMessages = false;
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -48,24 +44,13 @@ public class CallLogActivity<T extends Persistable> extends ListActivity {
         
         refreshView();
     }
-    
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(EXTRA_MESSAGES,isMessages);
     }
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onRestoreInstanceState(Bundle inState) {
         super.onRestoreInstanceState(inState);
@@ -100,10 +85,7 @@ public class CallLogActivity<T extends Persistable> extends ListActivity {
         this.setListAdapter(adapter);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.ListActivity#onListItemClick(android.widget.ListView, android.view.View, int, long)
-     * 
+    /**
      * Stores the path of selected form and finishes.
      */
     @Override

--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -38,10 +38,6 @@ public class CallOutActivity extends Activity {
     TelephonyManager tManager;
     CallListener listener;
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -152,10 +148,6 @@ public class CallOutActivity extends Activity {
         long duration;
         boolean finished = false;
 
-        /*
-         * (non-Javadoc)
-         * @see android.telephony.PhoneStateListener#onCallStateChanged(int, java.lang.String)
-         */
         @Override
         public void onCallStateChanged(int state, String incomingNumber) {
             super.onCallStateChanged(state, incomingNumber);

--- a/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
@@ -69,9 +69,6 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
     
     protected String filepath;
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         
@@ -95,10 +92,6 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
                 
                 SharedPreferences settings = CommCareApplication._().getCurrentApp().getAppPreferences();
                 SendTask<CommCareFormDumpActivity> mSendTask = new SendTask<CommCareFormDumpActivity>(getApplicationContext(), settings.getString("PostURL", url), getFolderPath()){
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                     */
                     @Override
                     protected void deliverResult( CommCareFormDumpActivity receiver, Boolean result) {
                         
@@ -117,20 +110,12 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                     */
                     @Override
                     protected void deliverUpdate(CommCareFormDumpActivity receiver, String... update) {
                         receiver.updateProgress(update[0], BULK_SEND_ID);
                         receiver.txtInteractiveMessages.setText(update[0]);
                     }
                     
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                     */
                     @Override
                     protected void deliverError(CommCareFormDumpActivity receiver, Exception e) {
                         Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "SendTask error: " + ExceptionReportTask.getStackTrace(e));
@@ -144,10 +129,6 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
         });
         
         btnDumpForms.setOnClickListener(new OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 
@@ -158,10 +139,6 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
                 }
                 SharedPreferences settings = CommCareApplication._().getCurrentApp().getAppPreferences();
                 DumpTask mDumpTask = new DumpTask(getApplicationContext(), txtInteractiveMessages){
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                     */
                     @Override
                     protected void deliverResult( CommCareFormDumpActivity receiver, Boolean result) {
                         if(result == Boolean.TRUE){
@@ -175,20 +152,12 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                     */
                     @Override
                     protected void deliverUpdate(CommCareFormDumpActivity receiver, String... update) {
                         receiver.updateProgress(update[0], BULK_DUMP_ID);
                         receiver.txtInteractiveMessages.setText(update[0]);
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                     */
                     @Override
                     protected void deliverError(CommCareFormDumpActivity receiver, Exception e) {
                         receiver.txtInteractiveMessages.setText(Localization.get("bulk.form.error", new String[] {e.getMessage()}));
@@ -207,11 +176,6 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onActivityResult(int, int, android.content.Intent)
-     */
-    
     private AlertDialog popupWarningMessage(){
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
         alertDialogBuilder.setTitle(Localization.get("bulk.form.alert.title"));
@@ -294,9 +258,6 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
         return ids;
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -306,23 +267,16 @@ public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpA
         finish();
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#taskCancelled(int)
-     */
     @Override
     public void taskCancelled(int id) {
         txtInteractiveMessages.setText(Localization.get("bulk.form.cancel"));
         this.transplantStyle(txtInteractiveMessages, R.layout.template_text_notification_problem);
     }
     
-    /** Implementation of generateProgressDialog() for DialogController -- other methods
+    /* Implementation of generateProgressDialog() for DialogController -- other methods
      * handled entirely in CommCareActivity
      */
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     */
     @Override
     public CustomProgressDialog generateProgressDialog(int taskId) {
         String title, message;

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -175,10 +175,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     ImageView topBannerImageView;
     int gridViewMargin;
 
-    /*
-         * (non-Javadoc)
-         * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-         */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -412,10 +408,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
         DataPullTask<CommCareHomeActivity> mDataPullTask = new DataPullTask<CommCareHomeActivity>(u.getUsername(), u.getCachedPwd(), prefs.getString("ota-restore-url", this.getString(R.string.ota_restore_url)), "", this) {
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult(CommCareHomeActivity receiver, Integer result) {
                 receiver.refreshView();
@@ -448,10 +440,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(CommCareHomeActivity receiver, Integer... update) {
                 if (update[0] == DataPullTask.PROGRESS_STARTED) {
@@ -472,10 +460,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 }
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(CommCareHomeActivity receiver,
                                         Exception e) {
@@ -489,22 +473,12 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         mDataPullTask.execute();
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean("was_external", wasExternal);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onRestoreInstanceState(Bundle inState) {
         super.onRestoreInstanceState(inState);
@@ -513,10 +487,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onActivityResult(int, int, android.content.Intent)
-     */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if(resultCode == RESULT_RESTART) {
@@ -943,10 +913,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             Text text = session.getCurrentEntry().getAssertions().getAssertionFailure(ec);
             if (text != null) {
                 createErrorDialog(text.evaluate(ec), new DialogInterface.OnClickListener() {
-                    /*
-                     * (non-Javadoc)
-                     * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                     */
                     @Override
                     public void onClick(DialogInterface dialog, int i) {
                         session.stepBack();
@@ -1050,10 +1016,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             formEntry(platform.getFormContentUri(record.getFormNamespace()), record, CommCareActivity.getTitle(this, null));
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#getActivityTitle()
-     */
     @Override
     public String getActivityTitle() {
         String userName = null;
@@ -1069,10 +1031,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         return "";
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#isTopNavEnabled()
-     */
     @Override
     protected boolean isTopNavEnabled() {
         return false;
@@ -1151,10 +1109,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         ProcessAndSendTask<CommCareHomeActivity> mProcess = new ProcessAndSendTask<CommCareHomeActivity>(this, getFormPostURL(),
                 sendTaskId, syncAfterwards) {
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult(CommCareHomeActivity receiver, Integer result) {
                 if (result == ProcessAndSendTask.PROGRESS_LOGGED_OUT) {
@@ -1183,19 +1137,11 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(CommCareHomeActivity receiver, Long... update) {
                 //we don't need to deliver updates here, it happens on the notification bar
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(CommCareHomeActivity receiver, Exception e) {
                 //TODO: Display somewhere useful
@@ -1221,11 +1167,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -1543,10 +1484,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     //END - Process and Send Listeners
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreateOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
@@ -1572,9 +1509,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     }
 
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onPrepareOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
@@ -1595,10 +1529,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 
@@ -1747,10 +1677,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
      */
     
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     */
     @Override
     public CustomProgressDialog generateProgressDialog(int taskId) {
         String title, message;
@@ -1779,10 +1705,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         return dialog;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#isBackEnabled()
-     */
     @Override
     public boolean isBackEnabled() {
         return false;

--- a/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
@@ -101,10 +101,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
     public FormRecord[] cachedRecords;
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState){
         super.onCreate(savedInstanceState);
@@ -138,10 +134,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         
         discoverButton = (Button)this.findViewById(R.id.discover_button);
         discoverButton.setOnClickListener(new OnClickListener(){
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 discoverPeers();
@@ -151,10 +143,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         sendButton = (Button)this.findViewById(R.id.send_button);
         sendButton.setOnClickListener(new OnClickListener(){
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 prepareFileTransfer();
@@ -164,10 +152,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         submitButton = (Button)this.findViewById(R.id.submit_button);
         submitButton.setOnClickListener(new OnClickListener(){
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 submitFiles();
@@ -177,10 +161,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         changeModeButton = (Button)this.findViewById(R.id.reset_state_button);
         changeModeButton.setOnClickListener(new OnClickListener(){
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 changeState();
@@ -215,10 +195,8 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         updateStatusText();
     }
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onPause()
-     * 
+
+    /**
      * unregister the broadcast receiver
      */
     @Override
@@ -268,10 +246,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         builder.setMessage(message);
         builder.setNeutralButton(localize("wifi.direct.receive.forms"), new DialogInterface.OnClickListener(){
 
-            /*
-             * (non-Javadoc)
-             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-             */
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 beReceiver();
@@ -279,10 +253,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         builder.setNegativeButton(localize("wifi.direct.transfer.forms"), new DialogInterface.OnClickListener(){
 
-            /*
-             * (non-Javadoc)
-             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-             */
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 beSender();
@@ -419,30 +389,18 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         // remove Forms from CC
 
         WipeTask mWipeTask = new WipeTask(getApplicationContext(), this.cachedRecords){
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult(CommCareWiFiDirectActivity receiver,
                     Boolean result) {
                 receiver.onCleanSuccessful();
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(CommCareWiFiDirectActivity receiver, String... update) {
                 receiver.updateProgress(update[0], WipeTask.WIPE_TASK_ID);
                 receiver.myStatusText.setText(update[0]);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(CommCareWiFiDirectActivity receiver, Exception e) {
                 receiver.myStatusText.setText("Error wiping forms: " + e.getMessage());
@@ -499,10 +457,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         SharedPreferences settings = CommCareApplication._().getCurrentApp().getAppPreferences();
         SendTask<CommCareWiFiDirectActivity> mSendTask = new SendTask<CommCareWiFiDirectActivity>(getApplicationContext(), settings.getString("PostURL", url), receiveFolder){
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult(CommCareWiFiDirectActivity receiver, Boolean result) {
                 if(result == Boolean.TRUE){
@@ -516,20 +470,12 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
                 }
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(CommCareWiFiDirectActivity receiver, String... update) {
                 receiver.updateProgress(update[0], BULK_SEND_ID);
                 receiver.myStatusText.setText(update[0]);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(CommCareWiFiDirectActivity receiver, Exception e) {
                 Logger.log(TAG, "Error submitting forms in wi-fi direct");
@@ -570,10 +516,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         Log.d(TAG, "creating unzip task");
 
         UnzipTask<CommCareWiFiDirectActivity> mUnzipTask = new UnzipTask<CommCareWiFiDirectActivity>() {
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult( CommCareWiFiDirectActivity receiver, Integer result) {
                 Log.d(TAG, "delivering unzip result");
@@ -586,10 +528,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
                 }
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(CommCareWiFiDirectActivity receiver, String... update) {
                 Log.d(TAG, "delivering unzip upate");
@@ -597,10 +535,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
                 receiver.myStatusText.setText(update[0]);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(CommCareWiFiDirectActivity receiver, Exception e) {
                 Log.d(TAG, "unzip deliver error: " + e.getMessage());
@@ -636,20 +570,12 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         mManager.discoverPeers(mChannel, new WifiP2pManager.ActionListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onSuccess()
-             */
             @Override
             public void onSuccess() {
                 Toast.makeText(CommCareWiFiDirectActivity.this, "Discovery Initiated",
                         Toast.LENGTH_SHORT).show();
             }
 
-            /*
-             * (non-Javadoc)
-             * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onFailure(int)
-             */
             @Override
             public void onFailure(int reasonCode) {
 
@@ -683,10 +609,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.DeviceListFragment.DeviceActionListener#showDetails(android.net.wifi.p2p.WifiP2pDevice)
-     */
     @Override
     public void showDetails(WifiP2pDevice device) {
         Log.d(TAG, "showDetails");
@@ -696,10 +618,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         fragment.showDetails(device);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.DeviceListFragment.DeviceActionListener#connect(android.net.wifi.p2p.WifiP2pConfig)
-     */
     @Override
     public void connect(WifiP2pConfig config) {
         Logger.log(TAG,"connecting to wi-fi peer");
@@ -708,19 +626,11 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         mManager.connect(mChannel, config, new ActionListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onSuccess()
-             */
             @Override
             public void onSuccess() {
                 // WiFiDirectBroadcastReceiver will notify us. Ignore for now.
             }
 
-            /*
-             * (non-Javadoc)
-             * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onFailure(int)
-             */
             @Override
             public void onFailure(int reason) {
                 Logger.log(TAG,"Connection to peer failed");
@@ -730,10 +640,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         });
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.DeviceListFragment.DeviceActionListener#disconnect()
-     */
     @Override
     public void disconnect() {
         Logger.log(TAG, "disconnecting from wi-fi direct group");
@@ -742,20 +648,12 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         fragment.resetViews();
         mManager.removeGroup(mChannel, new ActionListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onFailure(int)
-             */
             @Override
             public void onFailure(int reasonCode) {
                 Log.d(TAG, "Disconnect failed. Reason :" + reasonCode);
 
             }
 
-            /*
-             * (non-Javadoc)
-             * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onSuccess()
-             */
             @Override
             public void onSuccess() {
                 fragment.getView().setVisibility(View.GONE);
@@ -764,10 +662,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         });
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.DeviceListFragment.DeviceActionListener#cancelDisconnect()
-     */
     @Override
     public void cancelDisconnect() {
         //  A cancel abort request by user. Disconnect i.e. removeGroup if
@@ -784,20 +678,12 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
                 mManager.cancelConnect(mChannel, new ActionListener() {
 
-                    /*
-                     * (non-Javadoc)
-                     * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onSuccess()
-                     */
                     @Override
                     public void onSuccess() {
                         Toast.makeText(CommCareWiFiDirectActivity.this, "Aborting connection",
                                 Toast.LENGTH_SHORT).show();
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see android.net.wifi.p2p.WifiP2pManager.ActionListener#onFailure(int)
-                     */
                     @Override
                     public void onFailure(int reasonCode) {
                         Toast.makeText(CommCareWiFiDirectActivity.this,
@@ -870,30 +756,18 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         Logger.log(TAG, "Zipping Files");
         Log.d(CommCareWiFiDirectActivity.TAG, "Zipping Files2");
         ZipTask mZipTask = new ZipTask(this) {
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(CommCareWiFiDirectActivity receiver, String... update) {
                 receiver.updateProgress(update[0], taskId);
                 receiver.myStatusText.setText(update[0]);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(CommCareWiFiDirectActivity receiver, Exception e) {
                 receiver.myStatusText.setText("Error zipping files");
                 receiver.transplantStyle(receiver.myStatusText, R.layout.template_text_notification_problem);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult(CommCareWiFiDirectActivity receiver, FormRecord[] result) {
                 if(result != null){
@@ -923,10 +797,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
         FormTransferTask mTransferTask = new FormTransferTask(address,sourceZipDirectory,8988){
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult(CommCareWiFiDirectActivity receiver,
                     Boolean result) {
@@ -941,10 +811,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(CommCareWiFiDirectActivity receiver,
                     String... update) {
@@ -952,10 +818,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
                 receiver.myStatusText.setText(update[0]);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(CommCareWiFiDirectActivity receiver,
                     Exception e) {
@@ -1047,10 +909,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.FileServerFragment.FileServerListener#onFormsCopied(java.lang.String)
-     */
     @Override
     public void onFormsCopied(String result) {
         Logger.log(TAG, "Copied files successfully");
@@ -1058,10 +916,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
         this.unzipFiles(result);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.WiFiDirectManagementFragment.WifiDirectManagerListener#updatePeers()
-     */
     @Override
     public void updatePeers() {
         Logger.log(TAG, "Wi-Fi direct peers updating");
@@ -1070,10 +924,6 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.WiFiDirectManagementFragment.WifiDirectManagerListener#updateDeviceStatus(android.net.wifi.p2p.WifiP2pDevice)
-     */
     @Override
     public void updateDeviceStatus(WifiP2pDevice mDevice) {
         Logger.log(TAG, "Wi-fi direct status updating");
@@ -1084,10 +934,7 @@ public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDir
 
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     * 
+    /**
      * Implementation of generateProgressDialog() for DialogController -- other methods
      * handled entirely in CommCareActivity
      */

--- a/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
@@ -50,20 +50,12 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
         
     
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
         btnRunTest.setOnClickListener(new OnClickListener() 
         {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v)
             {
@@ -72,10 +64,6 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
                         getApplicationContext(),
                         CommCareApplication._().getCurrentApp().getCommCarePlatform())
                 {    
-                /*
-                 * (non-Javadoc)
-                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                 */
                 @Override
                     //<R> receiver, <C> result. 
                     //<C> is the return from DoTaskBackground, of type ArrayList<Boolean>
@@ -118,20 +106,12 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
                         return;
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                     */
                     @Override
                     protected void deliverUpdate(ConnectionDiagnosticActivity receiver, String... update) 
                     {
                         receiver.txtInteractiveMessages.setText((Localization.get("connection.test.update.message")));
                     }
                     
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                     */
                     @Override
                     protected void deliverError(ConnectionDiagnosticActivity receiver, Exception e)
                     {
@@ -148,10 +128,6 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
         //Set a button that allows you to change your airplane mode settings
         this.settingsButton.setOnClickListener( new OnClickListener()
         {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v)
             {
@@ -161,10 +137,6 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
         
         this.reportButton.setOnClickListener( new OnClickListener()
         {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v)
             {
@@ -201,10 +173,7 @@ public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDia
         });
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     * 
+    /**
      * Implementation of generateProgressDialog() for DialogController -- other methods
      * handled entirely in CommCareActivity
      */

--- a/app/src/org/commcare/dalvik/activities/DotsEntryActivity.java
+++ b/app/src/org/commcare/dalvik/activities/DotsEntryActivity.java
@@ -68,10 +68,6 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
     int zX = -1;
     int zY = -1;
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -145,11 +141,6 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
         mGestureDetector = new GestureDetector();
     }
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
@@ -161,10 +152,6 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onRestoreInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onRestoreInstanceState(Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
@@ -291,10 +278,6 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -307,10 +290,6 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onPause()
-     */
     @Override
     protected void onPause() {
         super.onPause();
@@ -328,10 +307,6 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
         showView(home, AnimationType.zoomout);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onKeyDown(int, android.view.KeyEvent)
-     */
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         switch (keyCode) {
@@ -366,11 +341,6 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
 
     boolean mBeenSwiped;
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onTouchEvent(android.view.MotionEvent)
-     */
     @Override
     public boolean onTouchEvent(MotionEvent motionEvent) {
         /*

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -68,10 +68,6 @@ public class EntityDetailActivity extends CommCareActivity implements DetailCall
     @UiElement(value=R.id.entity_detail_tabs)
     TabbedDetailView mDetailView;
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {        
         Intent i = getIntent();
@@ -144,20 +140,12 @@ public class EntityDetailActivity extends CommCareActivity implements DetailCall
         return mEntityContext;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#isTopNavEnabled()
-     */
     @Override
     protected boolean isTopNavEnabled() {
         return true;
     }
     
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#getActivityTitle()
-     */
     @Override
     public String getActivityTitle() {
         //Skipping this until it's a more general pattern
@@ -178,10 +166,6 @@ public class EntityDetailActivity extends CommCareActivity implements DetailCall
         i.putExtra(SessionFrame.STATE_DATUM_VAL, this.getIntent().getStringExtra(SessionFrame.STATE_DATUM_VAL));
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onActivityResult(int, int, android.content.Intent)
-     */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         switch(requestCode) {
@@ -222,10 +206,6 @@ public class EntityDetailActivity extends CommCareActivity implements DetailCall
         DetailCalloutListenerDefaultImpl.performCallout(this, callout, id);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onForwardSwipe()
-     */
     @Override
     protected boolean onForwardSwipe() {
         // Move along, provided we're on the last tab of tabbed case details
@@ -236,10 +216,6 @@ public class EntityDetailActivity extends CommCareActivity implements DetailCall
         return false;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onBackwardSwipe()
-     */
     @Override
     protected boolean onBackwardSwipe() {
         // Move back, provided we're on the first screen of tabbed case details

--- a/app/src/org/commcare/dalvik/activities/EntityMapActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityMapActivity.java
@@ -61,9 +61,6 @@ public class EntityMapActivity extends MapActivity {
     EntityOverlay mEntityOverlay;
     Vector<Entity<TreeReference>> entities;
     
-    /* (non-Javadoc)
-     * @see com.google.android.maps.MapActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
@@ -130,10 +127,6 @@ public class EntityMapActivity extends MapActivity {
         Drawable defaultMarker = this.getResources().getDrawable(R.drawable.marker);
         mEntityOverlay = new EntityOverlay(this, defaultMarker, map) {
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.dalvik.geo.EntityOverlay#selected(org.javarosa.core.model.instance.TreeReference)
-             */
             @Override
             protected void selected(TreeReference ref) {
                 Intent i = new Intent(EntityMapActivity.this.getIntent());
@@ -275,9 +268,6 @@ public class EntityMapActivity extends MapActivity {
     }
 
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onStop()
-     */
     @Override
     protected void onStop() {
         super.onStop();
@@ -285,9 +275,6 @@ public class EntityMapActivity extends MapActivity {
         mMyLocationOverlay.disableMyLocation();
     }
 
-    /* (non-Javadoc)
-     * @see com.google.android.maps.MapActivity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -146,10 +146,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
     private DataSetObserver mListStateObserver;
     private OnClickListener barcodeScanOnClickListener;
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -364,19 +360,11 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         };
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#isTopNavEnabled()
-     */
     @Override
     protected boolean isTopNavEnabled() {
         return true;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#getActivityTitle()
-     */
     @Override
     public String getActivityTitle() {
         //Skipping this until it's a more general pattern
@@ -533,10 +521,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         return detailIntent;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.AdapterView.OnItemClickListener#onItemClick(android.widget.AdapterView, android.view.View, int, long)
-     */
     @Override
     public void onItemClick(AdapterView<?> listView, View view, int position, long id) {
         if(id == EntityListAdapter.SPECIAL_ACTION) {
@@ -559,10 +543,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onActivityResult(int, int, android.content.Intent)
-     */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         switch(requestCode){
@@ -680,10 +660,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreateOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
@@ -753,9 +729,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         return searchbox.getText();
     }
     
-    /* (non-Javadoc)
-     * @see android.app.Activity#onPrepareOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         
@@ -766,10 +739,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         return super.onPrepareOptionsMenu(menu);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -859,10 +828,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         alert.show();
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onDestroy()
-     */
     @Override
     public void onDestroy() {
         super.onDestroy();
@@ -884,10 +849,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.speech.tts.TextToSpeech.OnInitListener#onInit(int)
-     */
     @Override
     public void onInit(int status) {
  
@@ -899,10 +860,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.EntityLoaderListener#deliverResult(java.util.List, java.util.List)
-     */
     @Override
     public void deliverResult(List<Entity<TreeReference>> entities, List<TreeReference> references, NodeEntityFactory factory) {
         loader = null;
@@ -958,10 +915,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.EntityLoaderListener#attach(org.commcare.android.tasks.EntityLoaderTask)
-     */
     @Override
     public void attach(EntityLoaderTask task) {
         findViewById(R.id.entity_select_loading).setVisibility(View.VISIBLE);
@@ -1046,20 +999,12 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
            detailView.refresh(factory.getDetail(), selection, detailIndex, false);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.tasks.EntityLoaderListener#deliverError(java.lang.Exception)
-     */
     @Override
     public void deliverError(Exception e) {
         displayException(e);
     }
 
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onForwardSwipe()
-     */
     @Override
     protected boolean onForwardSwipe() {
         // If user has picked an entity, move along to form entry
@@ -1075,10 +1020,6 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
         return true;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onBackwardSwipe()
-     */
     @Override
     protected boolean onBackwardSwipe() {
         if (inAwesomeMode && detailView != null && detailView.getCurrentTab() > 0) {

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -114,10 +114,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
     }
 
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -165,10 +161,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                 filterSelect.setAdapter(spinneritems);
                 spinneritems.setDropDownViewResource(R.layout.form_filter_item);
                 filterSelect.setOnItemSelectedListener(new OnItemSelectedListener() {
-                    /*
-                     * (non-Javadoc)
-                     * @see android.widget.AdapterView.OnItemSelectedListener#onItemSelected(android.widget.AdapterView, android.view.View, int, long)
-                     */
                     @Override
                     public void onItemSelected(AdapterView<?> arg0, View arg1, int index, long id) {
                         // NOTE: This gets called every time a spinner gets
@@ -184,10 +176,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see android.widget.AdapterView.OnItemSelectedListener#onNothingSelected(android.widget.AdapterView)
-                     */
                     @Override
                     public void onNothingSelected(AdapterView<?> arg0) {
                         // TODO Auto-generated method stub
@@ -253,10 +241,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.AdapterView.OnItemClickListener#onItemClick(android.widget.AdapterView, android.view.View, int, long)
-     * 
+    /**
      * Stores the path of selected form and finishes.
      */
     @Override
@@ -279,10 +264,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreateContextMenu(android.view.ContextMenu, android.view.View, android.view.ContextMenu.ContextMenuInfo)
-     */
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo)menuInfo;
@@ -301,10 +282,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         menu.add(Menu.NONE, SCAN_RECORD, SCAN_RECORD, Localization.get("app.workflow.forms.scan"));
     }
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onContextItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         try {
@@ -346,10 +323,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         mAlertDialog.setMessage(result.second);
         
         DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-             */
             @Override
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {
@@ -363,10 +336,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         mAlertDialog.show();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreateOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         boolean parent = super.onCreateOptionsMenu(menu);
@@ -417,10 +386,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         return parent;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onPrepareOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
@@ -438,10 +403,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
 
     TextToSpeech mTts;
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -463,30 +424,18 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                 //down.
                 DataPullTask<FormRecordListActivity> pull = new DataPullTask<FormRecordListActivity>(u.getUsername(),u.getCachedPwd(), source, "", this) {
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                     */
                     @Override
                     protected void deliverResult(FormRecordListActivity receiver, Integer status) {
                         switch(status) {
                         case DataPullTask.DOWNLOAD_SUCCESS:                            
                             FormRecordCleanupTask<FormRecordListActivity> task = new FormRecordCleanupTask<FormRecordListActivity>(FormRecordListActivity.this, platform,CLEANUP_ID) {
 
-                                /*
-                                 * (non-Javadoc)
-                                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                                 */
                                 @Override
                                 protected void deliverResult( FormRecordListActivity receiver, Integer result) {
                                     receiver.refreshView();
                                     
                                 }
 
-                                /*
-                                 * (non-Javadoc)
-                                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                                 */
                                 @Override
                                 protected void deliverUpdate( FormRecordListActivity receiver, Integer... values) {
                                     if(values[0] < 0) {
@@ -502,10 +451,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                                     
                                 }
 
-                                /*
-                                 * (non-Javadoc)
-                                 * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                                 */
                                 @Override
                                 protected void deliverError( FormRecordListActivity receiver, Exception e) {
                                     receiver.taskError(e);
@@ -537,10 +482,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                     */
                     @Override
                     protected void deliverUpdate(FormRecordListActivity receiver, Integer... update) {
                         switch(update[0]){
@@ -552,10 +493,6 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                     */
                     @Override
                     protected void deliverError(FormRecordListActivity receiver, Exception e) {
                         receiver.taskError(e);
@@ -588,20 +525,12 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         CommCareUtil.triggerLogSubmission(this);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onDestroy()
-     */
     @Override
     protected void onDestroy() {
         super.onDestroy();
         adapter.release();
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#getWakeLockingLevel()
-     */
     @Override
     protected int getWakeLockingLevel() {
         return PowerManager.PARTIAL_WAKE_LOCK;
@@ -634,10 +563,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
         enableSearch();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     * 
+    /**
      * Implementation of generateProgressDialog() for DialogController -- other methods
      * handled entirely in CommCareActivity
      */

--- a/app/src/org/commcare/dalvik/activities/InstallArchiveActivity.java
+++ b/app/src/org/commcare/dalvik/activities/InstallArchiveActivity.java
@@ -62,18 +62,11 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
     private String currentRef;
     private String targetDirectory;
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         btnFetchFiles.setOnClickListener(new OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 //Go fetch us a file path!
@@ -89,10 +82,6 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
         });
 
         btnInstallArchive.setOnClickListener(new OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
 
@@ -115,10 +104,6 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
 
         UnzipTask<InstallArchiveActivity> mUnzipTask = new UnzipTask<InstallArchiveActivity>() {
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-             */
             @Override
             protected void deliverResult( InstallArchiveActivity receiver, Integer result) {
                 Log.d(TAG, "delivering unzip result");
@@ -131,10 +116,6 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
                 }
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-             */
             @Override
             protected void deliverUpdate(InstallArchiveActivity receiver, String... update) {
                 Log.d(TAG, "delivering unzip upate");
@@ -143,10 +124,6 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
                 receiver.txtInteractiveMessages.setText(update[0]);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-             */
             @Override
             protected void deliverError(InstallArchiveActivity receiver, Exception e) {
                 Log.d(TAG, "unzip deliver error: " + e.getMessage());
@@ -180,10 +157,6 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
 
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onActivityResult(int, int, android.content.Intent)
-     */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if(requestCode == REQUEST_FILE_LOCATION) {
@@ -200,9 +173,6 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -240,9 +210,6 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#taskCancelled(int)
-     */
     @Override
     public void taskCancelled(int id) {
         txtInteractiveMessages.setText(Localization.get("archive.install.cancelled"));
@@ -258,11 +225,7 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
         return targetDirectory;
     }
     
-    
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     * 
+    /**
      * Implementation of generateProgressDialog() for DialogController -- other methods
      * handled entirely in CommCareActivity
      */

--- a/app/src/org/commcare/dalvik/activities/KeyAccessRequestActivity.java
+++ b/app/src/org/commcare/dalvik/activities/KeyAccessRequestActivity.java
@@ -32,19 +32,12 @@ public class KeyAccessRequestActivity extends CommCareActivity<KeyAccessRequestA
     @UiElement(value = R.id.screen_permission_request_button_deny, locale="app.key.request.deny")
     Button denyButton;
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         
         grantButton.setOnClickListener(new OnClickListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 Intent response = new Intent(getIntent());
@@ -69,10 +62,6 @@ public class KeyAccessRequestActivity extends CommCareActivity<KeyAccessRequestA
         
         denyButton.setOnClickListener(new OnClickListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 setResult(Activity.RESULT_CANCELED);
@@ -84,9 +73,6 @@ public class KeyAccessRequestActivity extends CommCareActivity<KeyAccessRequestA
     
     
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         // TODO Auto-generated method stub

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -132,10 +132,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -175,10 +171,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
 
         final View activityRootView = findViewById(R.id.screen_login_main);
         activityRootView.getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.ViewTreeObserver.OnGlobalLayoutListener#onGlobalLayout()
-             */
             @Override
             public void onGlobalLayout() {
                 int hideAll = LoginActivity.this.getResources().getInteger(R.integer.login_screen_hide_all_cuttoff);
@@ -262,10 +254,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                     */
                     @Override
                     protected void deliverUpdate(LoginActivity receiver, Integer... update) {
                         if(update[0] == DataPullTask.PROGRESS_STARTED) {
@@ -286,10 +274,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                     */
                     @Override
                     protected void deliverError( LoginActivity receiver, Exception e) {
                         receiver.raiseLoginMessage(StockMessages.Restore_Unknown, true);
@@ -300,11 +284,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
         dataPuller.execute();
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -461,9 +440,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
     public void finished(int status) {
     }
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onCreateOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
@@ -471,9 +447,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         boolean otherResult = super.onOptionsItemSelected(item);
@@ -529,10 +502,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     * 
+    /**
      * Implementation of generateProgressDialog() for DialogController -- other methods
      * handled entirely in CommCareActivity
      */
@@ -558,10 +528,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
         return dialog;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#isBackEnabled()
-     */
     @Override
     public boolean isBackEnabled() {
         return false;

--- a/app/src/org/commcare/dalvik/activities/MenuGrid.java
+++ b/app/src/org/commcare/dalvik/activities/MenuGrid.java
@@ -59,10 +59,6 @@ public class MenuGrid extends CommCareActivity implements OnItemClickListener, O
     @UiElement(R.id.grid_menu_grid)
     private GridView grid;
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -81,20 +77,11 @@ public class MenuGrid extends CommCareActivity implements OnItemClickListener, O
        grid.setOnItemLongClickListener(this);
     }
 
-
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#isTopNavEnabled()
-     */
     @Override
     protected boolean isTopNavEnabled() {
         return true;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#getActivityTitle()
-     */
     @Override
     public String getActivityTitle() {
         //return adapter.getMenuTitle();
@@ -110,10 +97,7 @@ public class MenuGrid extends CommCareActivity implements OnItemClickListener, O
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.AdapterView.OnItemClickListener#onItemClick(android.widget.AdapterView, android.view.View, int, long)
-     * 
+    /**
      * Stores the path of selected form and finishes.
      */
     @Override
@@ -163,10 +147,7 @@ public class MenuGrid extends CommCareActivity implements OnItemClickListener, O
         return false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onBackwardSwipe()
-     */
+    @Override
     protected boolean onBackwardSwipe() {
         onBackPressed();
         return true;

--- a/app/src/org/commcare/dalvik/activities/MenuList.java
+++ b/app/src/org/commcare/dalvik/activities/MenuList.java
@@ -52,10 +52,6 @@ public class MenuList extends CommCareActivity implements OnItemClickListener {
     // removed the UiElement annotation here because it was causing a crash @ loadFields() in CommCareActivity
     private TextView header;
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -80,19 +76,11 @@ public class MenuList extends CommCareActivity implements OnItemClickListener {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#isTopNavEnabled()
-     */
     @Override
     protected boolean isTopNavEnabled() {
         return true;
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#getActivityTitle()
-     */
     @Override
     public String getActivityTitle() {
         //return adapter.getMenuTitle();
@@ -108,10 +96,7 @@ public class MenuList extends CommCareActivity implements OnItemClickListener {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.AdapterView.OnItemClickListener#onItemClick(android.widget.AdapterView, android.view.View, int, long)
-     * 
+    /**
      * Stores the path of selected form and finishes.
      */
     @Override
@@ -139,10 +124,6 @@ public class MenuList extends CommCareActivity implements OnItemClickListener {
         finish();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onBackwardSwipe()
-     */
     protected boolean onBackwardSwipe() {
         onBackPressed();
         return true;

--- a/app/src/org/commcare/dalvik/activities/MessageActivity.java
+++ b/app/src/org/commcare/dalvik/activities/MessageActivity.java
@@ -31,9 +31,6 @@ public class MessageActivity extends ListActivity {
     
     private static final String KEY_MESSAGES = "ma_key_messages";
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -44,27 +41,18 @@ public class MessageActivity extends ListActivity {
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelableArrayList(KEY_MESSAGES, messages);
     }
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
         this.setContentView(R.layout.screen_messages);
         this.setListAdapter(new ArrayAdapter<NotificationMessage>(this, R.layout.layout_note_msg, messages) {
 
-            /* (non-Javadoc)
-             * @see android.widget.ArrayAdapter#getView(int, android.view.View, android.view.ViewGroup)
-             */
             @Override
             public View getView(int position, View convertView, ViewGroup parent) {
                 View messageView = convertView;
@@ -87,9 +75,6 @@ public class MessageActivity extends ListActivity {
                 return messageView;
             }
 
-            /* (non-Javadoc)
-             * @see android.widget.BaseAdapter#isEnabled(int)
-             */
             @Override
             public boolean isEnabled(int position) {
                 return false;

--- a/app/src/org/commcare/dalvik/activities/MessageLogActivity.java
+++ b/app/src/org/commcare/dalvik/activities/MessageLogActivity.java
@@ -23,10 +23,6 @@ public class MessageLogActivity extends ListActivity {
     
     boolean isMessages = false;
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -44,10 +40,7 @@ public class MessageLogActivity extends ListActivity {
         this.setListAdapter(messages);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.ListActivity#onListItemClick(android.widget.ListView, android.view.View, int, long)
-     * 
+    /**
      * Stores the path of selected form and finishes.
      */
     @Override

--- a/app/src/org/commcare/dalvik/activities/MultimediaInflaterActivity.java
+++ b/app/src/org/commcare/dalvik/activities/MultimediaInflaterActivity.java
@@ -60,9 +60,6 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
     
     boolean done = false;
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
@@ -71,10 +68,6 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
         super.onCreate(savedInstanceState);
         btnFetchFiles.setOnClickListener(new OnClickListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 //Go fetch us a file path!
@@ -90,18 +83,10 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
         });
 
         btnInstallMultimedia.setOnClickListener(new OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 MultimediaInflaterTask<MultimediaInflaterActivity> task = new MultimediaInflaterTask<MultimediaInflaterActivity>() {
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                     */
                     @Override
                     protected void deliverResult( MultimediaInflaterActivity receiver, Boolean result) {
                         if(result == Boolean.TRUE){
@@ -116,20 +101,12 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                     */
                     @Override
                     protected void deliverUpdate(MultimediaInflaterActivity receiver, String... update) {
                         receiver.updateProgress(update[0], CommCareTask.GENERIC_TASK_ID);
                         receiver.txtInteractiveMessages.setText(update[0]);
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                     */
                     @Override
                     protected void deliverError(MultimediaInflaterActivity receiver, Exception e) {
                         receiver.txtInteractiveMessages.setText(Localization.get("mult.install.error", new String[] {e.getMessage()}));
@@ -156,10 +133,6 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onActivityResult(int, int, android.content.Intent)
-     */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if(requestCode == REQUEST_FILE_LOCATION) {
@@ -176,9 +149,6 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -217,9 +187,6 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
         }
     }
     
-    /* (non-Javadoc)
-     * @see org.commcare.android.tasks.templates.CommCareTaskConnector#taskCancelled(int)
-     */
     @Override
     public void taskCancelled(int id) {
         txtInteractiveMessages.setText(Localization.get("mult.install.cancelled"));
@@ -295,11 +262,7 @@ public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInfla
         }
     }
     
-    
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#generateProgressDialog(int)
-     * 
+    /**
      * Implementation of generateProgressDialog() for DialogController -- other methods
      * handled entirely in CommCareActivity
      */

--- a/app/src/org/commcare/dalvik/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/dalvik/activities/RecoveryActivity.java
@@ -50,9 +50,6 @@ public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
     TextView txtUserMessage;
     
     
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -67,10 +64,6 @@ public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
         
         sendForms.setOnClickListener(new OnClickListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @SuppressLint("NewApi")
             @Override
             public void onClick(View v) {
@@ -80,19 +73,12 @@ public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
                 ProcessAndSendTask<RecoveryActivity> mProcess = new ProcessAndSendTask<RecoveryActivity>(RecoveryActivity.this, settings.getString("PostURL", 
                         RecoveryActivity.this.getString(R.string.PostURL)), SEND_TASK_ID, true){
 
-                    /* (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#onPreExecute()
-                     */
                     @Override
                     protected void onPreExecute() {
                         super.onPreExecute();
                         displayMessage("Submitting form(s) to the server...");
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverResult(java.lang.Object, java.lang.Object)
-                     */
                     @Override
                     protected void deliverResult(RecoveryActivity receiver, Integer result) {
                          if(result == ProcessAndSendTask.PROGRESS_LOGGED_OUT) {
@@ -112,19 +98,11 @@ public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
                         }
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverUpdate(java.lang.Object, java.lang.Object[])
-                     */
                     @Override
                     protected void deliverUpdate(RecoveryActivity receiver, Long... update) {
                         //we don't need to deliver updates here, it happens on the notification bar
                     }
 
-                    /*
-                     * (non-Javadoc)
-                     * @see org.commcare.android.tasks.templates.CommCareTask#deliverError(java.lang.Object, java.lang.Exception)
-                     */
                     @Override
                     protected void deliverError(RecoveryActivity receiver,Exception e) {
                         Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION,"Error in recovery form send: " + ExceptionReportTask.getStackTrace(e));
@@ -155,10 +133,6 @@ public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
         
         btnRecoverApp.setOnClickListener(new OnClickListener() {
 
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 displayMessage("App recovery is not yet enabled. Please clear user data (After sending all of your forms!) and re-install.");
@@ -170,18 +144,12 @@ public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
         txtUserMessage.setText(this.localize(text));
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#startBlockingForTask(int)
-     */
     @Override
     public void startBlockingForTask(int id) {
         btnRecoverApp.setEnabled(false);
         sendForms.setEnabled(false);
     }
 
-    /* (non-Javadoc)
-     * @see org.commcare.android.framework.CommCareActivity#stopBlockingForTask(int)
-     */
     @Override
     public void stopBlockingForTask(int id) {
         updateSendFormsState();

--- a/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
@@ -21,10 +21,6 @@ import android.widget.Toast;
 
 public class ReportProblemActivity extends CommCareActivity<ReportProblemActivity> implements OnClickListener {
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -35,10 +31,6 @@ public class ReportProblemActivity extends CommCareActivity<ReportProblemActivit
         ((TextView)findViewById(R.id.ReportPrompt01)).setText(this.localize("problem.report.prompt"));
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.View.OnClickListener#onClick(android.view.View)
-     */
     @Override
     public void onClick(View v) {
         EditText mEdit = (EditText)findViewById(R.id.ReportText01);

--- a/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
@@ -24,10 +24,6 @@ public class UnrecoverableErrorActivity extends Activity {
     String title;
     String message;
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -36,9 +32,6 @@ public class UnrecoverableErrorActivity extends Activity {
         this.showDialog(0);
     }
 
-    /* (non-Javadoc)
-     * @see android.app.Activity#onCreateDialog(int)
-     */
     @Override
     protected Dialog onCreateDialog(int id) {
         AlertDialog mNoStorageDialog = new AlertDialog.Builder(this).create();

--- a/app/src/org/commcare/dalvik/application/AndroidShortcuts.java
+++ b/app/src/org/commcare/dalvik/application/AndroidShortcuts.java
@@ -25,10 +25,6 @@ public class AndroidShortcuts extends Activity {
     String[] commands;
     String[] names;
     
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle bundle) {
         super.onCreate(bundle);

--- a/app/src/org/commcare/dalvik/application/CommCareApp.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApp.java
@@ -228,10 +228,6 @@ public class CommCareApp {
 
     public <T extends Persistable> SqlStorage<T> getStorage(String name, Class<T> c) {
         return new SqlStorage<T>(name, c, new DbHelper(CommCareApplication._().getApplicationContext()) {
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.database.DbHelper#getHandle()
-             */
             @Override
             public SQLiteDatabase getHandle() {
                 synchronized (appDbHandleLock) {

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -145,10 +145,6 @@ public class CommCareApplication extends Application {
      */
     private final PopupHandler toaster = new PopupHandler(this);
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Application#onCreate()
-     */
     @Override
     public void onCreate() {
         super.onCreate();
@@ -399,10 +395,6 @@ public class CommCareApplication extends Application {
 
     public <T extends Persistable> SqlStorage<T> getGlobalStorage(String table, Class<T> c) {
         return new SqlStorage<T>(table, c, new DbHelper(this.getApplicationContext()) {
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.database.DbHelper#getHandle()
-             */
             @Override
             public SQLiteDatabase getHandle() {
                 synchronized (globalDbHandleLock) {
@@ -429,10 +421,6 @@ public class CommCareApplication extends Application {
 
     public <T extends Persistable> SqlStorage<T> getUserStorage(String storage, Class<T> c) {
         return new SqlStorage<T>(storage, c, new DbHelper(this.getApplicationContext()) {
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.database.DbHelper#getHandle()
-             */
             @Override
             public SQLiteDatabase getHandle() throws SessionUnavailableException {
                 SQLiteDatabase database = getUserDbHandle();
@@ -446,10 +434,6 @@ public class CommCareApplication extends Application {
 
     public <T extends Persistable> SqlStorage<T> getRawStorage(String storage, Class<T> c, final SQLiteDatabase handle) {
         return new SqlStorage<T>(storage, c, new DbHelper(this.getApplicationContext()) {
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.database.DbHelper#getHandle()
-             */
             @Override
             public SQLiteDatabase getHandle() {
                 return handle;
@@ -492,10 +476,6 @@ public class CommCareApplication extends Application {
 
         this.getAppStorage(UserKeyRecord.class).removeAll(new EntityFilter<UserKeyRecord>() {
 
-            /*
-             * (non-Javadoc)
-             * @see org.javarosa.core.services.storage.EntityFilter#matches(java.lang.Object)
-             */
             @Override
             public boolean matches(UserKeyRecord ukr) {
                 if (ukr.getUsername().equalsIgnoreCase(username.toLowerCase())) {

--- a/app/src/org/commcare/dalvik/geo/EntityOverlay.java
+++ b/app/src/org/commcare/dalvik/geo/EntityOverlay.java
@@ -26,19 +26,11 @@ public abstract class EntityOverlay extends BalloonItemizedOverlay {
         this.context = context;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see com.google.android.maps.ItemizedOverlay#createItem(int)
-     */
     @Override
     protected OverlayItem createItem(int i) {
         return overlays[i];
     }
 
-    /*
-     * (non-Javadoc)
-     * @see com.google.android.maps.ItemizedOverlay#size()
-     */
     @Override
     public int size() {
         if (full) {
@@ -62,9 +54,6 @@ public abstract class EntityOverlay extends BalloonItemizedOverlay {
         populate();
     }
     
-    /* (non-Javadoc)
-     * @see com.readystatesoftware.mapviewballoons.BalloonItemizedOverlay#onBalloonTap(int, com.google.android.maps.OverlayItem)
-     */
     @Override
     protected boolean onBalloonTap(int index, OverlayItem item) {
         selected(references[index]);

--- a/app/src/org/commcare/dalvik/geo/EntityOverlayItem.java
+++ b/app/src/org/commcare/dalvik/geo/EntityOverlayItem.java
@@ -18,9 +18,6 @@ public class EntityOverlayItem extends OverlayItem {
         super(gp, big, small);
         this.custom = custom;
     }
-    /* (non-Javadoc)
-     * @see com.google.android.maps.OverlayItem#getMarker(int)
-     */
     @Override
     public Drawable getMarker(int stateBitset) {
         if(custom == null) {

--- a/app/src/org/commcare/dalvik/odk/provider/FormsProvider.java
+++ b/app/src/org/commcare/dalvik/odk/provider/FormsProvider.java
@@ -66,10 +66,6 @@ public class FormsProvider extends ContentProvider {
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.database.sqlite.SQLiteOpenHelper#onCreate(android.database.sqlite.SQLiteDatabase)
-         */
         @Override
         public void onCreate(SQLiteDatabase db) {
             db.execSQL("CREATE TABLE " + FORMS_TABLE_NAME + " (" 
@@ -90,10 +86,6 @@ public class FormsProvider extends ContentProvider {
                     + FormsColumns.JRCACHE_FILE_PATH + " text not null );");
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.database.sqlite.SQLiteOpenHelper#onUpgrade(android.database.sqlite.SQLiteDatabase, int, int)
-         */
         @Override
         public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
             Log.w(t, "Upgrading database from version " + oldVersion + " to " + newVersion
@@ -106,10 +98,6 @@ public class FormsProvider extends ContentProvider {
     private DatabaseHelper mDbHelper;
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#onCreate()
-     */
     @Override
     public boolean onCreate() {
         //This is so stupid.
@@ -124,10 +112,6 @@ public class FormsProvider extends ContentProvider {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#query(android.net.Uri, java.lang.String[], java.lang.String, java.lang.String[], java.lang.String)
-     */
     @Override
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
             String sortOrder) {
@@ -159,10 +143,6 @@ public class FormsProvider extends ContentProvider {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#getType(android.net.Uri)
-     */
     @Override
     public String getType(Uri uri) {
         switch (sUriMatcher.match(uri)) {
@@ -178,10 +158,6 @@ public class FormsProvider extends ContentProvider {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#insert(android.net.Uri, android.content.ContentValues)
-     */
     @Override
     public Uri insert(Uri uri, ContentValues initialValues) {
         init();
@@ -256,10 +232,7 @@ public class FormsProvider extends ContentProvider {
    
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#delete(android.net.Uri, java.lang.String, java.lang.String[])
-     * 
+    /**
      * This method removes the entry from the content provider, and also removes any associated
      * files. files: form.xml, [formmd5].formdef, formname-media {directory}
      */
@@ -326,10 +299,6 @@ public class FormsProvider extends ContentProvider {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#update(android.net.Uri, android.content.ContentValues, java.lang.String, java.lang.String[])
-     */
     @Override
     public int update(Uri uri, ContentValues values, String where, String[] whereArgs) {
         init();

--- a/app/src/org/commcare/dalvik/odk/provider/InstanceProvider.java
+++ b/app/src/org/commcare/dalvik/odk/provider/InstanceProvider.java
@@ -52,10 +52,6 @@ public class InstanceProvider extends ContentProvider {
             super(c, databaseName, null, DATABASE_VERSION);
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.database.sqlite.SQLiteOpenHelper#onCreate(android.database.sqlite.SQLiteDatabase)
-         */
         @Override
         public void onCreate(SQLiteDatabase db) {            
            db.execSQL("CREATE TABLE " + INSTANCES_TABLE_NAME + " (" 
@@ -71,10 +67,6 @@ public class InstanceProvider extends ContentProvider {
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.database.sqlite.SQLiteOpenHelper#onUpgrade(android.database.sqlite.SQLiteDatabase, int, int)
-         */
         @Override
         public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
             Log.w(t, "Upgrading database from version " + oldVersion + " to " + newVersion
@@ -86,10 +78,6 @@ public class InstanceProvider extends ContentProvider {
 
     private DatabaseHelper mDbHelper;
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#onCreate()
-     */
     @Override
     public boolean onCreate() {
         //This is so stupid.
@@ -106,10 +94,6 @@ public class InstanceProvider extends ContentProvider {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#query(android.net.Uri, java.lang.String[], java.lang.String, java.lang.String[], java.lang.String)
-     */
     @Override
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
             String sortOrder) {
@@ -140,10 +124,6 @@ public class InstanceProvider extends ContentProvider {
         return c;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#getType(android.net.Uri)
-     */
     @Override
     public String getType(Uri uri) {
         switch (sUriMatcher.match(uri)) {
@@ -256,10 +236,7 @@ public class InstanceProvider extends ContentProvider {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.ContentProvider#delete(android.net.Uri, java.lang.String, java.lang.String[])
-     * 
+    /**
      * This method removes the entry from the content provider, and also removes any associated files.
      * files:  form.xml, [formmd5].formdef, formname-media {directory}
      */

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -98,10 +98,6 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
     private static final int RECOVERY_MODE = Menu.FIRST + 3;
     private static final int SUPERUSER_PREFS = Menu.FIRST + 4;
 
-    /*
-     * (non-Javadoc)
-     * @see android.preference.PreferenceActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -123,10 +119,6 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
         setTitle("CommCare" + " > " + "Application Preferences");
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreateOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
@@ -153,10 +145,6 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
 
     int mDeveloperModeClicks = 0;
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -252,10 +240,6 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -264,10 +248,6 @@ public class CommCarePreferences extends PreferenceActivity implements OnSharedP
                 .registerOnSharedPreferenceChangeListener(this);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onPause()
-     */
     @Override
     protected void onPause() {
         super.onPause();

--- a/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
@@ -38,10 +38,6 @@ public class DeveloperPreferences extends PreferenceActivity {
     // not just the latest app version released (starred)?
     public final static String NEWEST_APP_VERSION_ENABLED = "cc-newest-version-from-hq";
 
-    /*
-     * (non-Javadoc)
-     * @see android.preference.PreferenceActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/org/commcare/dalvik/provider/CaseDataContentProvider.java
+++ b/app/src/org/commcare/dalvik/provider/CaseDataContentProvider.java
@@ -43,9 +43,6 @@ public class CaseDataContentProvider extends ContentProvider {
     
     //TODO: Caching - Use a cache table here or use an LRU or other system provided cache?
     
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#getType(android.net.Uri)
-     */
     @Override
     public String getType(Uri uri) {
         int match = CaseDataAPI.UriMatch(uri);
@@ -67,9 +64,6 @@ public class CaseDataContentProvider extends ContentProvider {
     }
 
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#onCreate()
-     */
     @Override
     public boolean onCreate() {
         caseMetaIndexTable.put(CaseDataAPI.MetadataColumns.CASE_ID, Case.INDEX_CASE_ID);
@@ -78,9 +72,6 @@ public class CaseDataContentProvider extends ContentProvider {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#query(android.net.Uri, java.lang.String[], java.lang.String, java.lang.String[], java.lang.String)
-     */
     @Override
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
 
@@ -291,9 +282,6 @@ public class CaseDataContentProvider extends ContentProvider {
     /** All of the below are invalid due to the read-only nature of the content provider. It's not 100% clear from spec how to express
      * the read-only-ness. **/
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#update(android.net.Uri, android.content.ContentValues, java.lang.String, java.lang.String[])
-     */
     @Override
     public int update(Uri uri, ContentValues values, String selection,String[] selectionArgs) {
         // Case content provider is read only.
@@ -301,9 +289,6 @@ public class CaseDataContentProvider extends ContentProvider {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#delete(android.net.Uri, java.lang.String, java.lang.String[])
-     */
     @Override
     public int delete(Uri uri, String selection, String[] selectionArgs) {
         // Case content provider is read only.
@@ -311,9 +296,6 @@ public class CaseDataContentProvider extends ContentProvider {
     }
     
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#insert(android.net.Uri, android.content.ContentValues)
-     */
     @Override
     public Uri insert(Uri uri, ContentValues values) {
         // TODO Auto-generated method stub

--- a/app/src/org/commcare/dalvik/provider/FixtureDataContentProvider.java
+++ b/app/src/org/commcare/dalvik/provider/FixtureDataContentProvider.java
@@ -36,9 +36,6 @@ import android.net.Uri;
  */
 public class FixtureDataContentProvider extends ContentProvider {
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#onCreate()
-     */
     @Override
     public boolean onCreate() {
         return true;
@@ -138,9 +135,6 @@ public class FixtureDataContentProvider extends ContentProvider {
     /** All of the below are invalid due to the read-only nature of the content provider. It's not 100% clear from spec how to express
      * the read-only-ness. **/
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#update(android.net.Uri, android.content.ContentValues, java.lang.String, java.lang.String[])
-     */
     @Override
     public int update(Uri uri, ContentValues values, String selection,String[] selectionArgs) {
         // Case content provider is read only.
@@ -148,9 +142,6 @@ public class FixtureDataContentProvider extends ContentProvider {
         return 0;
     }
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#delete(android.net.Uri, java.lang.String, java.lang.String[])
-     */
     @Override
     public int delete(Uri uri, String selection, String[] selectionArgs) {
         // Case content provider is read only.
@@ -158,9 +149,6 @@ public class FixtureDataContentProvider extends ContentProvider {
     }
 
 
-    /* (non-Javadoc)
-     * @see android.content.ContentProvider#insert(android.net.Uri, android.content.ContentValues)
-     */
     @Override
     public Uri insert(Uri uri, ContentValues values) {
         // TODO Auto-generated method stub

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -115,10 +115,6 @@ public class CommCareSessionService extends Service  {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Service#onCreate()
-     */
     @Override
     public void onCreate() {
         mNM = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
@@ -157,10 +153,6 @@ public class CommCareSessionService extends Service  {
         };
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Service#onStartCommand(android.content.Intent, int, int)
-     */
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         // We want this service to continue running until it is explicitly
@@ -168,10 +160,6 @@ public class CommCareSessionService extends Service  {
         return START_STICKY;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Service#onDestroy()
-     */
     @Override
     public void onDestroy() {
         // Cancel the persistent notification.
@@ -180,10 +168,6 @@ public class CommCareSessionService extends Service  {
         // TODO: Create a notification which the user can click to restart the session 
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Service#onBind(android.content.Intent)
-     */
     @Override
     public IBinder onBind(Intent intent) {
         return mBinder;
@@ -297,10 +281,6 @@ public class CommCareSessionService extends Service  {
             maintenanceTimer = new Timer("CommCareService");
             maintenanceTimer.schedule(new TimerTask() {
     
-                /*
-                 * (non-Javadoc)
-                 * @see java.util.TimerTask#run()
-                 */
                 @Override
                 public void run() {
                     timeToExpireSession();
@@ -545,10 +525,6 @@ public class CommCareSessionService extends Service  {
             
             int lastUpdate = 0;
             
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.DataSubmissionListener#beginSubmissionProcess(int)
-             */
             @Override
             public void beginSubmissionProcess(int totalItems) {
                 this.totalItems = totalItems;
@@ -587,10 +563,6 @@ public class CommCareSessionService extends Service  {
 
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.DataSubmissionListener#startSubmission(int, long)
-             */
             @Override
             public void startSubmission(int itemNumber, long length) {
                 currentSize = length;
@@ -600,10 +572,6 @@ public class CommCareSessionService extends Service  {
                 mNM.notify(notificationId, submissionNotification);
             }
 
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.DataSubmissionListener#notifyProgress(int, long)
-             */
             @Override
             public void notifyProgress(int itemNumber, long progress) {
                 int progressPercent = (int)Math.floor((progress * 1.0 / currentSize) * 100);
@@ -630,10 +598,6 @@ public class CommCareSessionService extends Service  {
                     lastUpdate = progressPercent;
                 }
             }
-            /*
-             * (non-Javadoc)
-             * @see org.commcare.android.tasks.DataSubmissionListener#endSubmissionProcess()
-             */
             @Override
             public void endSubmissionProcess() {
                 mNM.cancel(notificationId);

--- a/app/src/org/commcare/dalvik/services/WiFiDirectBroadcastReceiver.java
+++ b/app/src/org/commcare/dalvik/services/WiFiDirectBroadcastReceiver.java
@@ -55,11 +55,6 @@ public class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
         this.activity = activity;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.BroadcastReceiver#onReceive(android.content.Context,
-     * android.content.Intent)
-     */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/app/src/org/commcare/util/externalizable/ImprovedPrototypeFactory.java
+++ b/app/src/org/commcare/util/externalizable/ImprovedPrototypeFactory.java
@@ -24,10 +24,6 @@ public class ImprovedPrototypeFactory extends PrototypeFactory {
         hasher = new AndroidClassHasher();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.PrototypeFactory#addClass(java.lang.Class)
-     */
     @Override
     public void addClass (Class c) {
         if (!initialized) {
@@ -56,10 +52,6 @@ public class ImprovedPrototypeFactory extends PrototypeFactory {
         return Integer.valueOf((hash[3] << 0) + (hash[2] << 8) + (hash[1] << 16) + (hash[0] << 24));
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.PrototypeFactory#getClass(byte[])
-     */
     @Override
     public Class getClass (byte[] hash) {
         if (!initialized) {

--- a/app/src/org/commcare/xml/AndroidCaseXmlParser.java
+++ b/app/src/org/commcare/xml/AndroidCaseXmlParser.java
@@ -73,10 +73,6 @@ public class AndroidCaseXmlParser extends CaseXmlParser {
         mCaseIndexTable = new CaseIndexTable();
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.xml.CaseXmlParser#removeAttachment(org.commcare.cases.model.Case, java.lang.String)
-     */
     @Override
     protected void removeAttachment(Case caseForBlock, String attachmentName) {
         if(!processAttachments) { return;}
@@ -120,10 +116,6 @@ public class AndroidCaseXmlParser extends CaseXmlParser {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.xml.CaseXmlParser#processAttachment(java.lang.String, java.lang.String, java.lang.String, org.kxml2.io.KXmlParser)
-     */
     @Override
     protected String processAttachment(String src, String from, String name, KXmlParser parser) {
         if(!processAttachments) { return null;}
@@ -225,9 +217,6 @@ public class AndroidCaseXmlParser extends CaseXmlParser {
     }
 
 
-    /* (non-Javadoc)
-     * @see org.commcare.xml.CaseXmlParser#CreateCase(java.lang.String, java.lang.String)
-     */
     @Override
     protected Case CreateCase(String name, String typeId) {
         return new ACase(name, typeId);

--- a/app/src/org/commcare/xml/CommCareTransactionParserFactory.java
+++ b/app/src/org/commcare/xml/CommCareTransactionParserFactory.java
@@ -70,10 +70,6 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
                         //TODO: store these on the file system instead of in DB?
                         private IStorageUtilityIndexed fixtureStorage;
                         
-                        /*
-                         * (non-Javadoc)
-                         * @see org.commcare.xml.FixtureXmlParser#storage()
-                         */
                         @Override
                         public IStorageUtilityIndexed storage() {
                             if(fixtureStorage == null) {
@@ -89,10 +85,7 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
         }; 
     }
     
-    
-    /* (non-Javadoc)
-     * @see org.commcare.data.xml.TransactionParserFactory#getParser(org.kxml2.io.KXmlParser)
-     */
+    @Override
     public TransactionParser getParser(KXmlParser parser) {
         String name = parser.getName();
         String namespace = parser.getNamespace();
@@ -132,10 +125,6 @@ public class CommCareTransactionParserFactory implements TransactionParserFactor
                 @Override
                 public void commit(String parsed) throws IOException {}
 
-                /*
-                 * (non-Javadoc)
-                 * @see org.javarosa.xml.ElementParser#parse()
-                 */
                 @Override
                 public String parse() throws InvalidStructureException, IOException, XmlPullParserException, UnfullfilledRequirementsException {
                     this.checkNode("sync");

--- a/app/src/org/commcare/xml/FormInstanceXmlParser.java
+++ b/app/src/org/commcare/xml/FormInstanceXmlParser.java
@@ -178,10 +178,6 @@ public class FormInstanceXmlParser extends TransactionParser<FormRecord> {
         throw new RuntimeException("Couldn't create folder needed to save form instance");
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.data.xml.TransactionParser#commit(java.lang.Object)
-     */
     @Override
     public void commit(FormRecord parsed) throws IOException {
         //This is unused.

--- a/app/src/org/commcare/xml/KeyRecordParser.java
+++ b/app/src/org/commcare/xml/KeyRecordParser.java
@@ -32,10 +32,6 @@ public abstract class KeyRecordParser extends TransactionParser<ArrayList<UserKe
         this.keyRecords = new ArrayList<UserKeyRecord>();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.xml.ElementParser#parse()
-     */
     @Override
     public ArrayList<UserKeyRecord> parse() throws InvalidStructureException, IOException, XmlPullParserException, UnfullfilledRequirementsException {
         this.checkNode("auth_keys");

--- a/app/src/org/commcare/xml/MetaDataXmlParser.java
+++ b/app/src/org/commcare/xml/MetaDataXmlParser.java
@@ -18,19 +18,11 @@ public class MetaDataXmlParser extends TransactionParser<String[]> {
         super(parser);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.commcare.data.xml.TransactionParser#commit(java.lang.Object)
-     */
     @Override
     public void commit(String[] data) throws IOException {
         //nothing;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.xml.ElementParser#parse()
-     */
     @Override
     public String[] parse() throws InvalidStructureException, IOException, XmlPullParserException, UnfullfilledRequirementsException {
         this.checkNode("meta");

--- a/app/src/org/odk/collect/android/activities/DrawActivity.java
+++ b/app/src/org/odk/collect/android/activities/DrawActivity.java
@@ -82,10 +82,6 @@ public class DrawActivity extends Activity {
     private String alertTitleString;
     private AlertDialog alertDialog;
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
@@ -99,10 +95,6 @@ public class DrawActivity extends Activity {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -205,10 +197,6 @@ public class DrawActivity extends Activity {
 
         btnFinished = (Button) findViewById(R.id.btnFinishDraw);
         btnFinished.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
 
@@ -217,10 +205,6 @@ public class DrawActivity extends Activity {
         });
         btnReset = (Button) findViewById(R.id.btnResetDraw);
         btnReset.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 Reset();
@@ -228,10 +212,6 @@ public class DrawActivity extends Activity {
         });
         btnCancel = (Button) findViewById(R.id.btnCancelDraw);
         btnCancel.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
 
@@ -291,19 +271,11 @@ public class DrawActivity extends Activity {
         this.finish();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onConfigurationChanged(android.content.res.Configuration)
-     */
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onKeyDown(int, android.view.KeyEvent)
-     */
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         switch (keyCode) {
@@ -343,10 +315,6 @@ public class DrawActivity extends Activity {
         .setTitle(alertTitleString)
         .setNeutralButton(getString(R.string.do_not_exit),
                 new DialogInterface.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-             */
             @Override
             public void onClick(DialogInterface dialog, int id) {
 
@@ -356,10 +324,6 @@ public class DrawActivity extends Activity {
             }
         })
         .setItems(items, new DialogInterface.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-             */
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 switch (which) {
@@ -431,20 +395,12 @@ public class DrawActivity extends Activity {
             }
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.view.View#onSizeChanged(int, int, int, int)
-         */
         @Override
         protected void onSizeChanged(int w, int h, int oldw, int oldh) {
             super.onSizeChanged(w, h, oldw, oldh);
             resetImage(w, h);
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.view.View#onDraw(android.graphics.Canvas)
-         */
         @Override
         protected void onDraw(Canvas canvas) {
             canvas.drawColor(R.color.grey);
@@ -484,10 +440,6 @@ public class DrawActivity extends Activity {
             mCurrentPath.reset();
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.view.View#onTouchEvent(android.view.MotionEvent)
-         */
         @Override
         public boolean onTouchEvent(MotionEvent event) {
             float x = event.getX();

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -259,10 +259,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onCreate(android.os.Bundle)
-     */
     @Override
     @SuppressLint("NewApi")
     public void onCreate(Bundle savedInstanceState) {
@@ -616,10 +612,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
 
     public static final String TITLE_FRAGMENT_TAG = "odk_title_fragment";
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
@@ -644,10 +636,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onActivityResult(int, int, android.content.Intent)
-     */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
@@ -1268,10 +1256,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onPrepareOptionsMenu(android.view.Menu)
-     */
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         menu.removeItem(MENU_LANGUAGES);
@@ -1299,10 +1283,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -1423,10 +1403,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreateContextMenu(android.view.ContextMenu, android.view.View, android.view.ContextMenu.ContextMenuInfo)
-     */
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
@@ -1435,10 +1411,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onContextItemSelected(android.view.MenuItem)
-     */
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         // We don't have the right view here, so we store the View's ID as the
@@ -1454,10 +1426,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onRetainCustomNonConfigurationInstance()
-     * 
+    /**
      * If we're loading, then we pass the loading thread to our next instance.
      */
     @Override
@@ -1614,10 +1583,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 } else {
                     button.setText(StringUtils.getStringSpannableRobust(this, R.string.quit_entry));
                             button.setOnClickListener(new OnClickListener() {
-                                /*
-                                 * (non-Javadoc)
-                                 * @see android.view.View.OnClickListener#onClick(android.view.View)
-                                 */
                                 @Override
                                 public void onClick(View v) {
                                     // Form is marked as 'saved' here.
@@ -1676,10 +1641,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#dispatchTouchEvent(android.view.MotionEvent)
-     */
     @SuppressLint("NewApi")
     @Override
     public boolean dispatchTouchEvent(MotionEvent mv) {
@@ -2175,10 +2136,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                                         .setTitle(StringUtils.getStringRobust(this, R.string.quit_application, mFormController.getFormTitle()))
                                                 .setNeutralButton(StringUtils.getStringSpannableRobust(this, R.string.do_not_exit),
                         new DialogInterface.OnClickListener() {
-                            /*
-                             * (non-Javadoc)
-                             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                             */
                             @Override
                             public void onClick(DialogInterface dialog, int id) {
 
@@ -2186,10 +2143,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
 
                             }
                         }).setItems(items, new DialogInterface.OnClickListener() {
-                        /*
-                         * (non-Javadoc)
-                         * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                         */
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             switch (which) {
@@ -2375,10 +2328,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
 
         DialogInterface.OnClickListener quitListener = new DialogInterface.OnClickListener() {
 
-                    /*
-                     * (non-Javadoc)
-                     * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                     */
                     @Override
                     public void onClick(DialogInterface dialog, int i) {
                         switch (i) {
@@ -2416,10 +2365,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
             new AlertDialog.Builder(this)
                     .setSingleChoiceItems(languages, selected,
                         new DialogInterface.OnClickListener() {
-                            /*
-                             * (non-Javadoc)
-                             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                             */
                             @Override
                             public void onClick(DialogInterface dialog, int whichButton) {
                                 // Update the language in the content provider when selecting a new
@@ -2447,10 +2392,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                     .setTitle(StringUtils.getStringRobust(this, R.string.change_language))
                     .setNegativeButton(StringUtils.getStringSpannableRobust(this, R.string.do_not_change),
                         new DialogInterface.OnClickListener() {
-                            /*
-                             * (non-Javadoc)
-                             * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                             */
                             @Override
                             public void onClick(DialogInterface dialog, int whichButton) {
                             }
@@ -2459,10 +2400,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreateDialog(int)
-     * 
+    /**
      * We use Android's dialog management for loading/saving progress dialogs
      */
     @Override
@@ -2472,10 +2410,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 mProgressDialog = new ProgressDialog(this);
                 DialogInterface.OnClickListener loadingButtonListener =
                     new DialogInterface.OnClickListener() {
-                    /*
-                     * (non-Javadoc)
-                     * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                     */
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             dialog.dismiss();
@@ -2496,10 +2430,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 mProgressDialog = new ProgressDialog(this);
                 DialogInterface.OnClickListener savingButtonListener =
                     new DialogInterface.OnClickListener() {
-                        /*
-                         * (non-Javadoc)
-                         * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                         */
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             dialog.dismiss();
@@ -2534,10 +2464,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onPause()
-     */
     @Override
     protected void onPause() {
         super.onPause();
@@ -2554,10 +2480,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -2675,10 +2597,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.support.v4.app.FragmentActivity#onDestroy()
-     */
     @Override
     protected void onDestroy() {
         if (mFormLoaderTask != null) {
@@ -2705,40 +2623,25 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.animation.Animation.AnimationListener#onAnimationEnd(android.view.animation.Animation)
-     */
     @Override
     public void onAnimationEnd(Animation arg0) {
         mBeenSwiped = false;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.animation.Animation.AnimationListener#onAnimationRepeat(android.view.animation.Animation)
-     */
     @Override
     public void onAnimationRepeat(Animation animation) {
         // Added by AnimationListener interface.
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.animation.Animation.AnimationListener#onAnimationStart(android.view.animation.Animation)
-     */
     @Override
     public void onAnimationStart(Animation animation) {
         // Added by AnimationListener interface.
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.listeners.FormLoaderListener#loadingComplete(org.odk.collect.android.logic.FormController)
-     * 
+    /**
      * loadingComplete() is called by FormLoaderTask once it has finished loading a form.
      */
     @SuppressLint("NewApi")
@@ -2799,10 +2702,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.listeners.FormLoaderListener#loadingError(java.lang.String)
-     * 
+    /**
      * called by the FormLoaderTask if something goes wrong.
      */
     @Override
@@ -2999,19 +2899,13 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onDown(android.view.MotionEvent)
-     */
     @Override
     public boolean onDown(MotionEvent e) {
         return false;
     }
 
-    /*
+    /**
      * Looks for user swipes. If the user has swiped, move to the appropriate screen.
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onFling(android.view.MotionEvent, android.view.MotionEvent, float, float)
      */
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
@@ -3033,19 +2927,11 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onLongPress(android.view.MotionEvent)
-     */
     @Override
     public void onLongPress(MotionEvent e) {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onScroll(android.view.MotionEvent, android.view.MotionEvent, float, float)
-     */
     @Override
     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
         // The onFling() captures the 'up' event so our view thinks it gets long pressed.
@@ -3055,39 +2941,23 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onShowPress(android.view.MotionEvent)
-     */
     @Override
     public void onShowPress(MotionEvent e) {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.GestureDetector.OnGestureListener#onSingleTapUp(android.view.MotionEvent)
-     */
     @Override
     public boolean onSingleTapUp(MotionEvent e) {
         return false;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.listeners.AdvanceToNextListener#advance()
-     */
     @Override
     public void advance() {
         next();
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.listeners.WidgetChangedListener#widgetEntryChanged()
-     */
     @Override
     public void widgetEntryChanged() {
         updateFormRelevencies();

--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -56,10 +56,6 @@ public class FormHierarchyActivity extends ListActivity {
     FormIndex mStartIndex;
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -75,10 +71,6 @@ public class FormHierarchyActivity extends ListActivity {
 
         jumpPreviousButton = (Button) findViewById(R.id.jumpPreviousButton);
         jumpPreviousButton.setOnClickListener(new OnClickListener() {
-        	/*
-        	 * (non-Javadoc)
-        	 * @see android.view.View.OnClickListener#onClick(android.view.View)
-        	 */
             @Override
             public void onClick(View v) {
                 goUpLevel();
@@ -87,10 +79,6 @@ public class FormHierarchyActivity extends ListActivity {
 
         Button jumpBeginningButton = (Button) findViewById(R.id.jumpBeginningButton);
         jumpBeginningButton.setOnClickListener(new OnClickListener() {
-        	/*
-        	 * (non-Javadoc)
-        	 * @see android.view.View.OnClickListener#onClick(android.view.View)
-        	 */
             @Override
             public void onClick(View v) {
                 FormEntryActivity.mFormController.jumpToIndex(FormIndex
@@ -102,10 +90,6 @@ public class FormHierarchyActivity extends ListActivity {
 
         Button jumpEndButton = (Button) findViewById(R.id.jumpEndButton);
         jumpEndButton.setOnClickListener(new OnClickListener() {
-        	/*
-        	 * (non-Javadoc)
-        	 * @see android.view.View.OnClickListener#onClick(android.view.View)
-        	 */
             @Override
             public void onClick(View v) {
                 FormEntryActivity.mFormController.jumpToIndex(FormIndex.createEndOfFormIndex());
@@ -117,10 +101,6 @@ public class FormHierarchyActivity extends ListActivity {
         // kinda slow, but works.
         // this scrolls to the last question the user was looking at
         getListView().post(new Runnable() {
-        	/*
-        	 * (non-Javadoc)
-        	 * @see java.lang.Runnable#run()
-        	 */
             @Override
             public void run() {
                 int position = 0;
@@ -358,10 +338,6 @@ public class FormHierarchyActivity extends ListActivity {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.ListActivity#onListItemClick(android.widget.ListView, android.view.View, int, long)
-     */
     @Override
     protected void onListItemClick(ListView l, View v, int position, long id) {
         HierarchyElement h = (HierarchyElement) l.getItemAtPosition(position);
@@ -411,10 +387,6 @@ public class FormHierarchyActivity extends ListActivity {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onKeyDown(int, android.view.KeyEvent)
-     */
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         switch (keyCode) {

--- a/app/src/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/app/src/org/odk/collect/android/activities/GeoPointActivity.java
@@ -46,10 +46,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
 
     private ODKTimer mTimer;
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -75,10 +71,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
 
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onPause()
-     */
     @Override
     protected void onPause() {
         super.onPause();
@@ -93,20 +85,12 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
         mProviders = GeoUtils.evaluateProviders(mLocationManager);
         if (mProviders.isEmpty()) {
             DialogInterface.OnCancelListener onCancelListener = new DialogInterface.OnCancelListener() {
-                /*
-                 * (non-Javadoc)
-                 * @see android.content.DialogInterface.OnCancelListener#onCancel(android.content.DialogInterface)
-                 */
                 @Override
                 public void onCancel(DialogInterface dialog) {
                     mLocation = null;
@@ -146,10 +130,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
         // dialog displayed while fetching gps location
         
         OnClickListener cancelButtonListener = new OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v){
                 mLocation = null;
@@ -187,10 +167,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onLocationChanged(android.location.Location)
-     */
     @Override
     public void onLocationChanged(Location location) {
         mLocation = location;
@@ -220,30 +196,18 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onProviderDisabled(java.lang.String)
-     */
     @Override
     public void onProviderDisabled(String provider) {
 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onProviderEnabled(java.lang.String)
-     */
     @Override
     public void onProviderEnabled(String provider) {
 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onStatusChanged(java.lang.String, int, android.os.Bundle)
-     */
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
         switch (status) {
@@ -260,19 +224,11 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.listeners.TimerListener#notifyTimerFinished()
-     */
     @Override
     public void notifyTimerFinished() {
         onLocationChanged(mLocation);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     public void onSaveInstanceState(Bundle savedInstanceState) {
         savedInstanceState.putLong("millisRemaining",mTimer.getMillisUntilFinished());

--- a/app/src/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/app/src/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -52,10 +52,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
     private boolean mGPSOn = false;
     private boolean mNetworkOn = false;
     
-    /*
-     * (non-Javadoc)
-     * @see com.google.android.maps.MapActivity#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -74,10 +70,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
         mCancelLocation = (Button) findViewById(R.id.cancel_location);
         mCancelLocation.setOnClickListener(new OnClickListener() {
 
-        	/*
-        	 * (non-Javadoc)
-        	 * @see android.view.View.OnClickListener#onClick(android.view.View)
-        	 */
             @Override
             public void onClick(View v) {
                 finish();
@@ -115,10 +107,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
             mAcceptLocation = (Button) findViewById(R.id.accept_location);
             mAcceptLocation.setOnClickListener(new OnClickListener() {
 
-            	/*
-            	 * (non-Javadoc)
-            	 * @see android.view.View.OnClickListener#onClick(android.view.View)
-            	 */
                 @Override
                 public void onClick(View v) {
                     returnLocation();
@@ -136,10 +124,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
             mShowLocation.setVisibility(View.VISIBLE);
             mShowLocation.setOnClickListener(new OnClickListener() {
 
-            	/*
-            	 * (non-Javadoc)
-            	 * @see android.view.View.OnClickListener#onClick(android.view.View)
-            	 */
                 @Override
                 public void onClick(View v) {
                     mMapController.animateTo(mGeoPoint);
@@ -165,10 +149,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see com.google.android.maps.MapActivity#onPause()
-     */
     @Override
     protected void onPause() {
         super.onPause();
@@ -178,10 +158,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see com.google.android.maps.MapActivity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -197,20 +173,12 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see com.google.android.maps.MapActivity#isRouteDisplayed()
-     */
     @Override
     protected boolean isRouteDisplayed() {
         return false;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onLocationChanged(android.location.Location)
-     */
     @Override
     public void onLocationChanged(Location location) {
         if (mCaptureLocation) {
@@ -232,28 +200,16 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onProviderDisabled(java.lang.String)
-     */
     @Override
     public void onProviderDisabled(String provider) {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onProviderEnabled(java.lang.String)
-     */
     @Override
     public void onProviderEnabled(String provider) {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onStatusChanged(java.lang.String, int, android.os.Bundle)
-     */
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
     }
@@ -268,10 +224,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see com.google.android.maps.Overlay#draw(android.graphics.Canvas, com.google.android.maps.MapView, boolean)
-         */
         @Override
         public void draw(Canvas canvas, MapView mapView, boolean shadow) {
             super.draw(canvas, mapView, shadow);

--- a/app/src/org/odk/collect/android/adapters/HierarchyListAdapter.java
+++ b/app/src/org/odk/collect/android/adapters/HierarchyListAdapter.java
@@ -36,44 +36,24 @@ public class HierarchyListAdapter extends BaseAdapter {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
-    /*
-     * (non-Javadoc)
-     * @see android.widget.Adapter#getCount()
-     */
     @Override
     public int getCount() {
         return mItems.size();
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.Adapter#getItem(int)
-     */
     @Override
     public Object getItem(int position) {
         return mItems.get(position);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.Adapter#getItemId(int)
-     */
     @Override
     public long getItemId(int position) {
         return position;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.Adapter#getView(int, android.view.View, android.view.ViewGroup)
-     */
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         HierarchyElementView hev;

--- a/app/src/org/odk/collect/android/application/Collect.java
+++ b/app/src/org/odk/collect/android/application/Collect.java
@@ -121,11 +121,6 @@ public class Collect extends Application {
         return localContext;
     }
 
-
-    /*
-     * (non-Javadoc)
-     * @see android.app.Application#onCreate()
-     */
     @Override
     public void onCreate() {
         Log.i("Collect", "Collect created");

--- a/app/src/org/odk/collect/android/jr/extensions/AndroidXFormExtensions.java
+++ b/app/src/org/odk/collect/android/jr/extensions/AndroidXFormExtensions.java
@@ -36,19 +36,11 @@ public class AndroidXFormExtensions implements XFormExtension {
         return callout;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         intents = (Hashtable<String, IntentCallout>)ExtUtil.read(in, new ExtWrapMap(String.class, IntentCallout.class), pf);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out,  new ExtWrapMap(intents));

--- a/app/src/org/odk/collect/android/jr/extensions/CalendaredDateFormatHandler.java
+++ b/app/src/org/odk/collect/android/jr/extensions/CalendaredDateFormatHandler.java
@@ -24,19 +24,11 @@ public class CalendaredDateFormatHandler implements IFunctionHandler {
     public CalendaredDateFormatHandler(Context context) {
         this.context = context;
     }
-        /*
-         * (non-Javadoc)
-         * @see org.javarosa.core.model.condition.IFunctionHandler#getName()
-         */
         @Override
         public String getName() {
             return "format-date-for-calendar";
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.javarosa.core.model.condition.IFunctionHandler#getPrototypes()
-         */
         @Override
         public Vector getPrototypes() {
             Vector v = new Vector();
@@ -44,28 +36,16 @@ public class CalendaredDateFormatHandler implements IFunctionHandler {
             return v;
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.javarosa.core.model.condition.IFunctionHandler#rawArgs()
-         */
         @Override
         public boolean rawArgs() {
             return false;
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.javarosa.core.model.condition.IFunctionHandler#realTime()
-         */
         @Override
         public boolean realTime() {
             return false;
         }
 
-        /*
-         * (non-Javadoc)
-         * @see org.javarosa.core.model.condition.IFunctionHandler#eval(java.lang.Object[], org.javarosa.core.model.condition.EvaluationContext)
-         */
         @Override
         public Object eval(Object[] args, EvaluationContext ec) {
             if("".equals(args[0])) { return "";}

--- a/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
+++ b/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
@@ -184,10 +184,6 @@ public class IntentCallout implements Externalizable {
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         className = ExtUtil.readString(in);
@@ -198,10 +194,6 @@ public class IntentCallout implements Externalizable {
         buttonLabel = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, className);

--- a/app/src/org/odk/collect/android/jr/extensions/IntentExtensionParser.java
+++ b/app/src/org/odk/collect/android/jr/extensions/IntentExtensionParser.java
@@ -22,10 +22,6 @@ public class IntentExtensionParser implements IElementHandler {
     private static String RESPONSE = "response";
     private static String EXTRA = "extra";
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.xform.parse.IElementHandler#handle(org.javarosa.xform.parse.XFormParser, org.kxml2.kdom.Element, java.lang.Object)
-     */
     @Override
     public void handle(XFormParser p, Element e, Object parent) {
         if(!(parent instanceof FormDef)) {

--- a/app/src/org/odk/collect/android/jr/extensions/PollSensorAction.java
+++ b/app/src/org/odk/collect/android/jr/extensions/PollSensorAction.java
@@ -46,10 +46,6 @@ public class PollSensorAction extends Action implements LocationListener {
     private TreeReference mContextRef;
 
     private class ProvidersChangedHandler extends BroadcastReceiver {
-        /*
-         * (non-Javadoc)
-         * @see android.content.BroadcastReceiver#onReceive(android.content.Context, android.content.Intent)
-         */
         @Override
         public void onReceive(Context context, Intent intent) {
             Set<String> providers = GeoUtils.evaluateProviders(mLocationManager);
@@ -58,10 +54,6 @@ public class PollSensorAction extends Action implements LocationListener {
     }
     
     private class StopPollingTask extends TimerTask {
-        /*
-         * (non-Javadoc)
-         * @see java.util.TimerTask#run()
-         */
         @Override
         public void run() {
             mLocationManager.removeUpdates(PollSensorAction.this);
@@ -139,11 +131,7 @@ public class PollSensorAction extends Action implements LocationListener {
     }
     
     /**
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onLocationChanged(android.location.Location)
-     * 
      * If this action has a target node, update its value with the given location.
-     * @param location
      */
     @Override
     public void onLocationChanged(Location location) {
@@ -165,24 +153,12 @@ public class PollSensorAction extends Action implements LocationListener {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onProviderDisabled(java.lang.String)
-     */
     @Override
     public void onProviderDisabled(String provider) { }
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onProviderEnabled(java.lang.String)
-     */
     @Override
     public void onProviderEnabled(String provider) { }
 
-    /*
-     * (non-Javadoc)
-     * @see android.location.LocationListener#onStatusChanged(java.lang.String, int, android.os.Bundle)
-     */
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) { }
 }

--- a/app/src/org/odk/collect/android/jr/extensions/PollSensorExtensionParser.java
+++ b/app/src/org/odk/collect/android/jr/extensions/PollSensorExtensionParser.java
@@ -14,11 +14,8 @@ import org.kxml2.kdom.Element;
  */
 public class PollSensorExtensionParser implements IElementHandler {
     /**
-     * (non-Javadoc)
-     * @see org.javarosa.xform.parse.IElementHandler#handle(org.javarosa.xform.parse.XFormParser, org.kxml2.kdom.Element, java.lang.Object)
-     * 
      * Handle pollsensor node, creating a new PollSensor action with the node that sensor data will be written to.
-     * @param p Parser
+     *
      * @param e pollsensor Element
      * @param parent FormDef for the form being parsed
      */

--- a/app/src/org/odk/collect/android/logic/FileReference.java
+++ b/app/src/org/odk/collect/android/logic/FileReference.java
@@ -32,60 +32,36 @@ public class FileReference implements Reference {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#doesBinaryExist()
-     */
     @Override
     public boolean doesBinaryExist() {
         return new File(getInternalURI()).exists();
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#getStream()
-     */
     @Override
     public InputStream getStream() throws IOException {
         return new FileInputStream(getInternalURI());
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#getURI()
-     */
     @Override
     public String getURI() {
         return "jr://file" + referencePart;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#isReadOnly()
-     */
     @Override
     public boolean isReadOnly() {
         return false;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#getOutputStream()
-     */
     @Override
     public OutputStream getOutputStream() throws IOException {
         return new FileOutputStream(getInternalURI());
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#remove()
-     */
     @Override
     public void remove() {
         // TODO bad practice to ignore return values
@@ -93,20 +69,12 @@ public class FileReference implements Reference {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#getLocalURI()
-     */
     @Override
     public String getLocalURI() {
         return getInternalURI();
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.Reference#probeAlternativeReferences()
-     */
     @Override
     public Reference[] probeAlternativeReferences() {
         // TODO Auto-generated method stub

--- a/app/src/org/odk/collect/android/logic/FileReferenceFactory.java
+++ b/app/src/org/odk/collect/android/logic/FileReferenceFactory.java
@@ -23,10 +23,6 @@ public class FileReferenceFactory extends PrefixedRootFactory {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.reference.PrefixedRootFactory#factory(java.lang.String, java.lang.String)
-     */
     @Override
     protected Reference factory(String terminal, String URI) {
         return new FileReference(localRoot, terminal);

--- a/app/src/org/odk/collect/android/logic/PropertyManager.java
+++ b/app/src/org/odk/collect/android/logic/PropertyManager.java
@@ -72,59 +72,35 @@ public class PropertyManager implements IPropertyManager {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#getProperty(java.lang.String)
-     */
     @Override
     public Vector<String> getProperty(String propertyName) {
         return null;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#getSingularProperty(java.lang.String)
-     */
     @Override
     public String getSingularProperty(String propertyName) {
         return mProperties.get(propertyName.toLowerCase());
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#setProperty(java.lang.String, java.lang.String)
-     */
     @Override
     public void setProperty(String propertyName, String propertyValue) {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#setProperty(java.lang.String, java.util.Vector)
-     */
     @Override
     public void setProperty(String propertyName, @SuppressWarnings("rawtypes") Vector propertyValue) {
 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#addRules(org.javarosa.core.services.properties.IPropertyRules)
-     */
     @Override
     public void addRules(IPropertyRules rules) {
 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.javarosa.core.services.IPropertyManager#getRules()
-     */
     @Override
     public Vector<IPropertyRules> getRules() {
         return null;

--- a/app/src/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/app/src/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -93,10 +93,6 @@ public class PreferencesActivity extends PreferenceActivity implements
     private Context mContext;
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.preference.PreferenceActivity#onCreate(android.os.Bundle)
-     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -145,10 +141,6 @@ public class PreferencesActivity extends PreferenceActivity implements
                 }
 
 
-                /*
-                 * (non-Javadoc)
-                 * @see android.preference.Preference.OnPreferenceClickListener#onPreferenceClick(android.preference.Preference)
-                 */
                 @Override
                 public boolean onPreferenceClick(Preference preference) {
                     // if you have a value, you can clear it or select new.
@@ -165,20 +157,12 @@ public class PreferencesActivity extends PreferenceActivity implements
                         builder.setTitle(getString(R.string.change_splash_path));
                         builder.setNeutralButton(getString(R.string.cancel),
                             new DialogInterface.OnClickListener() {
-                        		/*
-                        		 * (non-Javadoc)
-                        		 * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                        		 */
                                 @Override
                                 public void onClick(DialogInterface dialog, int id) {
                                     dialog.dismiss();
                                 }
                             });
                         builder.setItems(items, new DialogInterface.OnClickListener() {
-                        	/*
-                        	 * (non-Javadoc)
-                        	 * @see android.content.DialogInterface.OnClickListener#onClick(android.content.DialogInterface, int)
-                        	 */
                             @Override
                             public void onClick(DialogInterface dialog, int item) {
                                 if (items[item].equals(getString(R.string.select_another_image))) {
@@ -211,10 +195,6 @@ public class PreferencesActivity extends PreferenceActivity implements
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onPause()
-     */
     @Override
     protected void onPause() {
         super.onPause();
@@ -223,10 +203,6 @@ public class PreferencesActivity extends PreferenceActivity implements
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.app.Activity#onResume()
-     */
     @Override
     protected void onResume() {
         super.onResume();
@@ -253,10 +229,6 @@ public class PreferencesActivity extends PreferenceActivity implements
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.preference.PreferenceActivity#onActivityResult(int, int, android.content.Intent)
-     */
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
@@ -298,10 +270,6 @@ public class PreferencesActivity extends PreferenceActivity implements
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.content.SharedPreferences.OnSharedPreferenceChangeListener#onSharedPreferenceChanged(android.content.SharedPreferences, java.lang.String)
-     */
     @Override
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String key) {
         switch (key) {

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -99,9 +99,6 @@ public class SaveToDiskTask extends AsyncTask<Void, String, Integer> {
 
 
     /**
-     * (non-Javadoc)
-     * @see android.os.AsyncTask#doInBackground(java.lang.Object[])
-     * 
      * Initialize {@link FormEntryController} with {@link FormDef} from binary or from XML. If given
      * an instance, it will be used to fill the {@link FormDef}.
      */
@@ -365,10 +362,6 @@ public class SaveToDiskTask extends AsyncTask<Void, String, Integer> {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.AsyncTask#onPostExecute(java.lang.Object)
-     */
     @Override
     protected void onPostExecute(Integer result) {
         synchronized (this) {

--- a/app/src/org/odk/collect/android/utilities/AgingCredentialsProvider.java
+++ b/app/src/org/odk/collect/android/utilities/AgingCredentialsProvider.java
@@ -43,20 +43,12 @@ public class AgingCredentialsProvider implements CredentialsProvider {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.apache.http.client.CredentialsProvider#clear()
-     */
     @Override
     public synchronized void clear() {
         provider.clear();
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.apache.http.client.CredentialsProvider#getCredentials(org.apache.http.auth.AuthScope)
-     */
     @Override
     public synchronized Credentials getCredentials(AuthScope authscope) {
         if (nextClearTimestamp < System.currentTimeMillis()) {
@@ -67,10 +59,6 @@ public class AgingCredentialsProvider implements CredentialsProvider {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.apache.http.client.CredentialsProvider#setCredentials(org.apache.http.auth.AuthScope, org.apache.http.auth.Credentials)
-     */
     @Override
     public synchronized void setCredentials(AuthScope authscope, Credentials credentials) {
         if (nextClearTimestamp < System.currentTimeMillis()) {

--- a/app/src/org/odk/collect/android/utilities/EnhancedDigestScheme.java
+++ b/app/src/org/odk/collect/android/utilities/EnhancedDigestScheme.java
@@ -126,16 +126,11 @@ public class EnhancedDigestScheme extends RFC2617Scheme {
     }
 
     /**
-     * (non-Javadoc)
-     * @see org.apache.http.impl.auth.AuthSchemeBase#processChallenge(org.apache.http.Header)
-     * 
      * Processes the Digest challenge.
      * 
-     * @param header
-     *            the challenge header
+     * @param header the challenge header
      * 
-     * @throws MalformedChallengeException
-     *             is thrown if the authentication challenge is malformed
+     * @throws MalformedChallengeException is thrown if the authentication challenge is malformed
      */
     @Override
     public void processChallenge(final Header header)

--- a/app/src/org/odk/collect/android/utilities/EnhancedDigestSchemeFactory.java
+++ b/app/src/org/odk/collect/android/utilities/EnhancedDigestSchemeFactory.java
@@ -27,10 +27,6 @@ import org.apache.http.params.HttpParams;
  */
 public class EnhancedDigestSchemeFactory implements AuthSchemeFactory {
 
-    /*
-     * (non-Javadoc)
-     * @see org.apache.http.auth.AuthSchemeFactory#newInstance(org.apache.http.params.HttpParams)
-     */
     @Override
     public AuthScheme newInstance(HttpParams params) {
         return new EnhancedDigestScheme();

--- a/app/src/org/odk/collect/android/utilities/EnhancedHttpClient.java
+++ b/app/src/org/odk/collect/android/utilities/EnhancedHttpClient.java
@@ -32,10 +32,6 @@ public class EnhancedHttpClient extends DefaultHttpClient {
         super(params);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.apache.http.impl.client.DefaultHttpClient#createAuthSchemeRegistry()
-     */
     @Override
     protected AuthSchemeRegistry createAuthSchemeRegistry() {
         AuthSchemeRegistry registry = new AuthSchemeRegistry();

--- a/app/src/org/odk/collect/android/utilities/IntegerSizeFilter.java
+++ b/app/src/org/odk/collect/android/utilities/IntegerSizeFilter.java
@@ -14,10 +14,6 @@ import android.text.Spanned;
 
 public class IntegerSizeFilter implements InputFilter {
 
-    /*
-     * (non-Javadoc)
-     * @see android.text.InputFilter#filter(java.lang.CharSequence, int, int, android.text.Spanned, int, int)
-     */
     @Override
     public CharSequence filter(CharSequence source, int start, int end,
             Spanned dest, int dstart, int dend) {

--- a/app/src/org/odk/collect/android/utilities/ODKTimer.java
+++ b/app/src/org/odk/collect/android/utilities/ODKTimer.java
@@ -20,20 +20,12 @@ public class ODKTimer extends CountDownTimer{
         mTimerListener = tl;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.CountDownTimer#onFinish()
-     */
     @Override
     public void onFinish() {
         mUntilFinished = 0;
         mTimerListener.notifyTimerFinished();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.os.CountDownTimer#onTick(long)
-     */
     @Override
     public void onTick(long millisUntilFinished) {
         mUntilFinished = millisUntilFinished;

--- a/app/src/org/odk/collect/android/views/ResizingImageView.java
+++ b/app/src/org/odk/collect/android/views/ResizingImageView.java
@@ -58,30 +58,18 @@ public class ResizingImageView extends ImageView {
         this.bigImageURI = bigImageURI;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.View#onTouchEvent(android.view.MotionEvent)
-     */
     @Override
     public boolean onTouchEvent(MotionEvent e) {
         scaleGestureDetector.onTouchEvent(e);
         return gestureDetector.onTouchEvent(e);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.ImageView#setMaxWidth(int)
-     */
     @Override
     public void setMaxWidth(int maxWidth) {
         super.setMaxWidth(maxWidth);
         mMaxWidth = maxWidth;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.ImageView#setMaxHeight(int)
-     */
     @Override
     public void setMaxHeight(int maxHeight) {
         super.setMaxHeight(maxHeight);
@@ -89,19 +77,11 @@ public class ResizingImageView extends ImageView {
     }
 
     private class GestureListener extends GestureDetector.SimpleOnGestureListener {
-        /*
-         * (non-Javadoc)
-         * @see android.view.GestureDetector.SimpleOnGestureListener#onDown(android.view.MotionEvent)
-         */
         @Override
         public boolean onDown(MotionEvent e) {
             return true;
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.view.GestureDetector.SimpleOnGestureListener#onDoubleTap(android.view.MotionEvent)
-         */
         @Override
         public boolean onDoubleTap(MotionEvent e) {
             getSuggestedMinimumHeight();
@@ -111,10 +91,6 @@ public class ResizingImageView extends ImageView {
     }
 
     private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
-        /*
-         * (non-Javadoc)
-         * @see android.view.ScaleGestureDetector.SimpleOnScaleGestureListener#onScale(android.view.ScaleGestureDetector)
-         */
         @Override
         public boolean onScale(ScaleGestureDetector detector) {
             scaleFactor *= detector.getScaleFactor();
@@ -173,9 +149,6 @@ public class ResizingImageView extends ImageView {
     }
 
     /*
-     * (non-Javadoc)
-     * @see android.widget.ImageView#onMeasure(int, int)
-     * 
      * The meat and potatoes of the class. Determines what algorithm to use
      * to resize the image based on the KEY_RESIZE preference. Currently can be
      * "full", "width", or "none". Will always preserve aspect ratio. 

--- a/app/src/org/odk/collect/android/views/ShrinkingTextView.java
+++ b/app/src/org/odk/collect/android/views/ShrinkingTextView.java
@@ -80,9 +80,6 @@ public class ShrinkingTextView extends TextView {
     }
 
     
-    /* (non-Javadoc)
-     * @see android.widget.TextView#draw(android.graphics.Canvas)
-     */
     @Override
     public void draw(Canvas canvas) {
         super.draw(canvas);
@@ -109,9 +106,6 @@ public class ShrinkingTextView extends TextView {
         }
     }
 
-    /* (non-Javadoc)
-     * @see android.widget.TextView#setText(java.lang.CharSequence, android.widget.TextView.BufferType)
-     */
     @Override
     public void setText(CharSequence text, BufferType type) {
         super.setText(text, type);
@@ -141,9 +135,6 @@ public class ShrinkingTextView extends TextView {
         }
     }
     
-    /* (non-Javadoc)
-     * @see android.widget.TextView#onMeasure(int, int)
-     */
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
@@ -187,10 +178,6 @@ public class ShrinkingTextView extends TextView {
             mDeltaHeight = endHeight - startHeight;
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.view.animation.Animation#applyTransformation(float, android.view.animation.Transformation)
-         */
         @Override
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             //ShrinkingTextView.this.setHeight((int) (mStartHeight + mDeltaHeight * interpolatedTime));
@@ -198,10 +185,6 @@ public class ShrinkingTextView extends TextView {
             ShrinkingTextView.this.requestLayout();
         }
 
-        /*
-         * (non-Javadoc)
-         * @see android.view.animation.Animation#willChangeBounds()
-         */
         @Override
         public boolean willChangeBounds() {
             return true;

--- a/app/src/org/odk/collect/android/widgets/AbstractUniversalDateWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AbstractUniversalDateWidget.java
@@ -100,10 +100,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
          * Initialise handlers for incrementing/decrementing dates
          */
         mDayHandler = new Handler() {
-            /*
-             * (non-Javadoc)
-             * @see android.os.Handler#handleMessage(android.os.Message)
-             */
             @Override
             public void handleMessage(Message msg) {
                 switch (msg.what) {
@@ -119,10 +115,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         };
         
         mMonthHandler = new Handler() {
-            /*
-             * (non-Javadoc)
-             * @see android.os.Handler#handleMessage(android.os.Message)
-             */
             @Override
             public void handleMessage(Message msg) {
                 switch (msg.what) {
@@ -138,10 +130,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         };
         
         mYearHandler = new Handler() {
-            /*
-             * (non-Javadoc)
-             * @see android.os.Handler#handleMessage(android.os.Message)
-             */
             @Override
             public void handleMessage(Message msg) {
                 switch (msg.what) {
@@ -172,10 +160,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         
         // button click listeners
         btnDayUp.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 if (mUpdater == null) {
@@ -185,10 +169,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         });
         
         btnMonthUp.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 if (mUpdater == null) {
@@ -198,10 +178,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         });
        
         btnYearUp.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 if (mUpdater == null) {
@@ -211,10 +187,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         });
 
         btnDayDown.setOnClickListener(new View.OnClickListener() {    
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 if (mUpdater == null) {
@@ -224,10 +196,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         });
 
         btnMonthDown.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 if (mUpdater == null) {
@@ -237,10 +205,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         });
 
         btnYearDown.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 if (mUpdater == null) {
@@ -328,9 +292,7 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
      */
     protected abstract long toMillisFromJavaEpoch(int year, int month, int day, long millisOffset);
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
+    /**
      * Resets date to today
      */
     @Override
@@ -341,10 +303,8 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         updateGregorianDateHelperDisplay();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     * Return the date for storing in ODK 
+    /**
+     * @return the date for storing in ODK 
      */
     @Override
     public IAnswerData getAnswer() {
@@ -352,10 +312,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         return new DateData(date);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -364,10 +320,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
         inputManager.hideSoftInputFromWindow(this.getWindowToken(), 0);
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         //super.setOnLongClickListener(l);
@@ -528,10 +480,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
             mView = mV;
             mHandler = mH;
         }
-        /*
-         * (non-Javadoc)
-         * @see android.view.View.OnTouchListener#onTouch(android.view.View, android.view.MotionEvent)
-         */
         @Override
         public boolean onTouch(View v, MotionEvent event) {
             boolean isReleased = event.getAction() == MotionEvent.ACTION_UP || event.getAction() == MotionEvent.ACTION_CANCEL;
@@ -557,10 +505,6 @@ public abstract class AbstractUniversalDateWidget extends QuestionWidget {
             mView = mV;
             mHandler = mH;
         }
-        /*
-         * (non-Javadoc)
-         * @see android.view.View.OnKeyListener#onKey(android.view.View, int, android.view.KeyEvent)
-         */
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
             boolean isKeyOfInterest = keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER;

--- a/app/src/org/odk/collect/android/widgets/AudioWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AudioWidget.java
@@ -187,10 +187,6 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)
-     */
     @Override
     public void setBinaryData(Object binaryuri) {
         // when replacing an answer. remove the current media.

--- a/app/src/org/odk/collect/android/widgets/AutoCompleteWidget.java
+++ b/app/src/org/odk/collect/android/widgets/AutoCompleteWidget.java
@@ -88,10 +88,6 @@ public class AutoCompleteWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         String response = autocomplete.getText().toString();
@@ -113,20 +109,12 @@ public class AutoCompleteWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         autocomplete.setText("");
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -148,10 +136,6 @@ public class AutoCompleteWidget extends QuestionWidget {
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#add(java.lang.Object)
-         */
         @Override
         public void add(String toAdd) {
             super.add(toAdd);
@@ -159,30 +143,18 @@ public class AutoCompleteWidget extends QuestionWidget {
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#getCount()
-         */
         @Override
         public int getCount() {
             return mItems.size();
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#getItem(int)
-         */
         @Override
         public String getItem(int position) {
             return mItems.get(position);
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#getPosition(java.lang.Object)
-         */
         @Override
         public int getPosition(String item) {
             return mItems.indexOf(item);
@@ -197,10 +169,6 @@ public class AutoCompleteWidget extends QuestionWidget {
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#getItemId(int)
-         */
         @Override
         public long getItemId(int position) {
             return position;
@@ -219,10 +187,6 @@ public class AutoCompleteWidget extends QuestionWidget {
             }
 
 
-            /*
-             * (non-Javadoc)
-             * @see android.widget.Filter#performFiltering(java.lang.CharSequence)
-             */
             @Override
             protected FilterResults performFiltering(CharSequence prefix) {
                 // Initiate our results object
@@ -296,10 +260,6 @@ public class AutoCompleteWidget extends QuestionWidget {
             }
 
 
-            /*
-             * (non-Javadoc)
-             * @see android.widget.Filter#publishResults(java.lang.CharSequence, android.widget.Filter.FilterResults)
-             */
             @SuppressWarnings("unchecked")
             @Override
             protected void publishResults(CharSequence constraint, FilterResults results) {
@@ -318,20 +278,12 @@ public class AutoCompleteWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         autocomplete.setOnLongClickListener(l);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/app/src/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -94,10 +94,6 @@ public class BarcodeWidget extends IntentWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         mStringAnswer.setText(null);

--- a/app/src/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/app/src/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -65,10 +65,6 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         }
 
         mDateListener = new DatePicker.OnDateChangedListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.widget.DatePicker.OnDateChangedListener#onDateChanged(android.widget.DatePicker, int, int, int)
-             */
             @Override
             public void onDateChanged(DatePicker view, int year, int month, int day) {
                 if (mPrompt.isReadOnly()) {
@@ -138,9 +134,7 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
+    /**
      * Resets date to today.
      */
     @Override
@@ -153,10 +147,6 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         mDatePicker.clearFocus();
@@ -170,10 +160,6 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -183,10 +169,6 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mDatePicker.setOnLongClickListener(l);
@@ -194,10 +176,6 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();
@@ -205,10 +183,6 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         mTimePicker.cancelLongPress();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.TimePicker.OnTimeChangedListener#onTimeChanged(android.widget.TimePicker, int, int)
-     */
     @Override
     public void onTimeChanged(TimePicker view, int hourOfDay, int minute) {
         widgetEntryChanged();

--- a/app/src/org/odk/collect/android/widgets/DateWidget.java
+++ b/app/src/org/odk/collect/android/widgets/DateWidget.java
@@ -53,10 +53,6 @@ public class DateWidget extends QuestionWidget {
         }
         
         mDateListener = new DatePicker.OnDateChangedListener() {
-        	/*
-        	 * (non-Javadoc)
-        	 * @see android.widget.DatePicker.OnDateChangedListener#onDateChanged(android.widget.DatePicker, int, int, int)
-        	 */
             @Override
             public void onDateChanged(DatePicker view, int year, int month, int day) {
                 if (mPrompt.isReadOnly()) {
@@ -108,9 +104,7 @@ public class DateWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
+    /**
      * Resets date to today.
      */
     @Override
@@ -121,10 +115,6 @@ public class DateWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         mDatePicker.clearFocus();
@@ -135,10 +125,6 @@ public class DateWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -148,20 +134,12 @@ public class DateWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mDatePicker.setOnLongClickListener(l);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/DecimalWidget.java
+++ b/app/src/org/odk/collect/android/widgets/DecimalWidget.java
@@ -82,10 +82,6 @@ public class DecimalWidget extends StringWidget {
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#setTextInputType(android.widget.EditText)
-     */
     @Override
     protected void setTextInputType(EditText mAnswer) {
         if(secret) {
@@ -94,10 +90,6 @@ public class DecimalWidget extends StringWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         String s = mAnswer.getText().toString().trim();
@@ -111,9 +103,8 @@ public class DecimalWidget extends StringWidget {
             }
         }
     }
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#setLastQuestion(boolean)
+
+    /**
      * If this is the last question, set the action button to close the keyboard
      */
     @Override
@@ -125,10 +116,6 @@ public class DecimalWidget extends StringWidget {
         }
     }
 
-    /*
-* (non-Javadoc)
-* @see android.view.View.OnClickListener#onClick(android.view.View)
-*/
     @Override
     public void onClick(View v) {
         setFocus(getContext());

--- a/app/src/org/odk/collect/android/widgets/EthiopianDateWidget.java
+++ b/app/src/org/odk/collect/android/widgets/EthiopianDateWidget.java
@@ -20,57 +20,41 @@ public class EthiopianDateWidget extends AbstractUniversalDateWidget {
     private static final Chronology CHRON_ETH = EthiopicChronology.getInstance();
 
     public EthiopianDateWidget(Context context, FormEntryPrompt prompt) {
-    	super(context, prompt);
+        super(context, prompt);
     }
     
     private UniversalDate constructUniversalDate(DateTime dt) {
-    	return new UniversalDate(
-    			dt.getYear(),
-    			dt.getMonthOfYear(),
-    			dt.getDayOfMonth(),
-    			dt.getMillis()
-    	);
+        return new UniversalDate(
+                dt.getYear(),
+                dt.getMonthOfYear(),
+                dt.getDayOfMonth(),
+                dt.getMillis()
+        );
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#decrementMonth(long)
-     */
     @Override
     protected UniversalDate decrementMonth(long millisFromJavaEpoch) {
-    	DateTime dt = new DateTime(millisFromJavaEpoch)
-    		.withChronology(CHRON_ETH)
-    		.minusMonths(1);
-    	return constructUniversalDate(dt);
+        DateTime dt = new DateTime(millisFromJavaEpoch)
+            .withChronology(CHRON_ETH)
+            .minusMonths(1);
+        return constructUniversalDate(dt);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#decrementYear(long)
-     */
     @Override
     protected UniversalDate decrementYear(long millisFromJavaEpoch) {
-    	DateTime dt = new DateTime(millisFromJavaEpoch)
-    		.withChronology(CHRON_ETH)
-    		.minusYears(1);
-    	return constructUniversalDate(dt);
+        DateTime dt = new DateTime(millisFromJavaEpoch)
+            .withChronology(CHRON_ETH)
+            .minusYears(1);
+        return constructUniversalDate(dt);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#fromMillis(long)
-     */
     @Override
     protected UniversalDate fromMillis(long millisFromJavaEpoch) {
-    	DateTime dt = new DateTime(millisFromJavaEpoch)
-    		.withChronology(CHRON_ETH);
-    	return constructUniversalDate(dt);
+        DateTime dt = new DateTime(millisFromJavaEpoch)
+            .withChronology(CHRON_ETH);
+        return constructUniversalDate(dt);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#getMonthsArray()
-     */
     @Override
     protected String[] getMonthsArray() {
         Resources res = getResources();
@@ -78,41 +62,29 @@ public class EthiopianDateWidget extends AbstractUniversalDateWidget {
         return res.getStringArray(R.array.ethiopian_months);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#incrementMonth(long)
-     */
     @Override
     protected UniversalDate incrementMonth(long millisFromJavaEpoch) {
-    	DateTime dt = new DateTime(millisFromJavaEpoch)
-    		.withChronology(CHRON_ETH)
-    		.plusMonths(1);
-    	return constructUniversalDate(dt);
+        DateTime dt = new DateTime(millisFromJavaEpoch)
+            .withChronology(CHRON_ETH)
+            .plusMonths(1);
+        return constructUniversalDate(dt);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#incrementYear(long)
-     */
     @Override
     protected UniversalDate incrementYear(long millisFromJavaEpoch) {
-    	DateTime dt = new DateTime(millisFromJavaEpoch)
-    		.withChronology(CHRON_ETH)
-    		.plusYears(1);
-    	return constructUniversalDate(dt);
+        DateTime dt = new DateTime(millisFromJavaEpoch)
+            .withChronology(CHRON_ETH)
+            .plusYears(1);
+        return constructUniversalDate(dt);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#toMillisFromJavaEpoch(int,int,int,long)
-     */
     @Override
     protected long toMillisFromJavaEpoch(int year, int month, int day, long millisOffset) {
-    	DateTime dt = new DateTime(CHRON_ETH)
-    		.withYear(year)
-    		.withMonthOfYear(month)
-    		.withDayOfMonth(day)
-    		.withMillisOfDay((int) millisOffset);
-    	return dt.getMillis();
+        DateTime dt = new DateTime(CHRON_ETH)
+            .withYear(year)
+            .withMonthOfYear(month)
+            .withDayOfMonth(day)
+            .withMillisOfDay((int) millisOffset);
+        return dt.getMillis();
     }
 }

--- a/app/src/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/app/src/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -147,10 +147,6 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         mStringAnswer.setText(null);
@@ -160,10 +156,6 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         String s = mStringAnswer.getText().toString();
@@ -221,10 +213,6 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -234,10 +222,6 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)
-     */
     @Override
     public void setBinaryData(Object answer) {
         String s = (String)answer;
@@ -257,20 +241,12 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#isWaitingForBinaryData()
-     */
     @Override
     public boolean isWaitingForBinaryData() {
         return mWaitingForData;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mViewButton.setOnLongClickListener(l);
@@ -280,10 +256,6 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/GridMultiWidget.java
+++ b/app/src/org/odk/collect/android/widgets/GridMultiWidget.java
@@ -205,10 +205,6 @@ public class GridMultiWidget extends QuestionWidget {
         addView(gridview);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         Vector<Selection> vc = new Vector<Selection>();
@@ -227,10 +223,6 @@ public class GridMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         for (int i = 0; i < mItems.size(); ++i) {
@@ -241,10 +233,6 @@ public class GridMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -353,20 +341,12 @@ public class GridMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         gridview.setOnLongClickListener(l);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/GridWidget.java
+++ b/app/src/org/odk/collect/android/widgets/GridWidget.java
@@ -338,11 +338,6 @@ public class GridWidget extends QuestionWidget {
         addView(gridview);
     }
 
-
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         for (int i = 0; i < choices.length; ++i) {
@@ -354,11 +349,6 @@ public class GridWidget extends QuestionWidget {
         return null;
     }
 
-
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         for (int i = 0; i < mItems.size(); ++i) {
@@ -368,11 +358,6 @@ public class GridWidget extends QuestionWidget {
 
     }
 
-
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -480,21 +465,11 @@ public class GridWidget extends QuestionWidget {
         }
     }
 
-
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         gridview.setOnLongClickListener(l);
     }
 
-
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/ImageWidget.java
+++ b/app/src/org/odk/collect/android/widgets/ImageWidget.java
@@ -245,10 +245,6 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         mBinaryName = null;*/
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         // remove the file
@@ -260,10 +256,6 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         mCaptureButton.setText(StringUtils.getStringSpannableRobust(getContext(), R.string.capture_image));
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         if (mBinaryName != null) {
@@ -273,10 +265,6 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)
-     */
     @Override
     public void setBinaryData(Object binaryuri) {
         // you are replacing an answer. delete the previous image using the
@@ -292,10 +280,6 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         mWaitingForData = false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -304,19 +288,11 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         inputManager.hideSoftInputFromWindow(this.getWindowToken(), 0);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#isWaitingForBinaryData()
-     */
     @Override
     public boolean isWaitingForBinaryData() {
         return mWaitingForData;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mCaptureButton.setOnLongClickListener(l);
@@ -326,10 +302,6 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/IntegerWidget.java
+++ b/app/src/org/odk/collect/android/widgets/IntegerWidget.java
@@ -85,10 +85,6 @@ public class IntegerWidget extends StringWidget {
     }
     
     
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#guessMaxStringLength(org.javarosa.form.api.FormEntryPrompt)
-     */
     @Override
     protected int guessMaxStringLength(FormEntryPrompt prompt) throws UnpivotableExpressionException{
         int existingGuess = Integer.MAX_VALUE;
@@ -132,10 +128,6 @@ public class IntegerWidget extends StringWidget {
         }
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#setTextInputType(android.widget.EditText)
-     */
     @Override
     protected void setTextInputType(EditText mAnswer) {
         if(secret) {
@@ -145,10 +137,6 @@ public class IntegerWidget extends StringWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         String s = mAnswer.getText().toString().trim();
@@ -167,9 +155,7 @@ public class IntegerWidget extends StringWidget {
             }
         }
     }
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#setLastQuestion(boolean)
+    /**
      * If this is the last question, set the action button to close the keyboard
      */
     @Override
@@ -181,10 +167,6 @@ public class IntegerWidget extends StringWidget {
         }
     }
 
-    /*
- * (non-Javadoc)
- * @see android.view.View.OnClickListener#onClick(android.view.View)
- */
     @Override
     public void onClick(View v) {
         setFocus(getContext());

--- a/app/src/org/odk/collect/android/widgets/IntentWidget.java
+++ b/app/src/org/odk/collect/android/widgets/IntentWidget.java
@@ -118,10 +118,6 @@ public class IntentWidget extends QuestionWidget implements IBinaryWidget {
 
         // launch barcode capture intent on click
         launchIntentButton.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 performCallout();
@@ -160,10 +156,6 @@ public class IntentWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         mStringAnswer.setText(null);
@@ -171,10 +163,6 @@ public class IntentWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         String s = mStringAnswer.getText().toString();
@@ -186,9 +174,7 @@ public class IntentWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)
+    /**
      * Allows answer to be set externally in {@Link FormEntryActivity}.
      */
     @Override
@@ -198,10 +184,6 @@ public class IntentWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -211,20 +193,12 @@ public class IntentWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#isWaitingForBinaryData()
-     */
     @Override
     public boolean isWaitingForBinaryData() {
         return mWaitingForData;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mStringAnswer.setOnLongClickListener(l);
@@ -232,10 +206,6 @@ public class IntentWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/LabelWidget.java
+++ b/app/src/org/odk/collect/android/widgets/LabelWidget.java
@@ -182,30 +182,18 @@ public class LabelWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         // Do nothing, no answers to clear
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         return null;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -246,10 +234,6 @@ public class LabelWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();
@@ -267,10 +251,6 @@ public class LabelWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mQuestionText.setOnLongClickListener(l);

--- a/app/src/org/odk/collect/android/widgets/ListMultiWidget.java
+++ b/app/src/org/odk/collect/android/widgets/ListMultiWidget.java
@@ -93,10 +93,6 @@ public class ListMultiWidget extends QuestionWidget {
 
                 // when clicked, check for readonly before toggling
                 c.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                    /*
-                     * (non-Javadoc)
-                     * @see android.widget.CompoundButton.OnCheckedChangeListener#onCheckedChanged(android.widget.CompoundButton, boolean)
-                     */
                     @Override
                     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                         if (!mCheckboxInit && mPrompt.isReadOnly()) {
@@ -253,10 +249,6 @@ public class ListMultiWidget extends QuestionWidget {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         int j = mItems.size();
@@ -271,10 +263,6 @@ public class ListMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         Vector<Selection> vc = new Vector<Selection>();
@@ -295,10 +283,6 @@ public class ListMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -339,10 +323,6 @@ public class ListMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         for (CheckBox c : mCheckboxes) {
@@ -351,10 +331,6 @@ public class ListMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/ListWidget.java
+++ b/app/src/org/odk/collect/android/widgets/ListWidget.java
@@ -228,10 +228,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     public ListWidget(Context context, FormEntryPrompt prompt, boolean displayLabel, WidgetChangedListener wcl) {
         super(context, prompt, wcl);
     }
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         for (RadioButton button : this.buttons) {
@@ -243,10 +239,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         int i = getCheckedId();
@@ -259,10 +251,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -282,10 +270,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.CompoundButton.OnCheckedChangeListener#onCheckedChanged(android.widget.CompoundButton, boolean)
-     */
     @Override
     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         if (!isChecked) {
@@ -335,10 +319,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         for (RadioButton r : buttons) {
@@ -347,10 +327,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/NepaliDateWidget.java
+++ b/app/src/org/odk/collect/android/widgets/NepaliDateWidget.java
@@ -16,42 +16,26 @@ import android.content.res.Resources;
 public class NepaliDateWidget extends AbstractUniversalDateWidget {
     
     public NepaliDateWidget(Context context, FormEntryPrompt prompt) {
-    	super(context, prompt);
+        super(context, prompt);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#decrementMonth(long)
-     */
     @Override
     protected UniversalDate decrementMonth(long millisFromJavaEpoch) {
-    	UniversalDate origDate = fromMillis(millisFromJavaEpoch);
-    	return NepaliDateUtilities.decrementMonth(origDate);
+        UniversalDate origDate = fromMillis(millisFromJavaEpoch);
+        return NepaliDateUtilities.decrementMonth(origDate);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#decrementYear(long)
-     */
     @Override
     protected UniversalDate decrementYear(long millisFromJavaEpoch) {
         UniversalDate origDate = fromMillis(millisFromJavaEpoch);
         return NepaliDateUtilities.decrementYear(origDate);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#fromMillis(long)
-     */
     @Override
     protected UniversalDate fromMillis(long millisFromJavaEpoch) {
         return NepaliDateUtilities.fromMillis(millisFromJavaEpoch);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#getMonthsArray()
-     */
     @Override
     protected String[] getMonthsArray() {
         Resources res = getResources();
@@ -59,30 +43,18 @@ public class NepaliDateWidget extends AbstractUniversalDateWidget {
         return res.getStringArray(R.array.nepali_months);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#incrementMonth(long)
-     */
     @Override
     protected UniversalDate incrementMonth(long millisFromJavaEpoch) {
         UniversalDate origDate = fromMillis(millisFromJavaEpoch);
         return NepaliDateUtilities.incrementMonth(origDate);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#incrementYear(long)
-     */
     @Override
     protected UniversalDate incrementYear(long millisFromJavaEpoch) {
         UniversalDate origDate = fromMillis(millisFromJavaEpoch);
         return NepaliDateUtilities.incrementYear(origDate);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.AbstractUniversalDateWidget#toMillisFromJavaEpoch(int,int,int,long)
-     */
     @Override
     protected long toMillisFromJavaEpoch(int year, int month, int day, long millisOffset) {
         return NepaliDateUtilities.toMillisFromJavaEpoch(year, month, day, millisOffset);

--- a/app/src/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/app/src/org/odk/collect/android/widgets/QuestionWidget.java
@@ -191,10 +191,6 @@ public abstract class QuestionWidget extends LinearLayout {
         public URLSpanNoUnderline(String url) {
             super(url);
         }
-        /*
-         * (non-Javadoc)
-         * @see android.text.style.ClickableSpan#updateDrawState(android.text.TextPaint)
-         */
         @Override public void updateDrawState(TextPaint ds) {
             super.updateDrawState(ds);
             ds.setUnderlineText(false);

--- a/app/src/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/app/src/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -93,10 +93,6 @@ public class SelectMultiWidget extends QuestionWidget {
                 
                 // when clicked, check for readonly before toggling
                 c.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                    /*
-                     * (non-Javadoc)
-                     * @see android.widget.CompoundButton.OnCheckedChangeListener#onCheckedChanged(android.widget.CompoundButton, boolean)
-                     */
                     @Override
                     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                         if (!mCheckboxInit && mPrompt.isReadOnly()) {
@@ -156,10 +152,6 @@ public class SelectMultiWidget extends QuestionWidget {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         int j = mItems.size();
@@ -174,10 +166,6 @@ public class SelectMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         Vector<Selection> vc = new Vector<Selection>();
@@ -198,10 +186,6 @@ public class SelectMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -211,10 +195,6 @@ public class SelectMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         for (CheckBox c : mCheckboxes) {
@@ -223,10 +203,6 @@ public class SelectMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/SelectOneAutoAdvanceWidget.java
+++ b/app/src/org/odk/collect/android/widgets/SelectOneAutoAdvanceWidget.java
@@ -143,10 +143,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         for (RadioButton button : this.buttons) {
@@ -158,10 +154,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         int i = getCheckedId();
@@ -174,10 +166,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -197,10 +185,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.CompoundButton.OnCheckedChangeListener#onCheckedChanged(android.widget.CompoundButton, boolean)
-     */
     @Override
     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         if (!buttonView.isPressed()) {
@@ -222,10 +206,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         for (RadioButton r : buttons) {
@@ -234,10 +214,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/SelectOneWidget.java
+++ b/app/src/org/odk/collect/android/widgets/SelectOneWidget.java
@@ -124,10 +124,6 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         for (RadioButton button : this.buttons) {
@@ -139,10 +135,6 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         int i = getCheckedId();
@@ -162,10 +154,6 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         onUserInteracton();
@@ -182,10 +170,6 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.CompoundButton.OnCheckedChangeListener#onCheckedChanged(android.widget.CompoundButton, boolean)
-     */
     @Override
     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         onUserInteracton();
@@ -206,10 +190,6 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         for (RadioButton r : buttons) {
@@ -218,10 +198,6 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/SignatureWidget.java
+++ b/app/src/org/odk/collect/android/widgets/SignatureWidget.java
@@ -181,10 +181,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         // remove the file
@@ -197,10 +193,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         if (mBinaryName != null) {
@@ -211,10 +203,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)
-     */
     @Override
     public void setBinaryData(Object binaryURI) {
         // you are replacing an answer. delete the previous image using the
@@ -231,10 +219,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
         mWaitingForData = false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -244,10 +228,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#isWaitingForBinaryData()
-     */
     @Override
     public boolean isWaitingForBinaryData() {
         return mWaitingForData;
@@ -261,10 +241,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
         mWaitingForData = false;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mSignButton.setOnLongClickListener(l);
@@ -274,10 +250,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/app/src/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -111,10 +111,6 @@ public class SpinnerMultiWidget extends QuestionWidget {
                 alert_builder.setMultiChoiceItems(answer_items, selections,
                     new DialogInterface.OnMultiChoiceClickListener() {
 
-                		/*
-                		 * (non-Javadoc)
-                		 * @see android.content.DialogInterface.OnMultiChoiceClickListener#onClick(android.content.DialogInterface, int, boolean)
-                		 */
                         @Override
                         public void onClick(DialogInterface dialog, int which, boolean isChecked) {
                             selections[which] = isChecked;
@@ -173,10 +169,6 @@ public class SpinnerMultiWidget extends QuestionWidget {
 
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         Vector<Selection> vc = new Vector<Selection>();
@@ -195,10 +187,6 @@ public class SpinnerMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         selectionText.setText(R.string.selected);
@@ -209,10 +197,6 @@ public class SpinnerMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -223,20 +207,12 @@ public class SpinnerMultiWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         button.setOnLongClickListener(l);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/SpinnerWidget.java
+++ b/app/src/org/odk/collect/android/widgets/SpinnerWidget.java
@@ -86,10 +86,6 @@ public class SpinnerWidget extends QuestionWidget {
         }
         
         spinner.setOnItemSelectedListener(new OnItemSelectedListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.widget.AdapterView.OnItemSelectedListener#onItemSelected(android.widget.AdapterView, android.view.View, int, long)
-             */
             @Override
             public void onItemSelected(AdapterView<?> parentView, View selectedItemView, int position, long id) {
                 if(hasListener){
@@ -97,10 +93,6 @@ public class SpinnerWidget extends QuestionWidget {
                 }
             }
 
-            /*
-             * (non-Javadoc)
-             * @see android.widget.AdapterView.OnItemSelectedListener#onNothingSelected(android.widget.AdapterView)
-             */
             @Override
             public void onNothingSelected(AdapterView<?> parent) {
                 //do nothing here
@@ -113,10 +105,6 @@ public class SpinnerWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         int i = spinner.getSelectedItemPosition();
@@ -129,10 +117,6 @@ public class SpinnerWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         // It seems that spinners cannot return a null answer. This resets the answer
@@ -142,10 +126,6 @@ public class SpinnerWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -173,10 +153,6 @@ public class SpinnerWidget extends QuestionWidget {
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#getDropDownView(int, android.view.View, android.view.ViewGroup)
-         */
         @Override
         // Defines the text view parameters for the drop down list entries
         public View getDropDownView(int position, View convertView, ViewGroup parent) {
@@ -194,10 +170,6 @@ public class SpinnerWidget extends QuestionWidget {
         }
 
 
-        /*
-         * (non-Javadoc)
-         * @see android.widget.ArrayAdapter#getView(int, android.view.View, android.view.ViewGroup)
-         */
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
             if (convertView == null) {
@@ -214,20 +186,12 @@ public class SpinnerWidget extends QuestionWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         spinner.setOnLongClickListener(l);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/StringNumberWidget.java
+++ b/app/src/org/odk/collect/android/widgets/StringNumberWidget.java
@@ -47,10 +47,6 @@ public class StringNumberWidget extends StringWidget {
         }
 
         mAnswer.setKeyListener(new DigitsKeyListener(true, true) {
-        	/*
-        	 * (non-Javadoc)
-        	 * @see android.text.method.DigitsKeyListener#getAcceptedChars()
-        	 */
             @Override
             protected char[] getAcceptedChars() {
                 char[] accepted = {
@@ -79,10 +75,6 @@ public class StringNumberWidget extends StringWidget {
 
     }
     
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#setTextInputType(android.widget.EditText)
-     */
     @Override
     protected void setTextInputType(EditText mAnswer) {
         if(secret) {
@@ -91,10 +83,6 @@ public class StringNumberWidget extends StringWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.StringWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         String s = mAnswer.getText().toString();
@@ -109,11 +97,9 @@ public class StringNumberWidget extends StringWidget {
         }
     }
 
-    /*
- * (non-Javadoc)
- * @see org.odk.collect.android.widgets.StringWidget#setLastQuestion(boolean)
- * If this is the last question, set the action button to close the keyboard
- */
+    /**
+     * If this is the last question, set the action button to close the keyboard
+     */
     @Override
     public void setLastQuestion(boolean isLast){
         if(isLast){
@@ -123,14 +109,9 @@ public class StringNumberWidget extends StringWidget {
         }
     }
 
-    /*
-* (non-Javadoc)
-* @see android.view.View.OnClickListener#onClick(android.view.View)
-*/
     @Override
     public void onClick(View v) {
         setFocus(getContext());
         // don't revert click behavior in this case since it might be customized.
     }
-
 }

--- a/app/src/org/odk/collect/android/widgets/StringWidget.java
+++ b/app/src/org/odk/collect/android/widgets/StringWidget.java
@@ -138,20 +138,12 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         mAnswer.setText(null);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         String s = mAnswer.getText().toString().trim();
@@ -163,10 +155,6 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         
@@ -190,10 +178,6 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.View#onKeyDown(int, android.view.KeyEvent)
-     */
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (event.isAltPressed() == true) {
@@ -204,30 +188,18 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mAnswer.setOnLongClickListener(l);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();
         mAnswer.cancelLongPress();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.view.View.OnClickListener#onClick(android.view.View)
-     */
     @Override
     public void onClick(View v) {
         //revert to default editor behavior
@@ -240,19 +212,11 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
         mAnswer.performClick();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.text.TextWatcher#afterTextChanged(android.text.Editable)
-     */
     @Override
     public void afterTextChanged(Editable s) {
         widgetEntryChanged();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.text.TextWatcher#beforeTextChanged(java.lang.CharSequence, int, int, int)
-     */
     @Override
     public void beforeTextChanged(CharSequence s, int start, int count,
             int after) {
@@ -260,10 +224,6 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
         
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.text.TextWatcher#onTextChanged(java.lang.CharSequence, int, int, int)
-     */
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
         // TODO Auto-generated method stub

--- a/app/src/org/odk/collect/android/widgets/TimeWidget.java
+++ b/app/src/org/odk/collect/android/widgets/TimeWidget.java
@@ -72,9 +72,7 @@ public class TimeWidget extends QuestionWidget implements OnTimeChangedListener 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
+    /**
      * Resets time to today.
      */
     @Override
@@ -84,10 +82,6 @@ public class TimeWidget extends QuestionWidget implements OnTimeChangedListener 
         mTimePicker.setCurrentMinute(ldt.getMinuteOfHour());
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         mTimePicker.clearFocus();
@@ -104,10 +98,6 @@ public class TimeWidget extends QuestionWidget implements OnTimeChangedListener 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -117,30 +107,18 @@ public class TimeWidget extends QuestionWidget implements OnTimeChangedListener 
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mTimePicker.setOnLongClickListener(l);
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();
         mTimePicker.cancelLongPress();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see android.widget.TimePicker.OnTimeChangedListener#onTimeChanged(android.widget.TimePicker, int, int)
-     */
     @Override
     public void onTimeChanged(TimePicker view, int hourOfDay, int minute) {
         this.widgetEntryChanged();

--- a/app/src/org/odk/collect/android/widgets/TriggerWidget.java
+++ b/app/src/org/odk/collect/android/widgets/TriggerWidget.java
@@ -81,10 +81,6 @@ public class TriggerWidget extends QuestionWidget {
                 !mPrompt.isReadOnly());
 
         mTriggerButton.setOnClickListener(new View.OnClickListener() {
-            /*
-             * (non-Javadoc)
-             * @see android.view.View.OnClickListener#onClick(android.view.View)
-             */
             @Override
             public void onClick(View v) {
                 if (mTriggerButton.isChecked()) {
@@ -116,20 +112,12 @@ public class TriggerWidget extends QuestionWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         mStringAnswer.setText(null);
         mTriggerButton.setChecked(false);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         if (!mInteractive) {
@@ -143,10 +131,6 @@ public class TriggerWidget extends QuestionWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -155,20 +139,12 @@ public class TriggerWidget extends QuestionWidget {
         inputManager.hideSoftInputFromWindow(this.getWindowToken(), 0);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mTriggerButton.setOnLongClickListener(l);
         mStringAnswer.setOnLongClickListener(l);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();

--- a/app/src/org/odk/collect/android/widgets/VideoWidget.java
+++ b/app/src/org/odk/collect/android/widgets/VideoWidget.java
@@ -188,10 +188,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#clearAnswer()
-     */
     @Override
     public void clearAnswer() {
         // remove the file
@@ -202,10 +198,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#getAnswer()
-     */
     @Override
     public IAnswerData getAnswer() {
         if (mBinaryName != null) {
@@ -215,10 +207,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#setBinaryData(java.lang.Object)
-     */
     @Override
     public void setBinaryData(Object binaryuri) {
         // you are replacing an answer. remove the media.
@@ -258,10 +246,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setFocus(android.content.Context)
-     */
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -271,20 +255,12 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.IBinaryWidget#isWaitingForBinaryData()
-     */
     @Override
     public boolean isWaitingForBinaryData() {
         return mWaitingForData;
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#setOnLongClickListener(android.view.View.OnLongClickListener)
-     */
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         mCaptureButton.setOnLongClickListener(l);
@@ -293,10 +269,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
     }
 
 
-    /*
-     * (non-Javadoc)
-     * @see org.odk.collect.android.widgets.QuestionWidget#cancelLongPress()
-     */
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();


### PR DESCRIPTION
Non-javadoc comments add unneeded cruft, nothing ensures they aren't out of date and perpetuating misinformation, and if there are Override annotations, don't actually provide any additional info.

Remove them and add Override annotations in places that they were missing.

Yet another installation of being bored on a road trip.