### PR TITLE
Enable install requests from external applications with multiple apps

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -110,9 +110,15 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     private CommCareApp ccApp;
 
     /**
-     * Indicates whether this activity was launched from the AppManagerActivity
+     * Indicates that this activity was launched from the AppManagerActivity
      */
-    private boolean mFromManager;
+    private boolean fromManager;
+
+    /**
+     * Indicates that this activity was launched from an outside application (such as a bit.ly
+     * url entered in a browser)
+     */
+    private boolean fromExternal;
 
     /**
      * Whether this needs to be interactive (if it's automatic, we want to skip
@@ -140,7 +146,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         CommCareSetupActivity oldActivity = (CommCareSetupActivity)this.getDestroyedActivityState();
-        this.mFromManager = this.getIntent().
+        this.fromManager = this.getIntent().
                 getBooleanExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, false);
 
         //Retrieve instance state
@@ -148,6 +154,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             Log.v("UiState", "SavedInstanceState is null, not getting anything from it =/");
             if(Intent.ACTION_VIEW.equals(this.getIntent().getAction())) {
                 //We got called from an outside application, it's gonna be a wild ride!
+                fromExternal = true;
                 incomingRef = this.getIntent().getData().toString();
                 if(incomingRef.contains(".ccz")) {
                     // make sure this is in the file system
@@ -210,7 +217,8 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         // If clicking the regular app icon brought us to CommCareSetupActivity
         // (because that's where we were last time the app was up), but there are now
         // 1 or more available apps, we want to redirect to CCHomeActivity
-        if (!mFromManager && !inUpgradeMode && CommCareApplication._().usableAppsPresent()) {
+        if (!fromManager && !fromExternal && !inUpgradeMode &&
+                CommCareApplication._().usableAppsPresent()) {
             Intent i = new Intent(this, CommCareHomeActivity.class);
             startActivity(i);
         }


### PR DESCRIPTION
If entry into CommCareSetupActivity came from an external application (such as a bit.ly url entered into a browser), do not redirect in onResume.