### PR TITLE
achartengine as a library

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.commcare.dalvik"
-    android:versionCode="106"
-    android:versionName="2.22" >
+          xmlns:tools="http://schemas.android.com/tools"
+          package="org.commcare.dalvik"
+          android:versionCode="106"
+          android:versionName="2.22">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -57,6 +58,7 @@
     </permission>
 
     <application
+        tools:replace="android:label,android:icon"
         android:name=".application.CommCareApplication"
         android:icon="@drawable/icon"
         android:label="@string/application_name"
@@ -75,7 +77,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
-        
+
         <activity
             android:name=".activities.AppManagerActivity"
             android:label="@string/manager_activity_name"
@@ -84,7 +86,7 @@
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
-        
+
         <activity
             android:name=".activities.LoginActivity"
             android:label="@string/application_name"
@@ -216,7 +218,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity-alias>
-        
+
         <activity-alias
             android:name=".application.ManagerGenerator"
             android:label="App Manager"

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile project(':commcare')
 
     compile project(':libraries:mapballoons')
+    compile project(':libraries:achartengine')
     compile fileTree(dir: 'app/libs', include: '*.jar')
     compile 'in.srain.cube:grid-view-with-header-footer:1.0.12'
     compile 'com.android.support:support-v4:22.1.1'
@@ -113,9 +114,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_7
     }
 
-    def sourceLocations = ['app/src'
-                           , 'libraries/achartengine/achartengine/src'
-                          ]
+    def sourceLocations = ['app/src']
 
     sourceSets {
       main {

--- a/libraries/achartengine/build.gradle
+++ b/libraries/achartengine/build.gradle
@@ -1,0 +1,34 @@
+// only need this because I'm calling build.gradle from the directory above
+def basedirprefix='achartengine/'
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.2.3'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+  compileSdkVersion "Google Inc.:Google APIs:22"
+  buildToolsVersion "22.0.1"
+
+  defaultConfig {
+    minSdkVersion 7
+    targetSdkVersion 22
+  }
+  sourceSets {
+    main {
+      manifest.srcFile basedirprefix + 'AndroidManifest.xml'
+      java.srcDirs = [basedirprefix + 'src']
+      resources.srcDirs = [basedirprefix + 'src']
+      aidl.srcDirs = [basedirprefix + 'src']
+      renderscript.srcDirs = [basedirprefix + 'src']
+      res.srcDirs = [basedirprefix + 'res']
+      assets.srcDirs = [basedirprefix + 'assets']
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ':libraries:mapballoons'
+include ':libraries:achartengine'
 include ':javarosa'
 project(':javarosa').projectDir = new File('../javarosa')
 


### PR DESCRIPTION
achartengine is now a library project, which makes 'go to source' and other AS functions work as intended.

This solves bug [177777](http://manage.dimagi.com/default.asp?177777#990599).