### PR TITLE
Fix bar graph type

### DIFF
--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -152,7 +152,7 @@ public class GraphView {
             return ChartFactory.getTimeChartView(mContext, mDataset, mRenderer, getTimeFormat());
         }
         if (Graph.TYPE_BAR.equals(mData.getType())) {
-            return ChartFactory.getBarChartView(mContext, mDataset, mRenderer, BarChart.Type.STACKED);
+            return ChartFactory.getBarChartView(mContext, mDataset, mRenderer, BarChart.Type.DEFAULT);
         }
         return ChartFactory.getLineChartView(mContext, mDataset, mRenderer);
     }


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?178650

This was changed from DEFAULT to STACKED, presumably unintentionally, in https://github.com/dimagi/commcare-odk/commit/f58e39b9fdbe41b9c0302c5e9911c5869fbb68c0 which was otherwise a whitespace-cleanup commit on the original bar graphs PR (https://github.com/dimagi/commcare-odk/pull/293).