### PR TITLE
Initialize AndroidSessionWrapper when an app is seated

### DIFF
--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -448,6 +448,7 @@ public class CommCareApplication extends Application {
             currentApp = app;
             if (currentApp.initializeApplication()) {
                 resourceState = STATE_READY;
+                //this.sessionWrapper = new AndroidSessionWrapper(this.getCommCarePlatform());
             } else {
                 //????
                 resourceState = STATE_CORRUPTED;
@@ -1056,7 +1057,8 @@ public class CommCareApplication extends Application {
         synchronized (serviceLock) {
             if (mIsBound) {
                 if (sessionWrapper != null) {
-                    sessionWrapper.reset();
+                    //sessionWrapper.reset();
+                    sessionWrapper = null;
                 }
                 mIsBound = false;
                 // Detach our existing connection.

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -448,7 +448,7 @@ public class CommCareApplication extends Application {
             currentApp = app;
             if (currentApp.initializeApplication()) {
                 resourceState = STATE_READY;
-                //this.sessionWrapper = new AndroidSessionWrapper(this.getCommCarePlatform());
+                this.sessionWrapper = new AndroidSessionWrapper(this.getCommCarePlatform());
             } else {
                 //????
                 resourceState = STATE_CORRUPTED;
@@ -1057,8 +1057,7 @@ public class CommCareApplication extends Application {
         synchronized (serviceLock) {
             if (mIsBound) {
                 if (sessionWrapper != null) {
-                    //sessionWrapper.reset();
-                    sessionWrapper = null;
+                    sessionWrapper.reset();
                 }
                 mIsBound = false;
                 // Detach our existing connection.


### PR DESCRIPTION
Fix for CommCareApplication not having the correct AndroidSessionWrapper for the currently-seated app.