### PR TITLE
Fix app closing intermittently on login

### DIFF
--- a/app/src/org/commcare/android/framework/SessionActivityRegistration.java
+++ b/app/src/org/commcare/android/framework/SessionActivityRegistration.java
@@ -74,7 +74,7 @@ public class SessionActivityRegistration {
      */
     private static void letHomeScreenRedirectToLogin(Context context) {
         Intent i = new Intent(context.getApplicationContext(), CommCareHomeActivity.class);
-        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         context.startActivity(i);
     }
 }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -1700,7 +1700,7 @@ public class CommCareHomeActivity extends SessionAwareCommCareActivity<CommCareH
 
     private void returnToLogin() {
         Intent i = new Intent(this.getApplicationContext(), LoginActivity.class);
-        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         this.startActivityForResult(i, LOGIN_USER);
     }
 }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -205,7 +205,7 @@ public class CommCareSessionService extends Service  {
         this.stopForeground(true);
 
         Intent i = new Intent(this, CommCareHomeActivity.class);
-        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
 
         Notification notification = new NotificationCompat.Builder(this)


### PR DESCRIPTION
Fix bug where every once in a while logging in puts the whole app into the background.

Caused by something (I don't know what) launching the LoginActivity twice combined with me not correctly using FLAG_ACTIVITY_CLEAR_TOP. Shoulda read the [whole entry in the docs](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_CLEAR_TOP)...