### PR TITLE
Raise runtime exception on form save error

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -409,9 +409,9 @@ notification.formentry.unretrievable.title=Form Entry Error - Data Lost
 notification.formentry.unretrievable.detail=CommCare couldn't retrieve the data that you just entered. Something went wrong with the app's internal communication.
 notification.formentry.unretrievable.action=Unfortunately, CommCare can't retrieve the form you were entering. You'll almost certainly need to re-enter it. This error has been submitted to the server and is being looked into.
 
-notification.formentry.save_error.title=Form Saving Failed
-notification.formentry.save_error.detail=The following error occurred while saving the form:
-notification.formentry.save_error.action=${0}
+notification.formentry.save_error.title=Error Saving your Form
+notification.formentry.save_error.detail=CommCare ran into an error while processing your form, due to a problem with the form definition. The form structure needs to be updated, and it is unlikely you can fix this error on the phone.
+notification.formentry.save_error.action=The error that occured was:\n${0}
 
 notification.processing.badstructure.title=Problem with your App
 notification.processing.badstructure.detail=CommCare couldn't process a form you completed because it contains invalid information.

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -409,6 +409,10 @@ notification.formentry.unretrievable.title=Form Entry Error - Data Lost
 notification.formentry.unretrievable.detail=CommCare couldn't retrieve the data that you just entered. Something went wrong with the app's internal communication.
 notification.formentry.unretrievable.action=Unfortunately, CommCare can't retrieve the form you were entering. You'll almost certainly need to re-enter it. This error has been submitted to the server and is being looked into.
 
+notification.formentry.save_error.title=Form Saving Failed
+notification.formentry.save_error.detail=The following error occurred while saving the form:
+notification.formentry.save_error.action=${0}
+
 notification.processing.badstructure.title=Problem with your App
 notification.processing.badstructure.detail=CommCare couldn't process a form you completed because it contains invalid information.
 notification.processing.badstructure.action=The form unfortunately can't be recovered. You can try to re-enter it, but it is likely that the form is designed incorrectly. If you were completing an incomplete form, that Form's data had become invalid and the form couldn't be used. Otherwise, please contact a supervisor or tech support. The error will be sent to your submission server as a log.

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -410,7 +410,7 @@ notification.formentry.unretrievable.detail=CommCare couldn't retrieve the data 
 notification.formentry.unretrievable.action=Unfortunately, CommCare can't retrieve the form you were entering. You'll almost certainly need to re-enter it. This error has been submitted to the server and is being looked into.
 
 notification.formentry.save_error.title=Error Saving your Form
-notification.formentry.save_error.detail=CommCare ran into an error while processing your form, due to a problem with the form definition. The form structure needs to be updated, and it is unlikely you can fix this error on the phone.
+notification.formentry.save_error.detail=CommCare ran into an error while processing your form, due to a problem with the form definition. The form structure needs to be updated, and it is unlikely you can fix this error on the phone. You should cancel form entry until the problem is addressed.
 notification.formentry.save_error.action=The error that occured was:\n${0}
 
 notification.processing.badstructure.title=Problem with your App

--- a/app/src/org/commcare/android/models/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/android/models/notifications/NotificationMessageFactory.java
@@ -59,7 +59,9 @@ public class NotificationMessageFactory {
         
         /**Could not retrieve Form Result **/
         FormEntry_Unretrievable ("notification.formentry.unretrievable"),
-        
+
+        FormEntry_Save_Error ("notification.formentry.save_error"),
+
         /**In airplane mode while trying to sync**/
         Sync_AirplaneMode("notification.sync.airplane"),
         

--- a/app/src/org/commcare/dalvik/odk/provider/InstanceProvider.java
+++ b/app/src/org/commcare/dalvik/odk/provider/InstanceProvider.java
@@ -18,6 +18,8 @@ import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.models.AndroidSessionWrapper;
 import org.commcare.android.models.logic.FormRecordProcessor;
+import org.commcare.android.models.notifications.NotificationMessage;
+import org.commcare.android.models.notifications.NotificationMessageFactory;
 import org.commcare.android.tasks.ExceptionReportTask;
 import org.commcare.android.tasks.FormRecordCleanupTask;
 import org.commcare.dalvik.application.CommCareApplication;
@@ -468,6 +470,10 @@ public class InstanceProvider extends ContentProvider {
                 try {
                     new FormRecordProcessor(getContext()).process(current);
                 } catch (Exception e) {
+                    NotificationMessage message =
+                            NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.FormEntry_Save_Error,
+                                    new String[]{null, null, e.getMessage()});
+                    CommCareApplication._().reportNotificationMessage(message);
                     Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW,
                             "Error processing form. Should be recaptured during async processing: " + e.getMessage());
                     throw new RuntimeException(e);

--- a/app/src/org/commcare/dalvik/odk/provider/InstanceProvider.java
+++ b/app/src/org/commcare/dalvik/odk/provider/InstanceProvider.java
@@ -470,6 +470,7 @@ public class InstanceProvider extends ContentProvider {
                 } catch (Exception e) {
                     Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW,
                             "Error processing form. Should be recaptured during async processing: " + e.getMessage());
+                    throw new RuntimeException(e);
                 }
             }
         }


### PR DESCRIPTION
Raise runtime exception when forms have trouble saving. This ensures the user sees that there was a problem saving the form.

This exception will be caught and reraised as a SQLException in InstanceProvider.update/insert

User should see "Sorry, form save failed!"  toast pop-up message and be left on the current screen.

A pinned notification will also be created with the title: _Form Saving Failed_
and the body _The following error occrued while saving the form:_ and then the error message, which might look something like:
```Invalid XML Structure(START_TAG <{http://commcarehq.org/case/transaction/v2}n0:update>@1:1006 in java.io.InputStreamReader@d058c15): No case found for update. Skipping ID: ```

Problem mentioned in http://manage.dimagi.com/default.asp?178655