### PR TITLE
Make session aware class extend CommCareActivity

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -59,7 +59,7 @@ import java.lang.reflect.Field;
  * 
  * @author ctsims
  */
-public abstract class CommCareActivity<R> extends SessionAwareFragmentActivity
+public abstract class CommCareActivity<R> extends FragmentActivity
         implements CommCareTaskConnector<R>, DialogController, OnGestureListener {
     private static final String TAG = CommCareActivity.class.getSimpleName();
     

--- a/app/src/org/commcare/android/framework/SessionAwareCommCareActivity.java
+++ b/app/src/org/commcare/android/framework/SessionAwareCommCareActivity.java
@@ -8,7 +8,7 @@ import android.support.v4.app.FragmentActivity;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public abstract class SessionAwareFragmentActivity extends FragmentActivity {
+public abstract class SessionAwareCommCareActivity<R> extends CommCareActivity<R> {
     @Override
     protected void onResume() {
         super.onResume();

--- a/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
@@ -5,8 +5,8 @@ import java.util.Vector;
 
 import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.models.notifications.NotificationMessageFactory;
@@ -38,7 +38,7 @@ import android.widget.TextView;
  */
 
 @ManagedUi(R.layout.screen_form_dump)
-public class CommCareFormDumpActivity extends CommCareActivity<CommCareFormDumpActivity> {
+public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommCareFormDumpActivity> {
     private static final String TAG = CommCareFormDumpActivity.class.getSimpleName();
      
     @UiElement(value = R.id.screen_bulk_form_prompt, locale="bulk.form.prompt")

--- a/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
@@ -26,12 +26,12 @@ import android.widget.Toast;
 
 import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.DeviceDetailFragment;
 import org.commcare.android.framework.DeviceListFragment;
 import org.commcare.android.framework.DeviceListFragment.DeviceActionListener;
 import org.commcare.android.framework.FileServerFragment;
 import org.commcare.android.framework.FileServerFragment.FileServerListener;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.WiFiDirectManagementFragment;
 import org.commcare.android.framework.WiFiDirectManagementFragment.WifiDirectManagerListener;
 import org.commcare.android.tasks.FormTransferTask;
@@ -62,7 +62,7 @@ import java.util.Vector;
  * WiFi state related events.
  */
 @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-public class CommCareWiFiDirectActivity extends CommCareActivity<CommCareWiFiDirectActivity> implements DeviceActionListener, FileServerListener, WifiDirectManagerListener {
+public class CommCareWiFiDirectActivity extends SessionAwareCommCareActivity<CommCareWiFiDirectActivity> implements DeviceActionListener, FileServerListener, WifiDirectManagerListener {
 
     public static final String TAG = CommCareWiFiDirectActivity.class.getSimpleName();
 

--- a/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ConnectionDiagnosticActivity.java
@@ -10,8 +10,8 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.tasks.ConnectionDiagnosticTask;
 import org.commcare.android.tasks.DataSubmissionListener;
@@ -31,7 +31,7 @@ import org.javarosa.core.services.locale.Localization;
  */
 
 @ManagedUi(R.layout.connection_diagnostic)
-public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDiagnosticActivity> {
+public class ConnectionDiagnosticActivity extends SessionAwareCommCareActivity<ConnectionDiagnosticActivity> {
     private static final String TAG = ConnectionDiagnosticActivity.class.getSimpleName();
 
     public static final String logUnsetPostURLMessage = "CCHQ ping test: post URL not set.";

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -11,8 +11,8 @@ import android.widget.Button;
 import android.widget.RelativeLayout;
 
 import org.commcare.android.adapters.EntityDetailAdapter;
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.android.models.AndroidSessionWrapper;
@@ -35,7 +35,7 @@ import org.javarosa.core.model.instance.TreeReference;
  *
  */
 @ManagedUi(R.layout.entity_detail)
-public class EntityDetailActivity extends CommCareActivity implements DetailCalloutListener {
+public class EntityDetailActivity extends SessionAwareCommCareActivity implements DetailCalloutListener {
     
     private CommCareSession session;
     private AndroidSessionWrapper asw;

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -38,7 +38,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.commcare.android.adapters.EntityListAdapter;
-import org.commcare.android.framework.CommCareActivity;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.android.models.AndroidSessionWrapper;
 import org.commcare.android.models.Entity;
@@ -64,7 +64,6 @@ import org.commcare.suite.model.DetailField;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.util.CommCareSession;
 import org.commcare.util.SessionFrame;
-import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.reference.InvalidReferenceException;
@@ -86,7 +85,7 @@ import java.util.TimerTask;
  * 
  * @author ctsims
  */
-public class EntitySelectActivity extends CommCareActivity implements TextWatcher, EntityLoaderListener, OnItemClickListener, TextToSpeech.OnInitListener, DetailCalloutListener {
+public class EntitySelectActivity extends SessionAwareCommCareActivity implements TextWatcher, EntityLoaderListener, OnItemClickListener, TextToSpeech.OnInitListener, DetailCalloutListener {
     private static final String TAG = EntitySelectActivity.class.getSimpleName();
 
     private CommCareSession session;

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -37,7 +37,7 @@ import org.commcare.android.database.UserStorageClosedException;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.android.database.user.models.User;
-import org.commcare.android.framework.CommCareActivity;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.models.logic.FormRecordProcessor;
 import org.commcare.android.tasks.DataPullTask;
@@ -60,7 +60,7 @@ import org.javarosa.core.services.storage.StorageFullException;
 import java.io.IOException;
 
 
-public class FormRecordListActivity extends CommCareActivity<FormRecordListActivity> implements TextWatcher, FormRecordLoadListener, OnItemClickListener {
+public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRecordListActivity> implements TextWatcher, FormRecordLoadListener, OnItemClickListener {
     public static final String TAG = FormRecordListActivity.class.getSimpleName();
 
     private static final int OPEN_RECORD = Menu.FIRST;

--- a/app/src/org/commcare/dalvik/activities/MenuGrid.java
+++ b/app/src/org/commcare/dalvik/activities/MenuGrid.java
@@ -27,8 +27,8 @@ import android.widget.GridView;
 
 import org.commcare.android.adapters.GridMenuAdapter;
 import org.commcare.android.adapters.MenuAdapter;
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
@@ -50,7 +50,7 @@ import java.io.IOException;
  */
 
 @ManagedUi(R.layout.grid_menu_layout)
-public class MenuGrid extends CommCareActivity implements OnItemClickListener, OnItemLongClickListener {
+public class MenuGrid extends SessionAwareCommCareActivity implements OnItemClickListener, OnItemLongClickListener {
     
     private CommCarePlatform platform;
     

--- a/app/src/org/commcare/dalvik/activities/MenuList.java
+++ b/app/src/org/commcare/dalvik/activities/MenuList.java
@@ -18,8 +18,8 @@ package org.commcare.dalvik.activities;
 
 import org.commcare.android.adapters.MenuAdapter;
 import org.commcare.android.framework.BreadcrumbBarFragment;
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
@@ -40,7 +40,7 @@ import android.widget.TextView;
 
 
 @ManagedUi(R.layout.screen_suite_menu)
-public class MenuList extends CommCareActivity implements OnItemClickListener {
+public class MenuList extends SessionAwareCommCareActivity implements OnItemClickListener {
     
     private CommCarePlatform platform;
     

--- a/app/src/org/commcare/dalvik/activities/MultimediaInflaterActivity.java
+++ b/app/src/org/commcare/dalvik/activities/MultimediaInflaterActivity.java
@@ -3,8 +3,8 @@ package org.commcare.dalvik.activities;
 import java.io.File;
 import java.util.ArrayList;
 
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.tasks.MultimediaInflaterTask;
 import org.commcare.android.tasks.templates.CommCareTask;
@@ -34,7 +34,7 @@ import android.widget.Toast;
  */
 
 @ManagedUi(R.layout.screen_multimedia_inflater)
-public class MultimediaInflaterActivity extends CommCareActivity<MultimediaInflaterActivity> {
+public class MultimediaInflaterActivity extends SessionAwareCommCareActivity<MultimediaInflaterActivity> {
     private static final String TAG = MultimediaInflaterActivity.class.getSimpleName();
     
     private static final String LOG_TAG = "CC-MultimediaInflator";

--- a/app/src/org/commcare/dalvik/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/dalvik/activities/RecoveryActivity.java
@@ -2,8 +2,8 @@ package org.commcare.dalvik.activities;
 
 import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.tasks.ExceptionReportTask;
@@ -29,7 +29,7 @@ import android.widget.TextView;
  * @author ctsims
  */
 @ManagedUi(R.layout.screen_recovery)
-public class RecoveryActivity extends CommCareActivity<RecoveryActivity> {
+public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActivity> {
     
     private static final int SEND_TASK_ID = 100;
     private static final int RECOVER_TASK_ID = 101;

--- a/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
@@ -11,14 +11,14 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.commcare.android.framework.CommCareActivity;
+import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.net.HttpRequestGenerator;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.javarosa.core.services.Logger;
 
-public class ReportProblemActivity extends CommCareActivity<ReportProblemActivity> implements OnClickListener {
+public class ReportProblemActivity extends SessionAwareCommCareActivity<ReportProblemActivity> implements OnClickListener {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -247,7 +247,8 @@ public class CommCareApplication extends Application {
     }
 
     /**
-     * Closes down the user service, resources, and background tasks.
+     * Closes down the user service, resources, and background tasks. Used for
+     * manual user log-outs.
      */
     public void closeUserSession() {
         synchronized(serviceLock) {
@@ -260,7 +261,8 @@ public class CommCareApplication extends Application {
 
     /**
      * Closes down the user service, resources, and background tasks,
-     * broadcasting an intent to redirect the user to the login screen.
+     * broadcasting an intent to redirect the user to the login screen. Used
+     * for session-expiration related user logouts.
      */
     public void expireUserSession() {
         synchronized(serviceLock) {

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -79,7 +79,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.commcare.android.framework.CommCareActivity;
-import org.commcare.android.framework.SessionAwareFragmentActivity;
+import org.commcare.android.framework.SessionActivityRegistration;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.SessionUnavailableException;
@@ -146,7 +146,7 @@ import javax.crypto.spec.SecretKeySpec;
  * 
  * @author Carl Hartung (carlhartung@gmail.com)
  */
-public class FormEntryActivity extends SessionAwareFragmentActivity implements AnimationListener, FormLoaderListener,
+public class FormEntryActivity extends FragmentActivity implements AnimationListener, FormLoaderListener,
         FormSavedListener, FormSaveCallback, AdvanceToNextListener, OnGestureListener,
         WidgetChangedListener {
     private static final String TAG = FormEntryActivity.class.getSimpleName();
@@ -892,7 +892,7 @@ public class FormEntryActivity extends SessionAwareFragmentActivity implements A
         //is to invalidate the view, though.
         Rect bounds = progressBar.getProgressDrawable().getBounds(); //Save the drawable bound
 
-        Log.i("Questions","Total questions: " + details.totalQuestions + " | Completed questions: " + details.completedQuestions);
+        Log.i("Questions", "Total questions: " + details.totalQuestions + " | Completed questions: " + details.completedQuestions);
 
         if (BuildConfig.DEBUG && ((bounds.width() == 0 && bounds.height() == 0) || progressBar.getVisibility() != View.VISIBLE)) {
             Log.e(TAG, "Invisible ProgressBar! Its visibility is: " + progressBar.getVisibility() + ", its bounds are: " + bounds);
@@ -2328,6 +2328,8 @@ public class FormEntryActivity extends SessionAwareFragmentActivity implements A
     protected void onPause() {
         super.onPause();
 
+        SessionActivityRegistration.unregisterSessionExpirationReceiver(this);
+
         dismissDialogs();
 
         if (mCurrentView != null && currentPromptIsQuestion()) {
@@ -2343,6 +2345,8 @@ public class FormEntryActivity extends SessionAwareFragmentActivity implements A
     @Override
     protected void onResume() {
         super.onResume();
+
+        SessionActivityRegistration.handleOrListenForSessionExpiration(this);
 
         registerFormEntryReceivers();
 


### PR DESCRIPTION
Some activities need to extend CommCareActivity but not be session aware.

Make SessionAwareCommCareActivity extend CommCareActivity instead of having CommCareActivity extend SessionAwareFragmentActivity.

FormEntryActivity is the one activity that needs to be session aware but not extend CommCareActivity, hence we manually add in the session un/registration handlers into onPause/onResume