### PR TITLE
Don't save on reaching form end if readonly

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1428,10 +1428,6 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
                 if(mFormController.isFormReadOnly()) {
                     button.setText(StringUtils.getStringSpannableRobust(this, R.string.exit));
                             button.setOnClickListener(new OnClickListener() {
-                                /*
-                                 * (non-Javadoc)
-                                 * @see android.view.View.OnClickListener#onClick(android.view.View)
-                                 */
                                 @Override
                                 public void onClick(View v) {
                                     finishReturnInstance();
@@ -2432,7 +2428,11 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
      * Call when the user is ready to save and return the current form as complete 
      */
     private void triggerUserFormComplete() {
-        saveDataToDisk(EXIT, true, getDefaultFormTitle(), false);
+        if (mFormController.isFormReadOnly()) {
+            finishReturnInstance(false);
+        } else {
+            saveDataToDisk(EXIT, true, getDefaultFormTitle(), false);
+        }
     }
 
     @Override


### PR DESCRIPTION
When navigating an archived form and press the green arrow at the end, it currently tries to save the form. 

This PR checks if the form is archived and doesn't trigger form saving if that is the case.