### PR TITLE
Newui/show CommCare version as Snackbar

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -70,6 +70,8 @@ home.menu.formdump=Manage SD
 home.menu.wifi.direct=Wifi Direct
 home.menu.connection.diagnostic=Connection Test
 home.menu.saved.forms=Saved Forms
+home.menu.version=CommCare Version
+home.version.copy=Copy
 
 install.version.mismatch=The application requires CommCare version ${0}. You are running ${1}.
 install.major.mismatch=Please uninstall your CommCare ODK Application from the phone Settings Menu, navigate to the marketplace, and install the proper version.

--- a/app/res/values-v11/themes.xml
+++ b/app/res/values-v11/themes.xml
@@ -3,7 +3,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
         <item name="android:colorBackground">@color/cc_neutral_bg</item>
         <item name="entity_detail_even_row_color">@color/translucent_grey_light</item>
@@ -15,7 +15,9 @@
         <item name="drawer_pulldown_even_row_color">@color/cc_brand_bg</item>
         <item name="drawer_pulldown_odd_row_color">@color/drawer_pulldown_odd_row_color</item>
         <item name="android:actionBarStyle">@style/ActionBar</item>
+        <item name="actionBarStyle">@style/ActionBar</item>
         <item name="android:actionOverflowButtonStyle">@style/OverflowButton</item>
+        <item name="actionOverflowButtonStyle">@style/OverflowButton</item>
         <item name="android:textViewStyle">@style/AppTheme.Widget.TextView</item>
         <item name="android:textSize">@dimen/text_medium</item>
         <item name="menu_tile_title_text_color">@color/cc_brand_bg</item>
@@ -30,12 +32,19 @@
         <item name="android:textSize">@dimen/text_medium</item>
     </style>
 
-    <style name="ActionBar" parent="android:Widget.Holo.Light.ActionBar">
+    <style name="ActionBar" parent="Widget.AppCompat.ActionBar">
         <item name="android:background">@color/cc_brand_color</item>
         <item name="android:titleTextStyle">@style/ActionBar.TitleTextStyle</item>
         <item name="android:subtitleTextStyle">@style/ActionBarSubtitleTextStyle</item>
-        <item name="android:logo">@drawable/actionbar_modern_spacing</item>
+        <item name="android:icon">@drawable/actionbar_modern_spacing</item>
         <item name="android:actionButtonStyle">@style/ActionButtonStyle</item>
+        <item name="background">@color/cc_brand_color</item>
+        <item name="titleTextStyle">@style/ActionBar.TitleTextStyle</item>
+        <item name="subtitleTextStyle">@style/ActionBarSubtitleTextStyle</item>
+        <item name="icon">@drawable/actionbar_modern_spacing</item>
+        <item name="actionButtonStyle">@style/ActionButtonStyle</item>
+        <item name="android:displayOptions">showHome|showTitle</item>
+        <item name="displayOptions">showHome|showTitle</item>
     </style>
 
     <style name="ActionBar.TitleTextStyle">

--- a/app/res/values-v11/themes.xml
+++ b/app/res/values-v11/themes.xml
@@ -22,6 +22,7 @@
         <item name="android:textSize">@dimen/text_medium</item>
         <item name="menu_tile_title_text_color">@color/cc_brand_bg</item>
         <item name="entity_select_title_text_color">@color/cc_light_warm_accent_text</item>
+        <item name="version_snackbar_text_color">@color/cc_brand_bg</item>
     </style>
     
         <style name="radio_button_modern" parent="@android:style/Widget.CompoundButton.RadioButton">
@@ -87,7 +88,4 @@
         <item name="android:layout_marginLeft">@dimen/title_round_bleed</item>
         <item name="android:paddingLeft">@dimen/title_paddingLeft</item>
 	</style>
-    
-    
-
 </resources>

--- a/app/res/values-v14/themes.xml
+++ b/app/res/values-v14/themes.xml
@@ -25,6 +25,7 @@
         <item name="entity_select_title_text_color">@color/cc_light_warm_accent_text</item>
         <item name="android:listViewStyle">@style/fading_edge</item>
         <item name="android:scrollViewStyle">@style/fading_edge</item>
+        <item name="version_snackbar_text_color">@color/cc_brand_bg</item>
     </style>
 
     <style name="radio_button_modern" parent="@android:style/Widget.CompoundButton.RadioButton">

--- a/app/res/values-v14/themes.xml
+++ b/app/res/values-v14/themes.xml
@@ -4,7 +4,7 @@
         Base application theme for API 14+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 14 theme customizations can go here. -->
         <item name="android:colorBackground">@color/cc_neutral_bg</item>
         <item name="entity_detail_even_row_color">@color/translucent_grey_light</item>
@@ -12,7 +12,9 @@
         <item name="entity_view_header_background_color">@color/cc_brand_text</item>
         <item name="entity_view_header_text_color">@color/cc_core_bg</item>
         <item name="android:actionBarStyle">@style/ActionBar</item>
+        <item name="actionBarStyle">@style/ActionBar</item>
         <item name="android:actionOverflowButtonStyle">@style/OverflowButton</item>
+        <item name="actionOverflowButtonStyle">@style/OverflowButton</item>
         <item name="searchbox_action_bar_color">@color/white</item>
         <item name="drawer_pulldown_text_color">@color/white</item>
         <item name="drawer_pulldown_even_row_color">@color/cc_brand_bg</item>
@@ -33,12 +35,19 @@
         <item name="android:textSize">@dimen/text_medium</item>
     </style>
 
-    <style name="ActionBar" parent="android:Widget.Holo.Light.ActionBar">
+    <style name="ActionBar" parent="Widget.AppCompat.ActionBar">
         <item name="android:background">@color/cc_brand_color</item>
         <item name="android:titleTextStyle">@style/ActionBar.TitleTextStyle</item>
         <item name="android:subtitleTextStyle">@style/ActionBarSubtitleTextStyle</item>
-        <item name="android:logo">@drawable/actionbar_modern_spacing</item>
+        <item name="android:icon">@drawable/actionbar_modern_spacing</item>
         <item name="android:actionButtonStyle">@style/ActionButtonStyle</item>
+        <item name="background">@color/cc_brand_color</item>
+        <item name="titleTextStyle">@style/ActionBar.TitleTextStyle</item>
+        <item name="subtitleTextStyle">@style/ActionBarSubtitleTextStyle</item>
+        <item name="icon">@drawable/actionbar_modern_spacing</item>
+        <item name="actionButtonStyle">@style/ActionButtonStyle</item>
+        <item name="android:displayOptions">showHome|showTitle</item>
+        <item name="displayOptions">showHome|showTitle</item>
     </style>
 
     <style name="ActionBar.TitleTextStyle">
@@ -50,12 +59,12 @@
         <item name="android:textColor">@color/white</item>
     </style>
 
-    <style name="ActionButtonStyle" parent="@android:style/Widget.Holo.Light.ActionButton">
+    <style name="ActionButtonStyle" parent="Widget.AppCompat.Light.ActionButton">
         <item name="android:minWidth">8dp</item>
     </style>
 
     <!-- TODO: add new Settings icon here (needs asset file first) -->
-    <style name="OverflowButton" parent="android:Widget.Holo.Light.ActionButton.Overflow">
+    <style name="OverflowButton" parent="Widget.AppCompat.Light.ActionButton.Overflow">
         <item name="android:src">@drawable/ic_action_overflow</item>
     </style>
 

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -13,6 +13,7 @@
     <attr name="drawer_pulldown_odd_row_color" format="reference"></attr>
     <attr name="menu_tile_title_text_color" format="reference"></attr>
     <attr name="entity_select_title_text_color" format="reference"></attr>
+    <attr name="version_snackbar_text_color" format="reference"></attr>
     <declare-styleable name="SquareButtonWithText">
         <attr name="backgroundcolor" format="reference|color" />
         <attr name="sqb_subtitle" format="string" />

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -15,7 +15,7 @@
     <attr name="entity_select_title_text_color" format="reference"></attr>
     <declare-styleable name="SquareButtonWithText">
         <attr name="backgroundcolor" format="reference|color" />
-        <attr name="subtitle" format="string" />
+        <attr name="sqb_subtitle" format="string" />
         <attr name="img" format="reference" />
         <attr name="colorText" format="reference|color" />
     </declare-styleable>

--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -14,6 +14,7 @@
         <item name="drawer_pulldown_odd_row_color">@color/drawer_pulldown_odd_row_color</item>
         <item name="menu_tile_title_text_color">@color/cc_brand_bg</item>
         <item name="entity_select_title_text_color">@color/cc_light_warm_accent_text</item>
+        <item name="version_snackbar_text_color">@color/cc_brand_bg</item>
     </style>
 
     <style name="fading_edge" parent="android:Widget.ListView">

--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
-    <style name="AppBaseTheme" parent="android:Theme.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
         <item name="android:colorBackground">@color/cc_neutral_bg</item>
         <item name="android:progressBarStyleHorizontal">@drawable/progressbar_modern</item>

--- a/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
@@ -104,6 +104,8 @@ public class BreadcrumbBarFragment extends Fragment {
             title = getBestTitle(activity);
         }
 
+        // with the new AppCompatActivity, the action bar can be null, in which case we just return
+        if(actionBar == null) { return; }
         boolean showNav = true;
         if(activity instanceof CommCareActivity) {
             showNav = ((CommCareActivity)activity).isBackEnabled();

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -1,5 +1,6 @@
 package org.commcare.android.framework;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -9,6 +10,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
 import android.text.Spannable;
 import android.util.DisplayMetrics;
 import android.util.Pair;
@@ -58,7 +60,7 @@ import java.lang.reflect.Field;
  * 
  * @author ctsims
  */
-public abstract class CommCareActivity<R> extends FragmentActivity
+public abstract class CommCareActivity<R> extends AppCompatActivity
         implements CommCareTaskConnector<R>, DialogController, OnGestureListener {
     private static final String TAG = CommCareActivity.class.getSimpleName();
     
@@ -101,7 +103,11 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             loadFields();
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            getActionBar().setDisplayShowCustomEnabled(true);
+            // the actionBar can be null when using the AppCompatActivity as a CommCareActivity superclass
+            ActionBar actionBar = getActionBar();
+            if(actionBar != null) {
+                actionBar.setDisplayShowCustomEnabled(true);
+            }
 
             // Add breadcrumb bar
             BreadcrumbBarFragment bar = (BreadcrumbBarFragment) fm.findFragmentByTag("breadcrumbs");

--- a/app/src/org/commcare/android/view/SquareButtonWithText.java
+++ b/app/src/org/commcare/android/view/SquareButtonWithText.java
@@ -59,7 +59,7 @@ public class SquareButtonWithText extends RelativeLayout {
 
         backgroundImg = typedArray.getDrawable(R.styleable.SquareButtonWithText_img);
         backgroundColor = getResources().getColor(typedArray.getResourceId(R.styleable.SquareButtonWithText_backgroundcolor, android.R.color.transparent));
-        text = typedArray.getString(R.styleable.SquareButtonWithText_subtitle);
+        text = typedArray.getString(R.styleable.SquareButtonWithText_sqb_subtitle);
         colorButtonText = typedArray.getResourceId(R.styleable.SquareButtonWithText_colorText, colorButtonText);
 
         typedArray.recycle();

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -17,6 +17,8 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.support.design.widget.Snackbar;
+import android.content.ClipboardManager;
 import android.text.Spannable;
 import android.text.format.DateUtils;
 import android.util.Base64;
@@ -135,6 +137,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
     private static final int MENU_WIFI_DIRECT = Menu.FIRST + 6;
     private static final int MENU_CONNECTION_DIAGNOSTIC = Menu.FIRST + 7;
     private static final int MENU_SAVED_FORMS = Menu.FIRST + 8;
+    private static final int MENU_ABOUT = Menu.FIRST + 9;
 
     /**
      * Restart is a special CommCare return code which means that the session was invalidated in the
@@ -1433,6 +1436,8 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 android.R.drawable.ic_menu_upload);
         menu.add(0, MENU_SAVED_FORMS, 0, Localization.get("home.menu.saved.forms")).setIcon(
                 R.drawable.notebook_full);
+        menu.add(0, MENU_ABOUT, 0, Localization.get("home.menu.version")).setIcon(
+                R.drawable.icon_addfolder_lightcool);
         return true;
     }
 
@@ -1451,6 +1456,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             menu.findItem(MENU_WIFI_DIRECT).setVisible(enableMenus && hasP2p());
             menu.findItem(MENU_CONNECTION_DIAGNOSTIC).setVisible(enableMenus);
             menu.findItem(MENU_SAVED_FORMS).setVisible(enableMenus);
+            menu.findItem(MENU_ABOUT).setVisible(enableMenus);
         } catch (SessionUnavailableException sue) {
             //Nothing
         }
@@ -1498,6 +1504,19 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 return true;
             case MENU_SAVED_FORMS:
                 goToFormArchive(false);
+                return true;
+            case MENU_ABOUT:
+                final String commcareVersion = CommCareApplication._().getCurrentVersionString();
+                Snackbar.make(findViewById(android.R.id.content), commcareVersion, Snackbar.LENGTH_LONG)
+                        .setAction(Localization.get("home.version.copy"), new OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+                                clipboard.setText(commcareVersion);
+                            }
+                        })
+                        .setActionTextColor(getResources().getColor(R.color.cc_brand_bg))
+                        .show();
                 return true;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -55,6 +55,7 @@ import org.commcare.android.tasks.SendTask;
 import org.commcare.android.tasks.WipeTask;
 import org.commcare.android.util.ACRAUtil;
 import org.commcare.android.util.AndroidCommCarePlatform;
+import org.commcare.android.util.AndroidUtil;
 import org.commcare.android.util.CommCareInstanceInitializer;
 import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.SessionUnavailableException;
@@ -1507,6 +1508,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                 return true;
             case MENU_ABOUT:
                 final String commcareVersion = CommCareApplication._().getCurrentVersionString();
+                final int commcareColor = AndroidUtil.getThemeColorIDs(this, new int[] {R.attr.version_snackbar_text_color})[0];
                 Snackbar.make(findViewById(android.R.id.content), commcareVersion, Snackbar.LENGTH_LONG)
                         .setAction(Localization.get("home.version.copy"), new OnClickListener() {
                             @Override
@@ -1515,7 +1517,7 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
                                 clipboard.setText(commcareVersion);
                             }
                         })
-                        .setActionTextColor(getResources().getColor(R.color.cc_brand_bg))
+                        .setActionTextColor(commcareColor)
                         .show();
                 return true;
         }

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile project(':libraries:mapballoons')
     compile fileTree(dir: 'app/libs', include: '*.jar')
     compile 'in.srain.cube:grid-view-with-header-footer:1.0.12'
-    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:design:22.2.0' // for snackbar support
 
     debugCompile 'com.facebook.stetho:stetho:1.1.1'
 }


### PR DESCRIPTION
Shows the CommCare version as a Snackbar element with an optional button to copy the version to the clipboard.

CommCareActivity now extends AppCompatActivity, and this may cause some unexpected bugs. If this is not acceptable, I'll try another approach.