### PR TITLE
Fixing black background circle in case detail drawer

### DIFF
--- a/app/res/drawable/circle_button.xml
+++ b/app/res/drawable/circle_button.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="oval">
-    <!--<solid android:color="#9F2200"/>-->
+    <solid android:color="@color/transparent"/>
     <stroke android:width="2dp"
         />
-    <!--android:color="#fff" -->
 </shape>


### PR DESCRIPTION
Small UI fix: making the case drawer detail button's background transparent.