### PR TITLE
Remove button lookup via resource id from HomeScreenAdapter

### DIFF
--- a/app/src/org/commcare/android/adapters/HomeScreenAdapter.java
+++ b/app/src/org/commcare/android/adapters/HomeScreenAdapter.java
@@ -11,7 +11,6 @@ import org.commcare.android.view.SquareButtonWithNotification;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 
 /**
@@ -19,11 +18,9 @@ import java.util.LinkedList;
  * Created by dancluna on 3/19/15.
  */
 public class HomeScreenAdapter extends BaseAdapter {
-    public static final String TAG = "HomeScrnAdpt";
+    private static final String TAG = HomeScreenAdapter.class.getSimpleName();
 
-    //region Buttons
-
-    static final int[] buttonsResources = new int[]{
+    private static final int[] buttonsResources = new int[]{
             R.layout.home_start_button,
             R.layout.home_savedforms_button,
             R.layout.home_incompleteforms_button,
@@ -31,63 +28,38 @@ public class HomeScreenAdapter extends BaseAdapter {
             R.layout.home_disconnect_button,
     };
 
-    static final HashMap<Integer, Integer> buttonsIDsToResources = new HashMap<Integer, Integer>() {{
-        put(R.id.home_start_sqbn, R.layout.home_start_button);
-        put(R.id.home_savedforms_sqbn, R.layout.home_savedforms_button);
-        put(R.id.home_sync_sqbn, R.layout.home_sync_button);
-        put(R.id.home_disconnect_sqbn, R.layout.home_disconnect_button);
-        put(R.id.home_incompleteforms_sqbn, R.layout.home_incompleteforms_button);
-    }};
+    private final SquareButtonWithNotification[] buttons =
+            new SquareButtonWithNotification[buttonsResources.length];
 
-    //endregion
+    private final boolean[] hiddenButtons = new boolean[buttonsResources.length];
 
-    //region Private variables
-
-    final SquareButtonWithNotification[] buttons = new SquareButtonWithNotification[buttonsResources.length];
-
-    private Context context;
-
-    private boolean[] hiddenButtons = new boolean[buttonsResources.length];
-    private boolean isInitialized = false;
-
-    private LinkedList<SquareButtonWithNotification> visibleButtons;
-
-    //endregion
-
-    //region Constructors
+    private final LinkedList<SquareButtonWithNotification> visibleButtons;
 
     public HomeScreenAdapter(Context c) {
-        this.context = c;
         visibleButtons = new LinkedList<SquareButtonWithNotification>();
+        LayoutInflater inflater = LayoutInflater.from(c);
         for (int i = 0; i < buttons.length; i++) {
-            if (buttons[i] != null) {
-                continue;
-            }
-            SquareButtonWithNotification button = (SquareButtonWithNotification)LayoutInflater.from(context)
-                    .inflate(buttonsResources[i], null, false);
-            buttons[i] = button;
-            Log.i(TAG, "Added button " + button + "to position " + i);
+            if (buttons[i] == null) {
+                SquareButtonWithNotification button =
+                        (SquareButtonWithNotification)inflater.inflate(buttonsResources[i], null, false);
+                buttons[i] = button;
+                Log.i(TAG, "Added button " + button + "to position " + i);
 
-            if (!hiddenButtons[i]) {
-                visibleButtons.add(button);
+                if (!hiddenButtons[i]) {
+                    visibleButtons.add(button);
+                }
             }
         }
-        isInitialized = true;
     }
-
-    //endregion
-
-    //region Public API
 
     /**
      * Sets the onClickListener for the given button
      *
      * @param resourceCode Android resource code (R.id.$button or R.layout.$button)
-     * @param lookupID     If set, will search for the button with the given R.id
      * @param listener     OnClickListener for the button
      */
-    public void setOnClickListenerForButton(int resourceCode, boolean lookupID, View.OnClickListener listener) {
-        int buttonIndex = getButtonIndex(resourceCode, lookupID);
+    public void setOnClickListenerForButton(int resourceCode, View.OnClickListener listener) {
+        int buttonIndex = getButtonIndex(resourceCode);
         SquareButtonWithNotification button = (SquareButtonWithNotification)getItem(buttonIndex);
         if (button != null) {
             if (BuildConfig.DEBUG) {
@@ -101,12 +73,12 @@ public class HomeScreenAdapter extends BaseAdapter {
         }
     }
 
-    public SquareButtonWithNotification getButton(int resourceCode, boolean lookupID) {
-        return buttons[getButtonIndex(resourceCode, lookupID)];
+    public SquareButtonWithNotification getButton(int resourceCode) {
+        return buttons[getButtonIndex(resourceCode)];
     }
 
-    public void setNotificationTextForButton(int resourceCode, boolean lookupID, String notificationText) {
-        SquareButtonWithNotification button = getButton(resourceCode, lookupID);
+    public void setNotificationTextForButton(int resourceCode, String notificationText) {
+        SquareButtonWithNotification button = getButton(resourceCode);
         if (button != null) {
             button.setNotificationText(notificationText);
             notifyDataSetChanged();
@@ -150,57 +122,32 @@ public class HomeScreenAdapter extends BaseAdapter {
      * Sets visibility for the button with the given resource code
      *
      * @param resourceCode   Android resource code (R.id.$button or R.layout.$button)
-     * @param lookupID       If set, will search for the button with the given R.id
      * @param isButtonHidden Button visibility state (true for hidden, false for visible)
      */
-    public void setButtonVisibility(int resourceCode, boolean lookupID, boolean isButtonHidden) {
-        int index = getButtonIndex(resourceCode, lookupID);
-        boolean toggled = isButtonHidden ^ hiddenButtons[index]; // checking if the button visibility was changed in this call
+    public void setButtonVisibility(int resourceCode, boolean isButtonHidden) {
+        int index = getButtonIndex(resourceCode);
+        boolean hasVisibilityChanged = isButtonHidden ^ hiddenButtons[index];
         hiddenButtons[index] = isButtonHidden;
-        if (!toggled) {
-            return;
-        } // if the visibility was not changed, we don't need to do anything
-        if (isButtonHidden) { // if the visibility was changed, we add/remove the button from the visible buttons' list
-            visibleButtons.remove(buttons[index]);
-        } else {
-            visibleButtons.add(index, buttons[index]);
-        }
-    }
-
-    //endregion
-
-    //region Private methods
-
-
-    /**
-     * Returns the index of the button with the given resource code. If lookupID is set, will search for the button with the given R.id; if not, will search for the button with the given R.layout code.
-     *
-     * @param resourceCode
-     * @param lookupID
-     * @return
-     * @throws java.lang.IllegalArgumentException If the given resourceCode is not found
-     */
-    private int getButtonIndex(int resourceCode, boolean lookupID) {
-        int code = resourceCode;
-        // if lookupID is set, we are mapping from an int in R.id to one in R.layout
-        if (lookupID) {
-            Integer layoutCode = buttonsIDsToResources.get(resourceCode);
-            if (layoutCode == null)
-                throw new IllegalArgumentException("ID code not found: " + resourceCode);
-            code = layoutCode;
-        }
-        Integer buttonIndex = null;
-        for (int i = 0; i < buttonsResources.length; i++) {
-            if (code == buttonsResources[i]) {
-                buttonIndex = i;
-                break;
+        if (hasVisibilityChanged) {
+            if (isButtonHidden) {
+                visibleButtons.remove(buttons[index]);
+            } else {
+                visibleButtons.add(index, buttons[index]);
             }
         }
-        if (buttonIndex == null) {
-            throw new IllegalArgumentException("Layout code not found: " + code);
-        }
-        return buttonIndex;
     }
 
-    //endregion
+    /**
+     * Returns the index of the button with the given resource code.
+     *
+     * @throws java.lang.IllegalArgumentException If the given resourceCode is not found
+     */
+    private int getButtonIndex(int resourceCode) {
+        for (int i = 0; i < buttonsResources.length; i++) {
+            if (resourceCode == buttonsResources[i]) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("Layout code not found: " + resourceCode);
+    }
 }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -215,9 +215,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
     private void configUi() {
         TextView version = (TextView)findViewById(R.id.str_version);
-        if (version != null) version.setText(CommCareApplication._().getCurrentVersionString());
-
-        // enter data button. expects a result.
+        if (version != null) {
+            version.setText(CommCareApplication._().getCurrentVersionString());
+        }
 
         startButton = adapter.getButton(R.layout.home_start_button);
         if (startButton == null) {
@@ -240,8 +240,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         };
         adapter.setOnClickListenerForButton(R.layout.home_start_button, startListener);
 
-
-        // enter data button. expects a result.
         viewIncomplete = adapter.getButton(R.layout.home_incompleteforms_button);
 
         if (viewIncomplete != null) {
@@ -369,7 +367,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         }
         
         if(User.TYPE_DEMO.equals(u.getUserType())) {
-            //Remind the user that there's no syncing in demo mode.0
+            //Remind the user that there's no syncing in demo mode.
             if (formsToSend) {
                 displayMessage(Localization.get("main.sync.demo.has.forms"), true, true);
             } else {
@@ -1269,7 +1267,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
     private void refreshView() {
         TextView version = (TextView)findViewById(R.id.str_version);
-        if (version == null) return;
+        if (version == null) {
+            return;
+        }
         version.setText(CommCareApplication._().getCurrentVersionString());
         boolean syncOK = true;
 
@@ -1303,9 +1303,11 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         if (!"".equals(customBannerURI)) {
             Bitmap bitmap = ViewUtil.inflateDisplayImage(this, customBannerURI);
             if (bitmap != null) {
-                if (topBannerImageView != null) topBannerImageView.setImageBitmap(bitmap);
-                else Log.i("TopBanner", "TopBanner is null!");
-
+                if (topBannerImageView != null) {
+                    topBannerImageView.setImageBitmap(bitmap);
+                } else {
+                    Log.i("TopBanner", "TopBanner is null!");
+                }
             }
         }
 
@@ -1359,7 +1361,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
         if (p != null && p.isFeatureActive(Profile.FEATURE_REVIEW)) {
             adapter.setButtonVisibility(R.layout.home_savedforms_button, false);
-
         }
 
         // set adapter to hide the buttons...
@@ -1372,7 +1373,6 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         adapter.setButtonVisibility(R.layout.home_incompleteforms_button, !showIncompleteForms);
 
         adapter.notifyDataSetChanged();
-
     }
 
     private void setSyncButtonText(Pair<Long, int[]> syncDetails, String syncTextKey) {
@@ -1396,8 +1396,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
         } else {
             Log.i("syncDetails", "SyncDetails has no count");
-            if (viewIncomplete != null)
+            if (viewIncomplete != null) {
                 viewIncomplete.setText(this.localize("home.forms.incomplete"));
+            }
         }
     }
 

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -219,7 +219,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
         // enter data button. expects a result.
 
-        startButton = adapter.getButton(R.layout.home_start_button, false);
+        startButton = adapter.getButton(R.layout.home_start_button);
         if (startButton == null) {
             Log.d("buttons", "startButton is null! Crashing!");
         }
@@ -238,11 +238,11 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 startActivityForResult(i, GET_COMMAND);
             }
         };
-        adapter.setOnClickListenerForButton(R.layout.home_start_button, false, startListener);
+        adapter.setOnClickListenerForButton(R.layout.home_start_button, startListener);
 
 
         // enter data button. expects a result.
-        viewIncomplete = adapter.getButton(R.layout.home_incompleteforms_button, false);
+        viewIncomplete = adapter.getButton(R.layout.home_incompleteforms_button);
 
         if (viewIncomplete != null) {
             setIncompleteFormsText(CommCareApplication._().getSyncDisplayParameters());
@@ -252,10 +252,10 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 goToFormArchive(true);
             }
         };
-        adapter.setOnClickListenerForButton(R.layout.home_incompleteforms_button, false, viewIncompleteListener);
+        adapter.setOnClickListenerForButton(R.layout.home_incompleteforms_button, viewIncompleteListener);
 
 
-        logoutButton = adapter.getButton(R.layout.home_disconnect_button, false);
+        logoutButton = adapter.getButton(R.layout.home_disconnect_button);
         if (logoutButton == null) {
             Log.d("buttons", "logoutButton is null! Crashing!");
         }
@@ -274,7 +274,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 returnToLogin();
             }
         };
-        adapter.setOnClickListenerForButton(R.layout.home_disconnect_button, false, logoutButtonListener);
+        adapter.setOnClickListenerForButton(R.layout.home_disconnect_button, logoutButtonListener);
         if (logoutButton != null) {
             logoutButton.setNotificationText(getActivityTitle());
             adapter.notifyDataSetChanged();
@@ -286,7 +286,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             formGroupLabel.setText(Localization.get("home.forms"));
         }
 
-        SquareButtonWithNotification viewOldForms = adapter.getButton(R.layout.home_savedforms_button, false);
+        SquareButtonWithNotification viewOldForms = adapter.getButton(R.layout.home_savedforms_button);
         if (viewOldForms == null) {
             Log.d("buttons", "viewOldForms is null! Crashing!");
         }
@@ -299,10 +299,10 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 goToFormArchive(false);
             }
         };
-        adapter.setOnClickListenerForButton(R.layout.home_savedforms_button, false, viewOldFormsListener);
+        adapter.setOnClickListenerForButton(R.layout.home_savedforms_button, viewOldFormsListener);
 
 
-        syncButton = adapter.getButton(R.layout.home_sync_button, false);
+        syncButton = adapter.getButton(R.layout.home_sync_button);
         if (syncButton == null) {
             Log.d("buttons", "syncButton is null! Crashing!");
         }
@@ -333,7 +333,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 }
             }
         };
-        adapter.setOnClickListenerForButton(R.layout.home_sync_button, false, syncButtonListener);
+        adapter.setOnClickListenerForButton(R.layout.home_sync_button, syncButtonListener);
 
         rebuildMenus();
     }
@@ -1264,7 +1264,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             Toast.makeText(this, message, Toast.LENGTH_LONG).show();
         }
 
-        adapter.setNotificationTextForButton(R.layout.home_sync_button, false, message);
+        adapter.setNotificationTextForButton(R.layout.home_sync_button, message);
     }
 
     private void refreshView() {
@@ -1358,7 +1358,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         //Make sure that the review button is properly enabled.
         Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
         if (p != null && p.isFeatureActive(Profile.FEATURE_REVIEW)) {
-            adapter.setButtonVisibility(R.layout.home_savedforms_button, false, false);
+            adapter.setButtonVisibility(R.layout.home_savedforms_button, false);
 
         }
 
@@ -1368,8 +1368,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
 
         Log.i("ShowForms", "ShowSavedForms: " + showSavedForms + " | ShowIncompleteForms: " + showIncompleteForms);
 
-        adapter.setButtonVisibility(R.layout.home_savedforms_button, false, !showSavedForms);
-        adapter.setButtonVisibility(R.layout.home_incompleteforms_button, false, !showIncompleteForms);
+        adapter.setButtonVisibility(R.layout.home_savedforms_button, !showSavedForms);
+        adapter.setButtonVisibility(R.layout.home_incompleteforms_button, !showIncompleteForms);
 
         adapter.notifyDataSetChanged();
 


### PR DESCRIPTION
@dcluna, while reviewing your UI refactor I asked you about the code in HomeScreenAdapter that did resource lookup based on resource id. I forgot what your reasoning was, so maybe this PR is moot. 

Regardless, I noticed that the lookupID parameter is always false, so I removed all the code that depends on it being set to true. If it was in fact being used we can close this PR.