### PR TITLE
Don't register form save callback for archived forms

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -970,9 +970,9 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
         //Create our form entry activity callout
         Intent i = new Intent(getApplicationContext(), FormEntryActivity.class);
         i.setAction(Intent.ACTION_EDIT);
-        i.putExtra("odk_title_fragment", BreadcrumbBarFragment.class.getName());
+        i.putExtra(FormEntryActivity.TITLE_FRAGMENT_TAG, BreadcrumbBarFragment.class.getName());
 
-        i.putExtra("instancedestination", CommCareApplication._().getCurrentApp().fsPath((GlobalConstants.FILE_CC_FORMS)));
+        i.putExtra(FormEntryActivity.KEY_INSTANCEDESTINATION, CommCareApplication._().getCurrentApp().fsPath((GlobalConstants.FILE_CC_FORMS)));
         
         // See if there's existing form data that we want to continue entering
         // (note, this should be stored in the form record as a URI link to
@@ -983,18 +983,16 @@ public class CommCareHomeActivity extends CommCareActivity<CommCareHomeActivity>
             i.setData(formUri);
         }
 
-        i.putExtra("org.odk.collect.resizing.enabled", CommCarePreferences.getResizeMethod());
+        i.putExtra(FormEntryActivity.KEY_RESIZING_ENABLED, CommCarePreferences.getResizeMethod());
 
-        i.putExtra("org.odk.collect.form.management", CommCarePreferences.isIncompleteFormsEnabled());
+        i.putExtra(FormEntryActivity.KEY_INCOMPLETE_ENABLED, CommCarePreferences.isIncompleteFormsEnabled());
 
-        i.putExtra("readonlyform", FormRecord.STATUS_SAVED.equals(r.getStatus()));
+        i.putExtra(FormEntryActivity.KEY_AES_STORAGE_KEY, Base64.encodeToString(r.getAesKey(), Base64.DEFAULT));
 
-        i.putExtra("key_aes_storage", Base64.encodeToString(r.getAesKey(), Base64.DEFAULT));
-
-        i.putExtra("form_content_uri", FormsProviderAPI.FormsColumns.CONTENT_URI.toString());
-        i.putExtra("instance_content_uri", InstanceProviderAPI.InstanceColumns.CONTENT_URI.toString());
+        i.putExtra(FormEntryActivity.KEY_FORM_CONTENT_URI, FormsProviderAPI.FormsColumns.CONTENT_URI.toString());
+        i.putExtra(FormEntryActivity.KEY_INSTANCE_CONTENT_URI, InstanceProviderAPI.InstanceColumns.CONTENT_URI.toString());
         if (headerTitle != null) {
-            i.putExtra("form_header", headerTitle);
+            i.putExtra(FormEntryActivity.KEY_HEADER_STRING, headerTitle);
         }
 
         startActivityForResult(i, MODEL_RESULT);

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -272,10 +272,8 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
             mFormLoaderTask = (FormLoaderTask) data;
         } else if (data instanceof SaveToDiskTask) {
             mSaveToDiskTask = (SaveToDiskTask) data;
-            registerSessionFormSaveCallback();
         } else if (!isNewForm) {
             // Screen orientation change
-            registerSessionFormSaveCallback();
             refreshCurrentView();
         } else {
             mFormController = null;

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -272,6 +272,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
             mFormLoaderTask = (FormLoaderTask) data;
         } else if (data instanceof SaveToDiskTask) {
             mSaveToDiskTask = (SaveToDiskTask) data;
+            registerSessionFormSaveCallback();
         } else if (!isNewForm) {
             // Screen orientation change
             registerSessionFormSaveCallback();

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -325,21 +325,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         }
     }
 
-    private void registerSessionFormSaveCallback() {
-        if (mFormController != null && !mFormController.isFormReadOnly()) {
-            try {
-                // CommCareSessionService will call this.formSaveCallback when
-                // the key session is closing down and we need to save any
-                // intermediate results before they become un-saveable.
-                CommCareApplication._().getSession().registerFormSaveCallback(this);
-            } catch (SessionUnavailableException e) {
-                Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW,
-                        "Couldn't register form save callback because session doesn't exist");
-            }
-        }
-    }
-
-
     @Override
     public boolean onMenuItemSelected(int featureId, MenuItem item) {
         /*
@@ -2540,6 +2525,21 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
         refreshCurrentView();
         updateNavigationCues(this.mCurrentView);
     }
+
+    private void registerSessionFormSaveCallback() {
+        if (mFormController != null && !mFormController.isFormReadOnly()) {
+            try {
+                // CommCareSessionService will call this.formSaveCallback when
+                // the key session is closing down and we need to save any
+                // intermediate results before they become un-saveable.
+                CommCareApplication._().getSession().registerFormSaveCallback(this);
+            } catch (SessionUnavailableException e) {
+                Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW,
+                        "Couldn't register form save callback because session doesn't exist");
+            }
+        }
+    }
+
 
 
     /**


### PR DESCRIPTION
Register form save callback, which is called on session expiration, only on form loading and if the current form isn't read only.

Also make use of FormEntryActivity constants in CommCareHomeActivity.