### PR TITLE
Rename ResourceEngineListener.updateProgress to not conflict w/ DialogController.updateProgress

### DIFF
--- a/app/src/org/commcare/android/tasks/ResourceEngineListener.java
+++ b/app/src/org/commcare/android/tasks/ResourceEngineListener.java
@@ -8,6 +8,6 @@ public interface ResourceEngineListener {
     public void failMissingResource(UnresolvedResourceException ure, ResourceEngineOutcomes statusmissing);
     public void failBadReqs(int code, String vReq, String vAvail, boolean majorIsProblem);
     public void failUnknown(ResourceEngineOutcomes statusfailunknown);
-    public void updateProgress(int done, int pending, int phase);
+    public void updateResourceProgress(int done, int pending, int phase);
     public void failWithNotification(ResourceEngineOutcomes statusfailstate);
 }

--- a/app/src/org/commcare/android/tasks/ResourceEngineListener.java
+++ b/app/src/org/commcare/android/tasks/ResourceEngineListener.java
@@ -4,10 +4,10 @@ import org.commcare.android.tasks.ResourceEngineTask.ResourceEngineOutcomes;
 import org.commcare.resources.model.UnresolvedResourceException;
 
 public interface ResourceEngineListener {
-    public void reportSuccess(boolean b);
-    public void failMissingResource(UnresolvedResourceException ure, ResourceEngineOutcomes statusmissing);
-    public void failBadReqs(int code, String vReq, String vAvail, boolean majorIsProblem);
-    public void failUnknown(ResourceEngineOutcomes statusfailunknown);
-    public void updateResourceProgress(int done, int pending, int phase);
-    public void failWithNotification(ResourceEngineOutcomes statusfailstate);
+    void reportSuccess(boolean b);
+    void failMissingResource(UnresolvedResourceException ure, ResourceEngineOutcomes statusmissing);
+    void failBadReqs(int code, String vReq, String vAvail, boolean majorIsProblem);
+    void failUnknown(ResourceEngineOutcomes statusfailunknown);
+    void updateResourceProgress(int done, int pending, int phase);
+    void failWithNotification(ResourceEngineOutcomes statusfailstate);
 }

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -469,7 +469,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 @Override
                 protected void deliverUpdate(CommCareSetupActivity receiver,
                                              int[]... update) {
-                    receiver.updateProgress(update[0][0], update[0][1], update[0][2]);
+                    receiver.updateResourceProgress(update[0][0], update[0][1], update[0][2]);
                 }
 
                 @Override
@@ -586,7 +586,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     }
     
     @Override
-    public void updateProgress(int done, int total, int phase) {
+    public void updateResourceProgress(int done, int total, int phase) {
         if(inUpgradeMode) {       
             if (phase == ResourceEngineTask.PHASE_DOWNLOAD) {
                 updateProgress(Localization.get("updates.found", new String[] {""+done,""+total}), DIALOG_INSTALL_PROGRESS);


### PR DESCRIPTION
I kept confusing the very similar updateProgress interfaces found in ResourceEngineListener and DialogController.

This PR renames ResourceEngineListener one to updateResourceProgress