### PR TITLE
Fix for update bug after multiple apps merge

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -209,7 +209,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         // If clicking the regular app icon brought us to CommCareSetupActivity
         // (because that's where we were last time the app was up), but there are now
         // 1 or more available apps, we want to redirect to CCHomeActivity
-        if (!mFromManager && CommCareApplication._().usableAppsPresent()) {
+        if (!mFromManager && !inUpgradeMode && CommCareApplication._().usableAppsPresent()) {
             Intent i = new Intent(this, CommCareHomeActivity.class);
             startActivity(i);
         }


### PR DESCRIPTION
CCSetupActivity should never redirect back to CCHomeActivity in onResume if it is in upgrade mode