### PR TITLE
CommCareActivity.onStop shouldn't be public or even there

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -325,11 +325,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public void cancelCurrentTask() {
         stateHolder.cancelTask();
     }
-    
-    @Override
-    public void onStop() {
-        super.onStop();
-    }
 
     protected void saveLastQueryString(String key) {
         SharedPreferences settings = getSharedPreferences(CommCarePreferences.ACTIONBAR_PREFS, 0);

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -64,9 +64,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     
     private final static String KEY_DIALOG_FRAG = "dialog_fragment";
 
-    protected final static int DIALOG_PROGRESS = 32;
-    protected final static String DIALOG_TEXT = "cca_dialog_text";
-
     StateFragment stateHolder;
 
     //fields for implementing task transitions for CommCareTaskConnector

--- a/app/src/org/commcare/dalvik/activities/EntityMapActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityMapActivity.java
@@ -269,7 +269,6 @@ public class EntityMapActivity extends MapActivity {
         return new CommCareInstanceInitializer(session);
     }
 
-
     @Override
     protected void onStop() {
         super.onStop();

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -467,7 +467,7 @@ public class EntitySelectActivity extends CommCareActivity implements TextWatche
     }
     
     @Override
-    public void onStop() {
+    protected void onStop() {
         super.onStop();
         stopTimer();
         saveLastQueryString(this.TAG + "-" + KEY_LAST_QUERY_STRING);

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -195,7 +195,7 @@ public class FormRecordListActivity extends CommCareActivity<FormRecordListActiv
     }
 
     @Override
-    public void onStop() {
+    protected void onStop() {
         super.onStop();
 
         saveLastQueryString(this.TAG + "-" + KEY_LAST_QUERY_STRING);


### PR DESCRIPTION
CommCareActivity.onStop overrides the protected onStop method in Activity, making it public, which is an accepted pattern. That said, there doesn't seem to be a reason for doing this (at least in the current state of the code base). Once the public modifier is changed to protected the overriding method just calls super, so we can safely remove it.