### PR TITLE
Don't make protected methods public during override

### DIFF
--- a/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
@@ -313,7 +313,7 @@ public class BreadcrumbBarFragment extends Fragment {
 
 
     @Override
-    protected void onResume() {
+    public void onResume() {
         super.onResume();
         if(tile != null) {
             ViewGroup vg = (ViewGroup)this.getActivity().findViewById(R.id.universal_frame_tile);

--- a/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
@@ -313,7 +313,7 @@ public class BreadcrumbBarFragment extends Fragment {
 
 
     @Override
-    public void onResume() {
+    protected void onResume() {
         super.onResume();
         if(tile != null) {
             ViewGroup vg = (ViewGroup)this.getActivity().findViewById(R.id.universal_frame_tile);

--- a/app/src/org/commcare/dalvik/activities/AppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/AppManagerActivity.java
@@ -35,14 +35,14 @@ public class AppManagerActivity extends Activity implements OnItemClickListener 
     private static final int MENU_CONNECTION_DIAGNOSTIC = 0;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.app_manager);
         ((ListView)this.findViewById(R.id.apps_list_view)).setOnItemClickListener(this);
     }
 
     @Override
-    public void onResume() {
+    protected void onResume() {
         super.onResume();
         refreshView();
     }

--- a/app/src/org/commcare/dalvik/activities/CallLogActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallLogActivity.java
@@ -31,7 +31,7 @@ public class CallLogActivity<T extends Persistable> extends ListActivity {
     boolean isMessages = false;
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         
         setTitle(getString(R.string.application_name) + " > " + "Phone Logs");

--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -39,7 +39,7 @@ public class CallOutActivity extends Activity {
     CallListener listener;
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         tManager = (TelephonyManager) this.getSystemService(TELEPHONY_SERVICE);
         listener = new CallListener(); 
@@ -53,7 +53,7 @@ public class CallOutActivity extends Activity {
         }
     }
     
-    public void onResume() {
+    protected void onResume() {
         super.onResume();
         if(listener.isFinished()) {
             long duration = listener.getCallDuration();

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -166,7 +166,7 @@ public class CommCareHomeActivity extends SessionAwareCommCareActivity<CommCareH
     private ImageView topBannerImageView;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         //This is a workaround required by Android Bug #2373, which is that Apps are launched from the

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -143,7 +143,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     //endregion
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         CommCareSetupActivity oldActivity = (CommCareSetupActivity)this.getDestroyedActivityState();
         this.fromManager = this.getIntent().
@@ -212,7 +212,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     }
 
     @Override
-    public void onResume() {
+    protected void onResume() {
         super.onResume();
         // If clicking the regular app icon brought us to CommCareSetupActivity
         // (because that's where we were last time the app was up), but there are now
@@ -283,11 +283,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         return fragment;
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-    }
-    
     @Override
     protected void onStart() {
         super.onStart();

--- a/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
@@ -72,7 +72,8 @@ public class CommCareVerificationActivity
     private boolean fromSettings;
 
 
-    public void onCreate(Bundle savedInstanceState){
+    @Override
+    protected void onCreate(Bundle savedInstanceState){
 
         super.onCreate(savedInstanceState);
         
@@ -97,7 +98,7 @@ public class CommCareVerificationActivity
     }
     
     @Override
-    public void onResume() {
+    protected void onResume() {
         super.onResume();
 
         // It is possible that the CommCare screen was left off in the VerificationActivity, but

--- a/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
@@ -102,7 +102,7 @@ public class CommCareWiFiDirectActivity extends SessionAwareCommCareActivity<Com
     public FormRecord[] cachedRecords;
 
     @Override
-    public void onCreate(Bundle savedInstanceState){
+    protected void onCreate(Bundle savedInstanceState){
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.wifi_direct_main);

--- a/app/src/org/commcare/dalvik/activities/DotsEntryActivity.java
+++ b/app/src/org/commcare/dalvik/activities/DotsEntryActivity.java
@@ -69,7 +69,7 @@ public class DotsEntryActivity extends Activity implements DotsEditListener, Ani
     int zY = -1;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         
         if(savedInstanceState != null) {

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -68,7 +68,7 @@ public class EntityDetailActivity extends SessionAwareCommCareActivity implement
     TabbedDetailView mDetailView;
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {        
+    protected void onCreate(Bundle savedInstanceState) {        
         Intent i = getIntent();
         
         try {

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -140,7 +140,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
     private OnClickListener barcodeScanOnClickListener;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         this.createDataSetObserver();
@@ -351,7 +351,8 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
     private boolean resuming = false;
     private boolean startOther = false;
 
-    public void onResume() {
+    @Override
+    protected void onResume() {
         super.onResume();
         //Don't go through making the whole thing if we're finishing anyway.
         if (this.isFinishing() || startOther) {
@@ -823,7 +824,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
     }
 
     @Override
-    public void onDestroy() {
+    protected void onDestroy() {
         super.onDestroy();
         if (loader != null) {
             if (isFinishing()) {

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -144,7 +144,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
 
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         try {
             platform = CommCareApplication._().getCommCarePlatform();
@@ -337,7 +337,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     }
 
     @Override
-    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
+    protected void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo)menuInfo;
         IncompleteFormRecordView ifrv = (IncompleteFormRecordView)adapter.getView(info.position, null, null);
         menu.setHeaderTitle(ifrv.mPrimaryTextView.getText() + " (" + ifrv.mRightTextView.getText() + ")");

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -337,7 +337,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     }
 
     @Override
-    protected void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
+    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo)menuInfo;
         IncompleteFormRecordView ifrv = (IncompleteFormRecordView)adapter.getView(info.position, null, null);
         menu.setHeaderTitle(ifrv.mPrimaryTextView.getText() + " (" + ifrv.mRightTextView.getText() + ")");

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -155,7 +155,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         username.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
         LoginBoxesStatus.Normal.setStatus(this);

--- a/app/src/org/commcare/dalvik/activities/MenuGrid.java
+++ b/app/src/org/commcare/dalvik/activities/MenuGrid.java
@@ -60,7 +60,7 @@ public class MenuGrid extends SessionAwareCommCareActivity implements OnItemClic
     private GridView grid;
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         platform = CommCareApplication._().getCommCarePlatform();
         

--- a/app/src/org/commcare/dalvik/activities/MenuList.java
+++ b/app/src/org/commcare/dalvik/activities/MenuList.java
@@ -53,7 +53,7 @@ public class MenuList extends SessionAwareCommCareActivity implements OnItemClic
     private TextView header;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         platform = CommCareApplication._().getCommCarePlatform();
         String menuId = getIntent().getStringExtra(SessionFrame.STATE_COMMAND_ID);

--- a/app/src/org/commcare/dalvik/activities/MessageLogActivity.java
+++ b/app/src/org/commcare/dalvik/activities/MessageLogActivity.java
@@ -22,7 +22,7 @@ public class MessageLogActivity extends ListActivity {
     boolean isMessages = false;
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         
         setTitle(getString(R.string.application_name) + " > " + "Message Logs");

--- a/app/src/org/commcare/dalvik/activities/PhoneLogActivity.java
+++ b/app/src/org/commcare/dalvik/activities/PhoneLogActivity.java
@@ -16,7 +16,8 @@ import org.commcare.dalvik.R;
  *
  */
 public class PhoneLogActivity extends TabActivity {
-    public void onCreate(Bundle savedInstanceState) {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.phone_logs);
         

--- a/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
+++ b/app/src/org/commcare/dalvik/activities/ReportProblemActivity.java
@@ -21,7 +21,7 @@ import org.javarosa.core.services.Logger;
 public class ReportProblemActivity extends SessionAwareCommCareActivity<ReportProblemActivity> implements OnClickListener {
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_report_problem);
         Button submitButton = (Button)findViewById(R.id.ReportButton01);

--- a/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
@@ -40,7 +40,7 @@ public class SingleAppManagerActivity extends Activity {
     private static final int LOGOUT_FOR_ARCHIVE = 2;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.single_app_view);
 
@@ -62,7 +62,7 @@ public class SingleAppManagerActivity extends Activity {
     }
 
     @Override
-    public void onResume() {
+    protected void onResume() {
         super.onResume();
         refresh();
     }

--- a/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
@@ -25,7 +25,7 @@ public class UnrecoverableErrorActivity extends Activity {
     String message;
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         title = this.getIntent().getStringExtra(EXTRA_ERROR_TITLE);
         message = this.getIntent().getStringExtra(EXTRA_ERROR_MESSAGE);

--- a/app/src/org/commcare/dalvik/application/AndroidShortcuts.java
+++ b/app/src/org/commcare/dalvik/application/AndroidShortcuts.java
@@ -26,7 +26,7 @@ public class AndroidShortcuts extends Activity {
     String[] names;
     
     @Override
-    public void onCreate(Bundle bundle) {
+    protected void onCreate(Bundle bundle) {
         super.onCreate(bundle);
 
         final Intent intent = getIntent();

--- a/app/src/org/commcare/dalvik/application/ManagerShortcut.java
+++ b/app/src/org/commcare/dalvik/application/ManagerShortcut.java
@@ -11,7 +11,7 @@ import org.commcare.dalvik.activities.AppManagerActivity;
 public class ManagerShortcut extends Activity {
 
     @Override
-    public void onCreate(Bundle bundle) {
+    protected void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         Intent shortcutIntent = new Intent(getApplicationContext(), AppManagerActivity.class);
         shortcutIntent.addCategory(Intent.CATEGORY_HOME);

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -112,7 +112,7 @@ public class CustomProgressDialog extends DialogFragment {
     }
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         restoreFields(savedInstanceState);
     }

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -112,7 +112,7 @@ public class CustomProgressDialog extends DialogFragment {
     }
     
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         restoreFields(savedInstanceState);
     }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -113,7 +113,7 @@ public class CommCareSessionService extends Service  {
     }
 
     @Override
-    public void onCreate() {
+    protected void onCreate() {
         mNM = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
         setSessionLength();
         pool = new CipherPool() {
@@ -158,7 +158,7 @@ public class CommCareSessionService extends Service  {
     }
 
     @Override
-    public void onDestroy() {
+    protected void onDestroy() {
         // Cancel the persistent notification.
         this.stopForeground(true);
     }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -113,7 +113,7 @@ public class CommCareSessionService extends Service  {
     }
 
     @Override
-    protected void onCreate() {
+    public void onCreate() {
         mNM = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
         setSessionLength();
         pool = new CipherPool() {
@@ -158,7 +158,7 @@ public class CommCareSessionService extends Service  {
     }
 
     @Override
-    protected void onDestroy() {
+    public void onDestroy() {
         // Cancel the persistent notification.
         this.stopForeground(true);
     }

--- a/app/src/org/odk/collect/android/activities/DrawActivity.java
+++ b/app/src/org/odk/collect/android/activities/DrawActivity.java
@@ -96,7 +96,7 @@ public class DrawActivity extends Activity {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -242,7 +242,7 @@ public class FormEntryActivity extends FragmentActivity implements AnimationList
 
     @Override
     @SuppressLint("NewApi")
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         addBreadcrumbBar();

--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -44,7 +44,7 @@ public class FormHierarchyActivity extends ListActivity {
 
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hierarchy_layout);
 

--- a/app/src/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/app/src/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -53,7 +53,7 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
     private boolean mNetworkOn = false;
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
 

--- a/libraries/achartengine/achartengine/demo/org/achartengine/chartdemo/demo/ChartDemo.java
+++ b/libraries/achartengine/achartengine/demo/org/achartengine/chartdemo/demo/ChartDemo.java
@@ -63,7 +63,7 @@ public class ChartDemo extends ListActivity {
 
   /** Called when the activity is first created. */
   @Override
-  public void onCreate(Bundle savedInstanceState) {
+  protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     int length = mCharts.length;
     mMenuText = new String[length + 3];

--- a/libraries/achartengine/achartengine/demo/org/achartengine/chartdemo/demo/GeneratedChartDemo.java
+++ b/libraries/achartengine/achartengine/demo/org/achartengine/chartdemo/demo/GeneratedChartDemo.java
@@ -51,7 +51,7 @@ public class GeneratedChartDemo extends ListActivity {
 
   /** Called when the activity is first created. */
   @Override
-  public void onCreate(Bundle savedInstanceState) {
+  protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     // I know, I know, this should go into strings.xml and accessed using
     // getString(R.string....)

--- a/test-app/src/com/dimagi/test/external/CaseContentActivity.java
+++ b/test-app/src/com/dimagi/test/external/CaseContentActivity.java
@@ -21,7 +21,7 @@ public class CaseContentActivity extends Activity {
      * @see android.app.Activity#onCreate(android.os.Bundle)
      */
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.content_page);
         showCaseData(null, null);

--- a/test-app/src/com/dimagi/test/external/CaseMediaActivity.java
+++ b/test-app/src/com/dimagi/test/external/CaseMediaActivity.java
@@ -27,7 +27,7 @@ public class CaseMediaActivity extends Activity {
      * @see android.app.Activity#onCreate(android.os.Bundle)
      */
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.media_page);
         showCaseData(null, null);

--- a/test-app/src/com/dimagi/test/external/ExternalAppActivity.java
+++ b/test-app/src/com/dimagi/test/external/ExternalAppActivity.java
@@ -39,7 +39,7 @@ public class ExternalAppActivity extends Activity {
      * @see android.app.Activity#onCreate(android.os.Bundle)
      */
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
         Button b = (Button)this.findViewById(R.id.btn_start_cc);

--- a/test-app/src/com/dimagi/test/external/FixtureContentActivity.java
+++ b/test-app/src/com/dimagi/test/external/FixtureContentActivity.java
@@ -21,7 +21,7 @@ public class FixtureContentActivity extends Activity {
      * @see android.app.Activity#onCreate(android.os.Bundle)
      */
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.content_page);
         showFixtureData(null, null);

--- a/test-app/src/com/dimagi/test/external/IntentCalloutTest.java
+++ b/test-app/src/com/dimagi/test/external/IntentCalloutTest.java
@@ -33,7 +33,7 @@ public class IntentCalloutTest extends Activity {
      * @see android.app.Activity#onCreate(android.os.Bundle)
      */
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_callout);
         returnToForm = (Button)this.findViewById(R.id.button_return);

--- a/test-app/src/com/dimagi/test/external/IntentReceiverTest.java
+++ b/test-app/src/com/dimagi/test/external/IntentReceiverTest.java
@@ -28,7 +28,7 @@ public class IntentReceiverTest extends Activity  {
     
     
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.intent_receiver);
         b = (Button)this.findViewById(R.id.btn_intent_listen);


### PR DESCRIPTION
When extending any sort of activity class that isn't a Fragment, we don't want to make the ```protected``` onCreate, onPause, onResume, etc methods into ```public``` ones when we override them.