### PR TITLE
Fixing bug where rows in case list with no icon had a white background

### DIFF
--- a/app/src/org/commcare/android/view/EntityView.java
+++ b/app/src/org/commcare/android/view/EntityView.java
@@ -279,7 +279,7 @@ public class EntityView extends LinearLayout {
             }
         }
         else {
-            iv.setImageDrawable(getResources().getDrawable(R.color.white));
+            iv.setImageDrawable(getResources().getDrawable(R.color.transparent));
         }
     }
     


### PR DESCRIPTION
When rows in case list have no icons, they currently have a white background - the correct behavior is to show nothing (transparent background).