### PR TITLE
Refactor CommCareHomeActivity

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -43,7 +43,6 @@ menu.archive=Offline Install
 
 profile.found=Application found. ${0} resources loaded, of ${1} total.
 
-app.workflow.login.lost=You were logged out of CommCare, please log back in
 app.workflow.incomplete.continue.title=Continue Form
 app.workflow.incomplete.continue=You've got a saved copy of an incomplete form for this client. Do you want to continue filling out that form?
 app.workflow.incomplete.continue.option.delete=Delete Old Copy
@@ -133,8 +132,6 @@ notifications.prompt.details=Select for details. ${0}
 notifications.prompt.more=(${0} More...)
 
 update.success.refresh=CommCare has been updated! Please log in again.
-
-home.logged.out=You were logged out. Please log back in to continue
 
 form.record.filter.subandpending=Filter By: All Completed Forms
 form.record.filter.submitted=Filter By: Only Submitted Forms

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -76,7 +76,6 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.storage.StorageFullException;
-import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
@@ -505,16 +504,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if(resultCode == RESULT_RESTART) {
-            try {
-                startNextFetch();
-            } catch (SessionUnavailableException e) {
-                // session has expired and re-login intent has
-                // probably already been triggered
-            }
-            return;
-        }
-        
-        try {
+            startNextFetch();
+        } else {
             // if handling new return code (want to return to home screen) but a return at the end of your statement
             switch(requestCode) {
             case INIT_APP:
@@ -716,12 +707,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             }
 
             startNextFetch();
-        } catch (SessionUnavailableException sue) {
-            //TODO: Cache current return, login, and try again
-            returnToLogin();
         }
         super.onActivityResult(requestCode, resultCode, intent);
-
     }
 
     /**
@@ -736,7 +723,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
      * the session to launch. If false then caller should exit or spawn home
      * activity.
      */
-    private boolean processReturnFromFormEntry(int resultCode, Intent intent) throws SessionUnavailableException {
+    private boolean processReturnFromFormEntry(int resultCode, Intent intent) {
         // TODO: We might need to load this from serialized state?
         AndroidSessionWrapper currentState = CommCareApplication._().getCurrentSessionWrapper();
 
@@ -904,7 +891,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         mAlertDialog.show();
     }
 
-    private void startNextFetch() throws SessionUnavailableException {
+    private void startNextFetch() {
         //TODO: feels like this logic should... not be in a big disgusting ifghetti.
         //Interface out the transitions, maybe?
 
@@ -925,12 +912,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                     @Override
                     public void onClick(DialogInterface dialog, int i) {
                         session.stepBack();
-                        try {
-                            CommCareHomeActivity.this.startNextFetch();
-                        } catch (SessionUnavailableException e) {
-                            // session has expired and re-login intent has
-                            // probably already been triggered
-                        }
+                        CommCareHomeActivity.this.startNextFetch();
                     }
                 });
                 return;
@@ -990,7 +972,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
      *
      * @param state Needed for FormRecord manipulations
      */
-    private void startFormEntry(AndroidSessionWrapper state) throws SessionUnavailableException {
+    private void startFormEntry(AndroidSessionWrapper state) {
             if (state.getFormRecordId() == -1) {
                 if (CommCarePreferences.isIncompleteFormsEnabled()) {
                     // Are existing (incomplete) forms using the same case?
@@ -1049,7 +1031,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         return false;
     }
 
-    private void formEntry(Uri formUri, FormRecord r) throws SessionUnavailableException {
+    private void formEntry(Uri formUri, FormRecord r) {
         formEntry(formUri, r, null);
     }
 
@@ -1319,8 +1301,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                             formEntry(platform.getFormContentUri(state.getSession().getForm()), state.getFormRecord());
                             break;
                     }
-                } catch (SessionUnavailableException sue) {
-                    //TODO: From home activity, login again and return to form list if possible.
                 } catch (StorageFullException e) {
                     throw new RuntimeException(e);
                 }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -321,7 +321,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             setSyncButtonText(CommCareApplication._().getSyncDisplayParameters(), null);
         View.OnClickListener syncButtonListener = new OnClickListener() {
             public void onClick(View v) {
-                if (!isOnline()) {
+                if (isNetworkNotConnected()) {
                     if (isAirplaneModeOn()) {
                         displayMessage(Localization.get("notification.sync.airplane.action"), true, true);
                         CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(StockMessages.Sync_AirplaneMode, AIRPLANE_MODE_CATEGORY));
@@ -354,13 +354,10 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         }
     }
 
-    private boolean isOnline() {
+    private boolean isNetworkNotConnected() {
         ConnectivityManager cm = (ConnectivityManager)getSystemService(CONNECTIVITY_SERVICE);
         NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo != null && netInfo.isConnectedOrConnecting()) {
-            return true;
-        }
-        return false;
+        return (netInfo == null || !netInfo.isConnectedOrConnecting());
     }
 
     private void goToFormArchive(boolean incomplete) {
@@ -1555,7 +1552,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 createPreferencesMenu(this);
                 return true;
             case MENU_UPDATE:
-                if (!isOnline() && isAirplaneModeOn()) {
+                if (isNetworkNotConnected() && isAirplaneModeOn()) {
                     CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(StockMessages.Sync_AirplaneMode));
                     return true;
                 }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -640,10 +640,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                     this.finish();
                     return;
                 } else if(resultCode == RESULT_OK) {
-                    if(intent.getBooleanExtra(LoginActivity.ALREADY_LOGGED_IN, false)) {
-                        //If we were already logged in just roll with it.
-                        //The onResume() will take us to the screen
-                    } else {
+                    if (!intent.getBooleanExtra(LoginActivity.ALREADY_LOGGED_IN, false)) {
                         refreshView();
                         
                         //Unless we're about to sync (which will handle this
@@ -1006,10 +1003,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             }
             startNextFetch();
         }
-
-        if (lastPopped != null) {
-            //overridePendingTransition(R.anim.push_right_in, R.anim.push_right_out);
-        }
     }
 
     /**
@@ -1175,12 +1168,10 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                     if (syncAfterwards) {
                         syncData(true);
                     }
-                } else if (result == FormUploadUtil.FAILURE) {
-                    //Failures make their own notification box
-                } else {
+                } else if (result != FormUploadUtil.FAILURE) {
+                    // Tasks with failure result codes will have already created a notification
                     receiver.displayMessage(Localization.get("sync.fail.unsent"), true);
                 }
-
             }
 
             /*
@@ -1326,10 +1317,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     }
 
     private void returnToLogin(String message) {
-        //Not yet.
-        if (message != null) {
-            //Toast.makeText(this, message, Toast.LENGTH_LONG).show();
-        }
         Intent i = new Intent(getApplicationContext(), LoginActivity.class);
         i.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         startActivityForResult(i, LOGIN_USER);

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -140,9 +140,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
      */
     public static final int RESULT_RESTART = 3;
 
-    private static int unsentFormNumberLimit;
-    private static int unsentFormTimeLimit;
-
     private final static String UNSENT_FORM_NUMBER_KEY = "unsent-number-limit";
     private final static String UNSENT_FORM_TIME_KEY = "unsent-time-limit";
 
@@ -156,14 +153,11 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
     private AndroidCommCarePlatform platform;
 
-    private AlertDialog mAskOldDialog;
-    private AlertDialog mAttemptFixDialog;
     private SquareButtonWithNotification startButton;
     private SquareButtonWithNotification logoutButton;
     private SquareButtonWithNotification viewIncomplete;
     private SquareButtonWithNotification syncButton;
 
-    private SquareButtonWithNotification viewOldForms;
     private HomeScreenAdapter adapter;
     private GridViewWithHeaderAndFooter gridView;
     private ImageView topBannerImageView;
@@ -295,7 +289,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             formGroupLabel.setText(Localization.get("home.forms"));
         }
 
-        viewOldForms = adapter.getButton(R.layout.home_savedforms_button, false);
+        SquareButtonWithNotification viewOldForms = adapter.getButton(R.layout.home_savedforms_button, false);
         if (viewOldForms == null) {
             Log.d("buttons", "viewOldForms is null! Crashing!");
         }
@@ -1284,7 +1278,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     }
 
     private void createAskUseOldDialog(final AndroidSessionWrapper state, final SessionStateDescriptor existing) {
-        mAskOldDialog = new AlertDialog.Builder(this).create();
+        AlertDialog mAskOldDialog = new AlertDialog.Builder(this).create();
         mAskOldDialog.setTitle(Localization.get("app.workflow.incomplete.continue.title"));
         mAskOldDialog.setMessage(Localization.get("app.workflow.incomplete.continue"));
         DialogInterface.OnClickListener useOldListener = new DialogInterface.OnClickListener() {
@@ -1353,8 +1347,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
 
-        unsentFormNumberLimit = Integer.parseInt(prefs.getString(UNSENT_FORM_NUMBER_KEY, "5"));
-        unsentFormTimeLimit = Integer.parseInt(prefs.getString(UNSENT_FORM_TIME_KEY, "5"));
+        int unsentFormNumberLimit = Integer.parseInt(prefs.getString(UNSENT_FORM_NUMBER_KEY, "5"));
+        int unsentFormTimeLimit = Integer.parseInt(prefs.getString(UNSENT_FORM_TIME_KEY, "5"));
 
         String syncKey = "home.sync";
         String lastMessageKey = "home.sync.message.last";
@@ -1639,7 +1633,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
     private Dialog createAskFixDialog() {
         //TODO: Localize this in theory, but really shift it to the upgrade/management state
-        mAttemptFixDialog = new AlertDialog.Builder(this).create();
+        AlertDialog mAttemptFixDialog = new AlertDialog.Builder(this).create();
 
         mAttemptFixDialog.setTitle("Storage is Corrupt :/");
         mAttemptFixDialog.setMessage("Sorry, something really bad has happened, and the app can't start up. With your permission CommCare can try to repair itself if you have network access.");
@@ -1650,7 +1644,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                         Intent intent = new Intent(CommCareHomeActivity.this, RecoveryActivity.class);
                         startActivity(intent);
                         break;
-
                     case DialogInterface.BUTTON_NEGATIVE: // Shut down
                         CommCareHomeActivity.this.finish();
                         break;

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -103,9 +103,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     public static final int MODEL_RESULT = 4;
     public static final int INIT_APP = 8;
     public static final int GET_INCOMPLETE_FORM = 16;
-    public static final int GET_REFERRAL = 32;
-    public static final int UPGRADE_APP = 64;
-    public static final int REPORT_PROBLEM_ACTIVITY = 128;
+    public static final int UPGRADE_APP = 32;
+    public static final int REPORT_PROBLEM_ACTIVITY = 64;
 
     /**
      * Request code for automatically validating media from home dispatch.
@@ -124,9 +123,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
      */
     public static final int MEDIA_VALIDATOR_ACTIVITY=8192;
 
-    public static final int USE_OLD_DIALOG = 1;
-    public static final int DIALOG_CORRUPTED = 4;
-    public static final int DIALOG_NO_STORAGE = 8;
+    public static final int DIALOG_CORRUPTED = 1;
 
     private static final int MENU_PREFERENCES = Menu.FIRST;
     private static final int MENU_UPDATE = Menu.FIRST + 1;
@@ -158,8 +155,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     // activity instead of commcare.
     boolean wasExternal = false;
 
-    View homeScreen;
-
     private AndroidCommCarePlatform platform;
 
     AlertDialog mAskOldDialog;
@@ -173,7 +168,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     HomeScreenAdapter adapter;
     GridViewWithHeaderAndFooter gridView;
     ImageView topBannerImageView;
-    int gridViewMargin;
 
     /*
          * (non-Javadoc)
@@ -1359,7 +1353,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         }
 
         adapter.setNotificationTextForButton(R.layout.home_sync_button, false, message);
-
     }
 
     private void refreshView() {
@@ -1607,10 +1600,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         return super.onOptionsItemSelected(item);
     }
     
-    private void createPreferencesMenu() {
-        createPreferencesMenu(this);
-    }
-
     public static void createPreferencesMenu(Activity activity) {
         Intent i = new Intent(activity, CommCarePreferences.class);
         activity.startActivityForResult(i, PREFERENCES_ACTIVITY);

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -786,11 +786,17 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 return false;
             }
 
-            Cursor c = getContentResolver().query(resultInstanceURI, null, null, null, null);
-            if (!c.moveToFirst()) {
-                throw new IllegalArgumentException("Empty query for instance record!");
+            Cursor c = null;
+            String instanceStatus;
+            try {
+                c = getContentResolver().query(resultInstanceURI, null, null, null, null);
+                if (!c.moveToFirst()) {
+                    throw new IllegalArgumentException("Empty query for instance record!");
+                }
+                instanceStatus = c.getString(c.getColumnIndexOrThrow(InstanceProviderAPI.InstanceColumns.STATUS));
+            } finally {
+                c.close();
             }
-            String instanceStatus = c.getString(c.getColumnIndexOrThrow(InstanceProviderAPI.InstanceColumns.STATUS));
             // was the record marked complete?
             boolean complete = InstanceProviderAPI.STATUS_COMPLETE.equals(instanceStatus);
 
@@ -1626,20 +1632,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         CommCareHomeActivity.this.startActivityForResult(i, CONNECTION_DIAGNOSTIC_ACTIVITY);
     }
 
-//    @Override
-//    public void onConfigurationChanged(Configuration newConfig) {
-//      super.onConfigurationChanged(newConfig);
-//      setContentView(R.layout.mainnew);
-//      try {
-//          configUi();
-//          refreshView();
-//      } catch(SessionUnavailableException sue) {
-//          //we'll handle this in resume?
-//      }
-//    }
-
     private boolean isAirplaneModeOn() {
-
         return Settings.System.getInt(getApplicationContext().getContentResolver(),
                 Settings.System.AIRPLANE_MODE_ON, 0) != 0;
     }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -97,33 +97,33 @@ import in.srain.cube.views.GridViewWithHeaderAndFooter;
 public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity> {
     private static final String TAG = CommCareHomeActivity.class.getSimpleName();
 
-    public static final int LOGIN_USER = 0;
-    public static final int GET_COMMAND = 1;
-    public static final int GET_CASE = 2;
-    public static final int MODEL_RESULT = 4;
-    public static final int INIT_APP = 8;
-    public static final int GET_INCOMPLETE_FORM = 16;
-    public static final int UPGRADE_APP = 32;
-    public static final int REPORT_PROBLEM_ACTIVITY = 64;
+    private static final int LOGIN_USER = 0;
+    private static final int GET_COMMAND = 1;
+    private static final int GET_CASE = 2;
+    private static final int MODEL_RESULT = 4;
+    private static final int INIT_APP = 8;
+    private static final int GET_INCOMPLETE_FORM = 16;
+    private static final int UPGRADE_APP = 32;
+    private static final int REPORT_PROBLEM_ACTIVITY = 64;
 
     /**
      * Request code for automatically validating media from home dispatch.
      * Should signal a return from CommCareVerificationActivity.
      */
-    public static final int MISSING_MEDIA_ACTIVITY=256;
-    public static final int DUMP_FORMS_ACTIVITY=512;
-    public static final int WIFI_DIRECT_ACTIVITY=1024;
-    public static final int CONNECTION_DIAGNOSTIC_ACTIVITY=2048;
-    public static final int PREFERENCES_ACTIVITY=4096;
+    private static final int MISSING_MEDIA_ACTIVITY=256;
+    private static final int DUMP_FORMS_ACTIVITY=512;
+    private static final int WIFI_DIRECT_ACTIVITY=1024;
+    private static final int CONNECTION_DIAGNOSTIC_ACTIVITY=2048;
+    private static final int PREFERENCES_ACTIVITY=4096;
 
     /**
      * Request code for launching media validator manually (Settings ->
      * Validate Media). Should signal a return from
      * CommCareVerificationActivity.
      */
-    public static final int MEDIA_VALIDATOR_ACTIVITY=8192;
+    private static final int MEDIA_VALIDATOR_ACTIVITY=8192;
 
-    public static final int DIALOG_CORRUPTED = 1;
+    private static final int DIALOG_CORRUPTED = 1;
 
     private static final int MENU_PREFERENCES = Menu.FIRST;
     private static final int MENU_UPDATE = Menu.FIRST + 1;
@@ -141,33 +141,33 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
      */
     public static final int RESULT_RESTART = 3;
 
-    public static int unsentFormNumberLimit;
-    public static int unsentFormTimeLimit;
+    private static int unsentFormNumberLimit;
+    private static int unsentFormTimeLimit;
 
-    public final static String UNSENT_FORM_NUMBER_KEY = "unsent-number-limit";
-    public final static String UNSENT_FORM_TIME_KEY = "unsent-time-limit";
+    private final static String UNSENT_FORM_NUMBER_KEY = "unsent-number-limit";
+    private final static String UNSENT_FORM_TIME_KEY = "unsent-time-limit";
 
-    public static final String SESSION_REQUEST = "ccodk_session_request";
+    private static final String SESSION_REQUEST = "ccodk_session_request";
 
-    public static final String AIRPLANE_MODE_CATEGORY = "airplane-mode";
+    private static final String AIRPLANE_MODE_CATEGORY = "airplane-mode";
     
     // The API allows for external calls. When this occurs, redispatch to their
     // activity instead of commcare.
-    boolean wasExternal = false;
+    private boolean wasExternal = false;
 
     private AndroidCommCarePlatform platform;
 
-    AlertDialog mAskOldDialog;
-    AlertDialog mAttemptFixDialog;
-    SquareButtonWithNotification startButton;
-    SquareButtonWithNotification logoutButton;
-    SquareButtonWithNotification viewIncomplete;
-    SquareButtonWithNotification syncButton;
+    private AlertDialog mAskOldDialog;
+    private AlertDialog mAttemptFixDialog;
+    private SquareButtonWithNotification startButton;
+    private SquareButtonWithNotification logoutButton;
+    private SquareButtonWithNotification viewIncomplete;
+    private SquareButtonWithNotification syncButton;
 
-    SquareButtonWithNotification viewOldForms;
-    HomeScreenAdapter adapter;
-    GridViewWithHeaderAndFooter gridView;
-    ImageView topBannerImageView;
+    private SquareButtonWithNotification viewOldForms;
+    private HomeScreenAdapter adapter;
+    private GridViewWithHeaderAndFooter gridView;
+    private ImageView topBannerImageView;
 
     /*
          * (non-Javadoc)
@@ -1092,7 +1092,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     /**
      * @return Were forms sent to the server by this method invocation?
      */
-    protected boolean checkAndStartUnsentTask(final boolean syncAfterwards) {
+    private boolean checkAndStartUnsentTask(final boolean syncAfterwards) {
         SqlStorage<FormRecord> storage = CommCareApplication._().getUserStorage(FormRecord.class);
         FormRecord[] records = StorageUtils.getUnsentRecords(storage);
 
@@ -1291,7 +1291,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         startActivityForResult(i, LOGIN_USER);
     }
 
-    public void createNoStorageDialog() {
+    private void createNoStorageDialog() {
         CommCareApplication._().triggerHandledAppExit(this, Localization.get("app.storage.missing.message"), Localization.get("app.storage.missing.title"));
     }
 
@@ -1657,7 +1657,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         } else return null;
     }
 
-    public Dialog createAskFixDialog() {
+    private Dialog createAskFixDialog() {
         //TODO: Localize this in theory, but really shift it to the upgrade/management state
         mAttemptFixDialog = new AlertDialog.Builder(this).create();
 

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -759,8 +759,10 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
         if (resultCode == RESULT_OK) {
             // Determine if the form instance is complete
-            // TODO: refactor this into a method -- PLM
-            Uri resultInstanceURI = intent.getData();
+            Uri resultInstanceURI = null;
+            if (intent != null) {
+                resultInstanceURI = intent.getData();
+            }
             if (resultInstanceURI == null) {
                 CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(StockMessages.FormEntry_Unretrievable));
                 Toast.makeText(this,

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -641,8 +641,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 if(resultCode == RESULT_CANCELED) {
                     refreshView();
                     return;
-                }
-                else if(resultCode == RESULT_OK) {
+                } else if(resultCode == RESULT_OK) {
                     int record = intent.getIntExtra("FORMRECORDS", -1);
                     if(record == -1) {
                         //Hm, what to do here?
@@ -782,7 +781,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 }
                 instanceStatus = c.getString(c.getColumnIndexOrThrow(InstanceProviderAPI.InstanceColumns.STATUS));
             } finally {
-                c.close();
+                if (c != null) {
+                    c.close();
+                }
             }
             // was the record marked complete?
             boolean complete = InstanceProviderAPI.STATUS_COMPLETE.equals(instanceStatus);

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -888,7 +888,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         mAlertDialog.setTitle(Localization.get("app.handled.error.title"));
         mAlertDialog.setMessage(errorMsg);
         mAlertDialog.setCancelable(false);
-        mAlertDialog.setButton(Localization.get("dialog.ok"), errorListener);
+        mAlertDialog.setButton(DialogInterface.BUTTON_POSITIVE, Localization.get("dialog.ok"), errorListener);
         mAlertDialog.show();
     }
 
@@ -1618,8 +1618,11 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     }
 
     private boolean isAirplaneModeOn() {
-        return Settings.System.getInt(getApplicationContext().getContentResolver(),
-                Settings.System.AIRPLANE_MODE_ON, 0) != 0;
+        if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return Settings.Global.getInt(getApplicationContext().getContentResolver(), Settings.Global.AIRPLANE_MODE_ON, 0) != 0;
+        } else {
+            return Settings.System.getInt(getApplicationContext().getContentResolver(), Settings.System.AIRPLANE_MODE_ON, 0) != 0;
+        }
     }
 
     private boolean hasP2p() {

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -287,7 +287,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                     // session expired, so re-login's probably been triggered
                     return;
                 }
-                returnToLogin(null);
+                returnToLogin();
             }
         };
         adapter.setOnClickListenerForButton(R.layout.home_disconnect_button, false, logoutButtonListener);
@@ -1138,7 +1138,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             @Override
             protected void deliverResult(CommCareHomeActivity receiver, Integer result) {
                 if (result == ProcessAndSendTask.PROGRESS_LOGGED_OUT) {
-                    returnToLogin(Localization.get("app.workflow.login.lost"));
+                    returnToLogin();
                     return;
                 }
                 receiver.refreshView();
@@ -1300,10 +1300,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     }
 
     private void returnToLogin() {
-        returnToLogin(Localization.get("app.workflow.login.lost"));
-    }
-
-    private void returnToLogin(String message) {
         Intent i = new Intent(getApplicationContext(), LoginActivity.class);
         i.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         startActivityForResult(i, LOGIN_USER);
@@ -1376,7 +1372,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         try {
             syncDetails = CommCareApplication._().getSyncDisplayParameters();
         } catch (UserStorageClosedException e) {
-            returnToLogin(Localization.get("home.logged.out"));
+            returnToLogin();
             return;
         }
 

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -334,13 +334,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
                 CommCareApplication._().clearNotifications(AIRPLANE_MODE_CATEGORY);
 
-                boolean formsSentToServer = false;
-                try {
-                    formsSentToServer = checkAndStartUnsentTask(true);
-                } catch (SessionUnavailableException e) {
-                    // Session is expired, stop using the user DB.
-                    return;
-                }
+                boolean formsSentToServer = checkAndStartUnsentTask(true);
 
                 if(!formsSentToServer) {
                     // No forms needed to be sent to the server, so let's just
@@ -1056,9 +1050,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         formEntry(formUri, r, null);
     }
 
-    private void formEntry(Uri formUri, FormRecord r, String headerTitle) throws SessionUnavailableException {
+    private void formEntry(Uri formUri, FormRecord r, String headerTitle) {
         Logger.log(AndroidLogger.TYPE_FORM_ENTRY, "Form Entry Starting|" + r.getFormNamespace());
-
 
         //TODO: This is... just terrible. Specify where external instance data should come from
         FormLoaderTask.iif = new CommCareInstanceInitializer(CommCareApplication._().getCurrentSession());
@@ -1099,7 +1092,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     /**
      * @return Were forms sent to the server by this method invocation?
      */
-    protected boolean checkAndStartUnsentTask(final boolean syncAfterwards) throws SessionUnavailableException {
+    protected boolean checkAndStartUnsentTask(final boolean syncAfterwards) {
         SqlStorage<FormRecord> storage = CommCareApplication._().getUserStorage(FormRecord.class);
         FormRecord[] records = StorageUtils.getUnsentRecords(storage);
 
@@ -1107,7 +1100,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             processAndSend(records, syncAfterwards);
             return true;
         } else {
-            //Nothing.
             return false;
         }
     }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -847,7 +847,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             Logger.log(AndroidLogger.TYPE_FORM_ENTRY, "Form Entry Cancelled");
 
             // If the form was unstarted, we want to wipe the record.
-            if (current.getStatus() == FormRecord.STATUS_UNSTARTED) {
+            if (current.getStatus().equals(FormRecord.STATUS_UNSTARTED)) {
                 // Entry was cancelled.
                 FormRecordCleanupTask.wipeRecord(this, currentState);
             }
@@ -961,7 +961,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 return;
             }
             startFormEntry(CommCareApplication._().getCurrentSessionWrapper());
-        } else if (needed == SessionFrame.STATE_COMMAND_ID) {
+        } else if (needed.equals(SessionFrame.STATE_COMMAND_ID)) {
             Intent i;
 
             if (DeveloperPreferences.isGridMenuEnabled()) {
@@ -972,7 +972,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
             i.putExtra(SessionFrame.STATE_COMMAND_ID, session.getCommand());
             startActivityForResult(i, GET_COMMAND);
-        } else if (needed == SessionFrame.STATE_DATUM_VAL) {
+        } else if (needed.equals(SessionFrame.STATE_DATUM_VAL)) {
             Intent i = new Intent(getApplicationContext(), EntitySelectActivity.class);
 
             i.putExtra(SessionFrame.STATE_COMMAND_ID, session.getCommand());
@@ -981,7 +981,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             }
 
             startActivityForResult(i, GET_CASE);
-        } else if (needed == SessionFrame.STATE_DATUM_COMPUTED) {
+        } else if (needed.equals(SessionFrame.STATE_DATUM_COMPUTED)) {
             //compute
             SessionDatum datum = session.getNeededDatum();
             XPathExpression form;
@@ -1056,7 +1056,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
      */
     @Override
     public String getActivityTitle() {
-        String userName = null;
+        String userName;
 
         try {
             userName = CommCareApplication._().getSession().getLoggedInUser().getUsername();

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -883,36 +883,23 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
 
     private void showDemoModeWarning() {
-        //TODO: How do we style this to "light"?
         AlertDialog demoModeWarning = new AlertDialog.Builder(new ContextThemeWrapper(this, android.R.style.Theme_Light)).setInverseBackgroundForced(true).create();
         demoModeWarning.setTitle(Localization.get("demo.mode.warning.title"));
+        demoModeWarning.setCancelable(false);
 
         DialogInterface.OnClickListener demoModeWarningListener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
-                switch (i) {
-                    case DialogInterface.BUTTON1:
-                        //Nothing, dismiss
-                        break;
-                }
-
+                // user has acknowledged demo warning
             }
         };
-        demoModeWarning.setCancelable(false);
-        demoModeWarning.setButton(Localization.get("demo.mode.warning.dismiss"), demoModeWarningListener);
-
-
-        String path = null;
-        try {
-            path = Localization.get("demo.warning.filepath");
-        } catch (NoLocalizedTextException nlte) {
-
-        }
-
+        demoModeWarning.setButton(android.content.DialogInterface.BUTTON_POSITIVE,
+                Localization.get("demo.mode.warning.dismiss"),
+                demoModeWarningListener);
 
         HorizontalMediaView tiav = new HorizontalMediaView(this);
-        tiav.setAVT(Localization.get("demo.mode.warning"), path, null);
-        demoModeWarning.setView(tiav);
+        tiav.setAVT(Localization.get("demo.mode.warning"), null, null);
 
+        demoModeWarning.setView(tiav);
         demoModeWarning.show();
     }
 
@@ -1513,22 +1500,14 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         }
     }
 
-    //Process and send listeners
-
     private boolean isDemoUser() {
         try {
             User u = CommCareApplication._().getSession().getLoggedInUser();
-            if (User.TYPE_DEMO.equals(u.getUserType())) {
-                return true;
-            }
+            return (User.TYPE_DEMO.equals(u.getUserType()));
         } catch (SessionUnavailableException e) {
-
+            return false;
         }
-        return false;
     }
-
-    //END - Process and Send Listeners
-
 
     /*
      * (non-Javadoc)

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -1289,17 +1289,21 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             public void onClick(DialogInterface dialog, int i) {
                 try {
                     switch (i) {
-                        case DialogInterface.BUTTON1: // yes, use old
-                            //Replace the current state from the descriptor
+                        case DialogInterface.BUTTON_POSITIVE:
+                            // use the old form instance and load the it's state from the descriptor
                             state.loadFromStateDescription(existing);
                             formEntry(platform.getFormContentUri(state.getSession().getForm()), state.getFormRecord());
                             break;
-                        case DialogInterface.BUTTON2: // no, and delete the old one
+                        case DialogInterface.BUTTON_NEGATIVE:
+                            // delete the old incomplete form
                             FormRecordCleanupTask.wipeRecord(CommCareHomeActivity.this, existing);
-                            //fallthrough to new now that old record is gone
-                        case DialogInterface.BUTTON3: // no, create new
+                            // fallthrough to new now that old record is gone
+                        case DialogInterface.BUTTON_NEUTRAL:
+                            // create a new form record and begin form entry
                             state.commitStub();
                             formEntry(platform.getFormContentUri(state.getSession().getForm()), state.getFormRecord());
+                            break;
+                        default:
                             break;
                     }
                 } catch (StorageFullException e) {
@@ -1308,9 +1312,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             }
         };
         mAskOldDialog.setCancelable(false);
-        mAskOldDialog.setButton(Localization.get("option.yes"), useOldListener);
-        mAskOldDialog.setButton2(Localization.get("app.workflow.incomplete.continue.option.delete"), useOldListener);
-        mAskOldDialog.setButton3(Localization.get("option.no"), useOldListener);
+        mAskOldDialog.setButton(DialogInterface.BUTTON_POSITIVE, Localization.get("option.yes"), useOldListener);
+        mAskOldDialog.setButton(DialogInterface.BUTTON_NEGATIVE, Localization.get("app.workflow.incomplete.continue.option.delete"), useOldListener);
+        mAskOldDialog.setButton(DialogInterface.BUTTON_NEUTRAL, Localization.get("option.no"), useOldListener);
 
         mAskOldDialog.show();
     }
@@ -1637,24 +1641,23 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         DialogInterface.OnClickListener attemptFixDialog = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {
-                    case DialogInterface.BUTTON1: // attempt repair
+                    case DialogInterface.BUTTON_POSITIVE: // attempt repair
                         Intent intent = new Intent(CommCareHomeActivity.this, RecoveryActivity.class);
                         startActivity(intent);
                         break;
 
-                    case DialogInterface.BUTTON2: // Shut down
+                    case DialogInterface.BUTTON_NEGATIVE: // Shut down
                         CommCareHomeActivity.this.finish();
                         break;
                 }
             }
         };
         mAttemptFixDialog.setCancelable(false);
-        mAttemptFixDialog.setButton("Enter Recovery Mode", attemptFixDialog);
-        mAttemptFixDialog.setButton2("Shut Down", attemptFixDialog);
+        mAttemptFixDialog.setButton(DialogInterface.BUTTON_POSITIVE, "Enter Recovery Mode", attemptFixDialog);
+        mAttemptFixDialog.setButton(DialogInterface.BUTTON_NEGATIVE, "Shut Down", attemptFixDialog);
 
         return mAttemptFixDialog;
     }
-
 
     /**
      * All methods for implementation of DialogController that are not already handled in CommCareActivity *


### PR DESCRIPTION
Linting of CommCareHomeActivity.

I did remove several throw/catches for SessionUnavailableException that weren't relevant. Those blocks are really throwing SessionStateUninitException. It should be possible to refactor the code to avoid needing to ever throw SessionStateUninitException; I will leave this to a future PR.

Easiest to review commit by commit.