### PR TITLE
Disable acra if submission url isn't valid

### DIFF
--- a/app/src/org/commcare/android/util/ACRAUtil.java
+++ b/app/src/org/commcare/android/util/ACRAUtil.java
@@ -1,11 +1,13 @@
 package org.commcare.android.util;
 
 import android.app.Application;
+import android.webkit.URLUtil;
 
 import org.acra.ACRA;
 import org.acra.ACRAConfiguration;
 import org.acra.ErrorReporter;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.activities.ReportProblemActivity;
 
 /**
  * Contains constants and methods used in ACRA reporting.
@@ -19,23 +21,41 @@ public class ACRAUtil {
     public static final String DOMAIN = "domain";
     public static final String USERNAME = "username";
 
+    private static boolean acraSetup = false;
+
     /**
-     * Add debugging value to the ACRA report bundle. Only most recent value stored for each key.
+     * Add debugging value to the ACRA report bundle. Only most recent value
+     * stored for each key.
      */
-    public static void addCustomData(String key, String value){
+    public static void addCustomData(String key, String value) {
         ErrorReporter mReporter = ACRA.getErrorReporter();
         mReporter.putCustomData(key, value);
     }
 
-    public static void initACRA(Application app){
-
-        ACRA.init(app);
-        ACRAConfiguration acraConfig = ACRA.getConfig();
-        acraConfig.setFormUriBasicAuthLogin(app.getString(R.string.acra_user));
-        acraConfig.setFormUriBasicAuthPassword(app.getString(R.string.acra_password));
-        acraConfig.setFormUri(app.getString(R.string.acra_url));
-        ACRA.setConfig(acraConfig);
-
+    public static void initACRA(Application app) {
+        String url = app.getString(R.string.acra_url);
+        if (URLUtil.isValidUrl(url)) {
+            ACRA.init(app);
+            ACRAConfiguration acraConfig = ACRA.getConfig();
+            acraConfig.setFormUriBasicAuthLogin(app.getString(R.string.acra_user));
+            acraConfig.setFormUriBasicAuthPassword(app.getString(R.string.acra_password));
+            acraConfig.setFormUri(url);
+            ACRA.setConfig(acraConfig);
+            acraSetup = true;
+        }
     }
 
+    public static void registerAppData() {
+        if (acraSetup) {
+            addCustomData(ACRAUtil.POST_URL, ReportProblemActivity.getPostURL());
+            addCustomData(ACRAUtil.VERSION, ReportProblemActivity.getVersion());
+            addCustomData(ACRAUtil.DOMAIN, ReportProblemActivity.getDomain());
+        }
+    }
+
+    public static void registerUserData() {
+        if (acraSetup) {
+            ACRAUtil.addCustomData(ACRAUtil.USERNAME, ReportProblemActivity.getUser());
+        }
+    }
 }

--- a/app/src/org/commcare/android/util/ACRAUtil.java
+++ b/app/src/org/commcare/android/util/ACRAUtil.java
@@ -21,7 +21,7 @@ public class ACRAUtil {
     public static final String DOMAIN = "domain";
     public static final String USERNAME = "username";
 
-    private static boolean acraSetup = false;
+    private static boolean isAcraConfigured = false;
 
     /**
      * Add debugging value to the ACRA report bundle. Only most recent value
@@ -41,12 +41,12 @@ public class ACRAUtil {
             acraConfig.setFormUriBasicAuthPassword(app.getString(R.string.acra_password));
             acraConfig.setFormUri(url);
             ACRA.setConfig(acraConfig);
-            acraSetup = true;
+            isAcraConfigured = true;
         }
     }
 
     public static void registerAppData() {
-        if (acraSetup) {
+        if (isAcraConfigured) {
             addCustomData(ACRAUtil.POST_URL, ReportProblemActivity.getPostURL());
             addCustomData(ACRAUtil.VERSION, ReportProblemActivity.getVersion());
             addCustomData(ACRAUtil.DOMAIN, ReportProblemActivity.getDomain());
@@ -54,7 +54,7 @@ public class ACRAUtil {
     }
 
     public static void registerUserData() {
-        if (acraSetup) {
+        if (isAcraConfigured) {
             ACRAUtil.addCustomData(ACRAUtil.USERNAME, ReportProblemActivity.getUser());
         }
     }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -31,6 +31,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.acra.ACRA;
 import org.commcare.android.adapters.HomeScreenAdapter;
 import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.UserStorageClosedException;
@@ -180,14 +181,11 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             }
         }
 
-
         if (savedInstanceState != null) {
             wasExternal = savedInstanceState.getBoolean("was_external");
         }
 
-        ACRAUtil.addCustomData(ACRAUtil.POST_URL, ReportProblemActivity.getPostURL());
-        ACRAUtil.addCustomData(ACRAUtil.VERSION, ReportProblemActivity.getVersion());
-        ACRAUtil.addCustomData(ACRAUtil.DOMAIN, ReportProblemActivity.getDomain());
+        ACRAUtil.registerAppData();
 
         setContentView(R.layout.mainnew_modern);
         adapter = new HomeScreenAdapter(this);

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -427,7 +427,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity> {
     private void done() {
         Intent i = new Intent();
         setResult(RESULT_OK, i);
-        ACRAUtil.addCustomData(ACRAUtil.USERNAME, ReportProblemActivity.getUser());
+
+        ACRAUtil.registerUserData();
+
         CommCareApplication._().clearNotifications(NOTIFICATION_MESSAGE_LOGIN);
         finish();
     }

--- a/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
@@ -45,47 +45,46 @@ public class ReportProblemActivity extends CommCareActivity<ReportProblemActivit
      * when trying to file a bug.
      */
 
-    public static String getDomain(){
+    public static String getDomain() {
         try {
             SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
             return prefs.getString(HttpRequestGenerator.USER_DOMAIN_SUFFIX, "not found");
-        } catch(Exception e){
+        } catch (Exception e) {
             return "Domain not set.";
         }
     }
 
-    public static String getPostURL(){
-        try{
+    public static String getPostURL() {
+        try {
             SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
             return prefs.getString(HttpRequestGenerator.USER_DOMAIN_SUFFIX, "not found");
-        } catch(Exception e){
+        } catch (Exception e) {
             return "PostURL not set.";
         }
     }
 
-    public static String getUser(){
-        try{
+    public static String getUser() {
+        try {
             return CommCareApplication._().getSession().getLoggedInUser().getUsername();
-        } catch(Exception e){
+        } catch (Exception e) {
             return "User not logged in.";
         }
     }
 
-    public static String getVersion(){
+    public static String getVersion() {
         try {
             return CommCareApplication._().getCurrentVersionString();
-        } catch(Exception e){
+        } catch (Exception e) {
             return "Version not set.";
         }
     }
 
-    private static String buildMessage(String userInput){
-
+    private static String buildMessage(String userInput) {
         String domain = ReportProblemActivity.getDomain();
         String postURL = ReportProblemActivity.getPostURL();
-        String version= ReportProblemActivity.getVersion();
+        String version = ReportProblemActivity.getVersion();
         String username = ReportProblemActivity.getUser();
-        
+
         return "Problem reported via CommCareODK. " +
                 "\n User: " + username +
                 "\n Domain: " + domain +
@@ -97,12 +96,12 @@ public class ReportProblemActivity extends CommCareActivity<ReportProblemActivit
                 "\n Message: " + userInput;
     }
 
-    public void sendReportEmail(String report){
+    public void sendReportEmail(String report) {
         Intent i = new Intent(Intent.ACTION_SEND);
         i.setType("message/rfc822");
-        i.putExtra(Intent.EXTRA_EMAIL  , new String[]{"commcarehq-support@dimagi.com"});
-        i.putExtra(Intent.EXTRA_TEXT, this.buildMessage(report));
-        i.putExtra(Intent.EXTRA_SUBJECT   , "Mobile Error Report");
+        i.putExtra(Intent.EXTRA_EMAIL, new String[]{"commcarehq-support@dimagi.com"});
+        i.putExtra(Intent.EXTRA_TEXT, ReportProblemActivity.buildMessage(report));
+        i.putExtra(Intent.EXTRA_SUBJECT, "Mobile Error Report");
 
         try {
             startActivity(Intent.createChooser(i, "Send mail..."));
@@ -110,5 +109,4 @@ public class ReportProblemActivity extends CommCareActivity<ReportProblemActivit
             Toast.makeText(ReportProblemActivity.this, "There are no email clients installed.", Toast.LENGTH_SHORT).show();
         }
     }
-
 }

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -102,11 +102,10 @@ import javax.crypto.SecretKey;
  */
 @ReportsCrashes(
         formUri = "https://your/cloudant/report",
-        reportType = org.acra.sender.HttpSender.Type.JSON,
-        httpMethod = org.acra.sender.HttpSender.Method.PUT,
         formUriBasicAuthLogin="your_username",
-        formUriBasicAuthPassword="your_password"
-)
+        formUriBasicAuthPassword="your_password",
+        reportType = org.acra.sender.HttpSender.Type.JSON,
+        httpMethod = org.acra.sender.HttpSender.Method.PUT)
 public class CommCareApplication extends Application {
 
 


### PR DESCRIPTION
ACRA crashes and blocks stack traces when it isn't setup correctly.

This PR disables ACRA if the submission url isn't a valid url.