### PR TITLE
Make action bar in CCSetupActivity app-agnostic

### DIFF
--- a/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
@@ -12,6 +12,7 @@ import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.view.GridEntityView;
 import org.commcare.android.view.TabbedDetailView;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.activities.CommCareSetupActivity;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.preferences.DeveloperPreferences;
 import org.commcare.suite.model.Detail;
@@ -376,6 +377,9 @@ public class BreadcrumbBarFragment extends Fragment {
     }
 
     private static String defaultTitle(String currentTitle, Activity activity) {
+        if (activity instanceof CommCareSetupActivity) {
+            return "CommCare";
+        }
         if(currentTitle == null || "".equals(currentTitle)) {
             currentTitle = CommCareActivity.getTopLevelTitleName(activity);
         }


### PR DESCRIPTION
With multiple apps, it is now possible to end up in CommCareSetupActivity while an app is seated, which causes the action bar to show an app name in that activity. This is confusing since CommCareSetupActivity should be an app-agnostic activity, so ensure that the action bar just always says "CommCare" for this activity.