### PR TITLE
Using compatibility library to avoid crashes in pre-HoneycombM2 devices

### DIFF
--- a/app/src/org/commcare/android/view/GridEntityView.java
+++ b/app/src/org/commcare/android/view/GridEntityView.java
@@ -3,19 +3,6 @@
  */
 package org.commcare.android.view;
 
-import org.commcare.android.models.AsyncEntity;
-import org.commcare.android.models.Entity;
-import org.commcare.android.util.CachingAsyncImageLoader;
-import org.commcare.android.util.MarkupUtil;
-import org.commcare.dalvik.R;
-import org.commcare.suite.model.Detail;
-import org.commcare.util.GridCoordinate;
-import org.commcare.util.GridStyle;
-import org.javarosa.core.services.Logger;
-import org.javarosa.xpath.XPathUnhandledException;
-import org.odk.collect.android.views.media.AudioButton;
-import org.odk.collect.android.views.media.ViewId;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
@@ -33,6 +20,19 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
 import android.widget.TextView;
+
+import org.commcare.android.models.AsyncEntity;
+import org.commcare.android.models.Entity;
+import org.commcare.android.util.CachingAsyncImageLoader;
+import org.commcare.android.util.MarkupUtil;
+import org.commcare.dalvik.R;
+import org.commcare.suite.model.Detail;
+import org.commcare.util.GridCoordinate;
+import org.commcare.util.GridStyle;
+import org.javarosa.core.services.Logger;
+import org.javarosa.xpath.XPathUnhandledException;
+import org.odk.collect.android.views.media.AudioButton;
+import org.odk.collect.android.views.media.ViewId;
 
 import java.util.Arrays;
 
@@ -141,10 +141,9 @@ public class GridEntityView extends GridLayout {
 		this.mFuzzySearchEnabled = fuzzySearchEnabled;
 		
 		//setup all the various dimensions we need
-		Point size = new Point();
 		Display display = ((Activity)context).getWindowManager().getDefaultDisplay();
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2)
-		{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2) {
+			Point size = new Point();
 			display.getSize(size);
 
 			screenWidth = size.x;

--- a/app/src/org/commcare/android/view/GridEntityView.java
+++ b/app/src/org/commcare/android/view/GridEntityView.java
@@ -16,21 +16,22 @@ import org.javarosa.xpath.XPathUnhandledException;
 import org.odk.collect.android.views.media.AudioButton;
 import org.odk.collect.android.views.media.ViewId;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Point;
+import android.os.Build;
+import android.support.v7.widget.GridLayout;
+import android.support.v7.widget.Space;
 import android.text.Spannable;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.view.Display;
 import android.view.Gravity;
 import android.view.View;
-import android.widget.GridLayout;
 import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
-import android.widget.Space;
 import android.widget.TextView;
 
 import java.util.Arrays;
@@ -42,7 +43,6 @@ import java.util.Arrays;
  * Significant axis of configuration are NUMBER_ROWS, NUMBER_COLUMNS, AND CELL_HEIGHT_DIVISOR defined below
  *
  */
-@SuppressLint("NewApi")
 public class GridEntityView extends GridLayout {
 
 	private String[] forms;
@@ -142,11 +142,18 @@ public class GridEntityView extends GridLayout {
 		
 		//setup all the various dimensions we need
 		Point size = new Point();
-		((Activity)context).getWindowManager().getDefaultDisplay().getSize(size);
-		
-		screenWidth = size.x;
-		screenHeight = size.y;
-		
+		Display display = ((Activity)context).getWindowManager().getDefaultDisplay();
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2)
+		{
+			display.getSize(size);
+
+			screenWidth = size.x;
+			screenHeight = size.y;
+		} else {
+			screenWidth = display.getWidth();
+			screenHeight = display.getHeight();
+		}
+
 		// If screen is rotated, use width for cell height measurement
 		if(getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE){
 		    //TODO: call to inAwesomeMode was not working for me. What's the best method to determine this?

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile fileTree(dir: 'app/libs', include: '*.jar')
     compile 'in.srain.cube:grid-view-with-header-footer:1.0.12'
     compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:gridlayout-v7:21.0.0'
 
     debugCompile 'com.facebook.stetho:stetho:1.1.1'
 }


### PR DESCRIPTION
GridEntityView was extending the stock GridLayout, thus crashing in old devices. This PR fixes that.