### PR TITLE
Removed unused error logic from FormEntryActivity

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -176,10 +176,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     // Identifies the gp of the form used to launch form entry
     public static final String KEY_FORMPATH = "formpath";
     public static final String KEY_INSTANCEDESTINATION = "instancedestination";
-    public static final String KEY_INSTANCES = "instances";
-    public static final String KEY_SUCCESS = "success";
-    public static final String KEY_ERROR = "error";
-    
+
     public static final String KEY_FORM_CONTENT_URI = "form_content_uri";
     public static final String KEY_INSTANCE_CONTENT_URI = "instance_content_uri";
     
@@ -231,8 +228,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
     private AlertDialog mRepeatDialog;
     private AlertDialog mAlertDialog;
     private ProgressDialog mProgressDialog;
-    private String mErrorMessage;
-    
+
     private boolean mIncompleteEnabled = true;
 
     // used to limit forward/backward swipes to one per question
@@ -325,9 +321,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
             if (savedInstanceState.containsKey(NEWFORM)) {
                 newForm = savedInstanceState.getBoolean(NEWFORM, true);
             }
-            if (savedInstanceState.containsKey(KEY_ERROR)) {
-                mErrorMessage = savedInstanceState.getString(KEY_ERROR);
-            }
             if (savedInstanceState.containsKey(KEY_FORM_CONTENT_URI)) {
                 formProviderContentURI = Uri.parse(savedInstanceState.getString(KEY_FORM_CONTENT_URI));
             }
@@ -360,13 +353,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 hasSaved = savedInstanceState.getBoolean(KEY_HAS_SAVED);
             }
            
-        }
-
-        // If a parse error message is showing then nothing else is loaded
-        // Dialogs mid form just disappear on rotation.
-        if (mErrorMessage != null) {
-            CommCareActivity.createErrorDialog(this, mErrorMessage, EXIT);
-            return;
         }
 
         // Check to see if this is a screen flip or a new form load.
@@ -635,7 +621,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         super.onSaveInstanceState(outState);
         outState.putString(KEY_FORMPATH, mFormPath);
         outState.putBoolean(NEWFORM, false);
-        outState.putString(KEY_ERROR, mErrorMessage);
         outState.putString(KEY_FORM_CONTENT_URI, formProviderContentURI.toString());
         outState.putString(KEY_INSTANCE_CONTENT_URI, instanceProviderContentURI.toString());
         outState.putString(KEY_INSTANCEDESTINATION, mInstanceDestination);
@@ -2527,10 +2512,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         }
         if (mSaveToDiskTask != null) {
             mSaveToDiskTask.setFormSavedListener(this);
-        }
-        if (mErrorMessage != null && (mAlertDialog != null && !mAlertDialog.isShowing())) {
-            CommCareActivity.createErrorDialog(this, mErrorMessage, EXIT);
-            return;
         }
 
         //csims@dimagi.com - 22/08/2012 - For release only, fix immediately.


### PR DESCRIPTION
Noticed some logic surrounding mErrorMessage in FormEntryActivity, which was never being written (other than in onSaveInstanceState)