### PR TITLE
Configure zoom placement & tweak aesthetics

### DIFF
--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -13,6 +13,7 @@ import org.achartengine.chart.PointStyle;
 import org.achartengine.model.TimeSeries;
 import org.achartengine.model.XYMultipleSeriesDataset;
 import org.achartengine.model.XYSeries;
+import org.achartengine.renderer.DefaultRenderer;
 import org.achartengine.renderer.XYMultipleSeriesRenderer;
 import org.achartengine.renderer.XYSeriesRenderer;
 import org.commcare.android.models.RangeXYValueSeries;
@@ -127,6 +128,24 @@ public class GraphView {
         mRenderer.setPanEnabled(allow, allow);
         mRenderer.setZoomEnabled(allow, allow);
         mRenderer.setZoomButtonsVisible(allow);
+        if (allow) {
+            DefaultRenderer.Location loc = stringToLocation(mData.getConfiguration("zoom-location", "bottom-right"));
+            mRenderer.setZoomLocation(loc);
+        }
+    }
+
+    private DefaultRenderer.Location stringToLocation(String str) {
+        // Java, why don't you have a concise way to define a hashmap?
+        if (str.equals("top-left")) {
+            return DefaultRenderer.Location.TOP_LEFT;
+        }
+        if (str.equals("top-right")) {
+            return DefaultRenderer.Location.TOP_RIGHT;
+        }
+        if (str.equals("bottom-left")) {
+            return DefaultRenderer.Location.BOTTOM_LEFT;
+        }
+        return DefaultRenderer.Location.BOTTOM_RIGHT;
     }
 
     /*

--- a/libraries/achartengine/achartengine/src/org/achartengine/GraphicalView.java
+++ b/libraries/achartengine/achartengine/src/org/achartengine/GraphicalView.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2009 - 2013 SC 4ViewSoft SRL
- *  
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
- *      http://www.apache.org/licenses/LICENSE-2.0
- *  
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 package org.achartengine;
-
-import org.achartengine.chart.AbstractChart;
-import org.achartengine.chart.RoundChart;
-import org.achartengine.chart.XYChart;
-import org.achartengine.model.Point;
-import org.achartengine.model.SeriesSelection;
-import org.achartengine.renderer.DefaultRenderer;
-import org.achartengine.renderer.XYMultipleSeriesRenderer;
-import org.achartengine.tools.FitZoom;
-import org.achartengine.tools.PanListener;
-import org.achartengine.tools.Zoom;
-import org.achartengine.tools.ZoomListener;
 
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -40,312 +28,375 @@ import android.os.Handler;
 import android.view.MotionEvent;
 import android.view.View;
 
+import org.achartengine.chart.AbstractChart;
+import org.achartengine.chart.RoundChart;
+import org.achartengine.chart.XYChart;
+import org.achartengine.model.Point;
+import org.achartengine.model.SeriesSelection;
+import org.achartengine.renderer.DefaultRenderer;
+import org.achartengine.renderer.XYMultipleSeriesRenderer;
+import org.achartengine.tools.FitZoom;
+import org.achartengine.tools.PanListener;
+import org.achartengine.tools.Zoom;
+import org.achartengine.tools.ZoomListener;
+
 /**
  * The view that encapsulates the graphical chart.
  */
 public class GraphicalView extends View {
-  /** The chart to be drawn. */
-  private AbstractChart mChart;
-  /** The chart renderer. */
-  private DefaultRenderer mRenderer;
-  /** The view bounds. */
-  private Rect mRect = new Rect();
-  /** The user interface thread handler. */
-  private Handler mHandler;
-  /** The zoom buttons rectangle. */
-  private RectF mZoomR = new RectF();
-  /** The zoom in icon. */
-  private Bitmap zoomInImage;
-  /** The zoom out icon. */
-  private Bitmap zoomOutImage;
-  /** The fit zoom icon. */
-  private Bitmap fitZoomImage;
-  /** The zoom area size. */
-  private int zoomSize = 50;
-  /** The zoom buttons background color. */
-  private static final int ZOOM_BUTTONS_COLOR = Color.argb(175, 150, 150, 150);
-  /** The zoom in tool. */
-  private Zoom mZoomIn;
-  /** The zoom out tool. */
-  private Zoom mZoomOut;
-  /** The fit zoom tool. */
-  private FitZoom mFitZoom;
-  /** The paint to be used when drawing the chart. */
-  private Paint mPaint = new Paint();
-  /** The touch handler. */
-  private ITouchHandler mTouchHandler;
-  /** The old x coordinate. */
-  private float oldX;
-  /** The old y coordinate. */
-  private float oldY;
-  /** If the graphical view is drawn. */
-  private boolean mDrawn;
+    /**
+     * The chart to be drawn.
+     */
+    private AbstractChart mChart;
+    /**
+     * The chart renderer.
+     */
+    private DefaultRenderer mRenderer;
+    /**
+     * The view bounds.
+     */
+    private Rect mRect = new Rect();
+    /**
+     * The user interface thread handler.
+     */
+    private Handler mHandler;
+    /**
+     * The zoom buttons rectangle.
+     */
+    private RectF mZoomR = new RectF();
+    /**
+     * The zoom in icon.
+     */
+    private Bitmap zoomInImage;
+    /**
+     * The zoom out icon.
+     */
+    private Bitmap zoomOutImage;
+    /**
+     * The fit zoom icon.
+     */
+    private Bitmap fitZoomImage;
+    /**
+     * The zoom area size.
+     */
+    private int zoomSize = 50;
+    /**
+     * The zoom buttons background color.
+     */
+    private static final int ZOOM_BUTTONS_COLOR = Color.argb(64, 150, 150, 150);
+    /**
+     * The zoom in tool.
+     */
+    private Zoom mZoomIn;
+    /**
+     * The zoom out tool.
+     */
+    private Zoom mZoomOut;
+    /**
+     * The fit zoom tool.
+     */
+    private FitZoom mFitZoom;
+    /**
+     * The paint to be used when drawing the chart.
+     */
+    private Paint mPaint = new Paint();
+    /**
+     * The touch handler.
+     */
+    private ITouchHandler mTouchHandler;
+    /**
+     * The old x coordinate.
+     */
+    private float oldX;
+    /**
+     * The old y coordinate.
+     */
+    private float oldY;
+    /**
+     * If the graphical view is drawn.
+     */
+    private boolean mDrawn;
 
-  /**
-   * Creates a new graphical view.
-   * 
-   * @param context the context
-   * @param chart the chart to be drawn
-   */
-  public GraphicalView(Context context, AbstractChart chart) {
-    super(context);
-    mChart = chart;
-    mHandler = new Handler();
-    if (mChart instanceof XYChart) {
-      mRenderer = ((XYChart) mChart).getRenderer();
-    } else {
-      mRenderer = ((RoundChart) mChart).getRenderer();
-    }
-    if (mRenderer.isZoomButtonsVisible()) {
-      zoomInImage = BitmapFactory.decodeStream(GraphicalView.class
-          .getResourceAsStream("image/zoom_in.png"));
-      zoomOutImage = BitmapFactory.decodeStream(GraphicalView.class
-          .getResourceAsStream("image/zoom_out.png"));
-      fitZoomImage = BitmapFactory.decodeStream(GraphicalView.class
-          .getResourceAsStream("image/zoom-1.png"));
+    /**
+     * Creates a new graphical view.
+     *
+     * @param context the context
+     * @param chart   the chart to be drawn
+     */
+    public GraphicalView(Context context, AbstractChart chart) {
+        super(context);
+        mChart = chart;
+        mHandler = new Handler();
+        if (mChart instanceof XYChart) {
+            mRenderer = ((XYChart) mChart).getRenderer();
+        } else {
+            mRenderer = ((RoundChart) mChart).getRenderer();
+        }
+        if (mRenderer.isZoomButtonsVisible()) {
+            zoomInImage = BitmapFactory.decodeStream(GraphicalView.class
+                    .getResourceAsStream("image/zoom_in.png"));
+            zoomOutImage = BitmapFactory.decodeStream(GraphicalView.class
+                    .getResourceAsStream("image/zoom_out.png"));
+            fitZoomImage = BitmapFactory.decodeStream(GraphicalView.class
+                    .getResourceAsStream("image/zoom-1.png"));
+        }
+
+        if (mRenderer instanceof XYMultipleSeriesRenderer
+                && ((XYMultipleSeriesRenderer) mRenderer).getMarginsColor() == XYMultipleSeriesRenderer.NO_COLOR) {
+            ((XYMultipleSeriesRenderer) mRenderer).setMarginsColor(mPaint.getColor());
+        }
+        if (mRenderer.isZoomEnabled() && mRenderer.isZoomButtonsVisible()
+                || mRenderer.isExternalZoomEnabled()) {
+            mZoomIn = new Zoom(mChart, true, mRenderer.getZoomRate());
+            mZoomOut = new Zoom(mChart, false, mRenderer.getZoomRate());
+            mFitZoom = new FitZoom(mChart);
+        }
+        int version = 7;
+        try {
+            version = Integer.valueOf(Build.VERSION.SDK);
+        } catch (Exception e) {
+            // do nothing
+        }
+        if (version < 7) {
+            mTouchHandler = new TouchHandlerOld(this, mChart);
+        } else {
+            mTouchHandler = new TouchHandler(this, mChart);
+        }
     }
 
-    if (mRenderer instanceof XYMultipleSeriesRenderer
-        && ((XYMultipleSeriesRenderer) mRenderer).getMarginsColor() == XYMultipleSeriesRenderer.NO_COLOR) {
-      ((XYMultipleSeriesRenderer) mRenderer).setMarginsColor(mPaint.getColor());
+    /**
+     * Returns the current series selection object.
+     *
+     * @return the series selection
+     */
+    public SeriesSelection getCurrentSeriesAndPoint() {
+        return mChart.getSeriesAndPointForScreenCoordinate(new Point(oldX, oldY));
     }
-    if (mRenderer.isZoomEnabled() && mRenderer.isZoomButtonsVisible()
-        || mRenderer.isExternalZoomEnabled()) {
-      mZoomIn = new Zoom(mChart, true, mRenderer.getZoomRate());
-      mZoomOut = new Zoom(mChart, false, mRenderer.getZoomRate());
-      mFitZoom = new FitZoom(mChart);
+
+    /**
+     * Returns the drawn state of the chart.
+     *
+     * @return the drawn state of the chart
+     */
+    public boolean isChartDrawn() {
+        return mDrawn;
     }
-    int version = 7;
-    try {
-      version = Integer.valueOf(Build.VERSION.SDK);
-    } catch (Exception e) {
-      // do nothing
+
+    /**
+     * Transforms the currently selected screen point to a real point.
+     *
+     * @param scale the scale
+     * @return the currently selected real point
+     */
+    public double[] toRealPoint(int scale) {
+        if (mChart instanceof XYChart) {
+            XYChart chart = (XYChart) mChart;
+            return chart.toRealPoint(oldX, oldY, scale);
+        }
+        return null;
     }
-    if (version < 7) {
-      mTouchHandler = new TouchHandlerOld(this, mChart);
-    } else {
-      mTouchHandler = new TouchHandler(this, mChart);
+
+    public AbstractChart getChart() {
+        return mChart;
     }
-  }
 
-  /**
-   * Returns the current series selection object.
-   * 
-   * @return the series selection
-   */
-  public SeriesSelection getCurrentSeriesAndPoint() {
-    return mChart.getSeriesAndPointForScreenCoordinate(new Point(oldX, oldY));
-  }
-
-  /**
-   * Returns the drawn state of the chart.
-   * 
-   * @return the drawn state of the chart
-   */
-  public boolean isChartDrawn() {
-    return mDrawn;
-  }
-
-  /**
-   * Transforms the currently selected screen point to a real point.
-   * 
-   * @param scale the scale
-   * @return the currently selected real point
-   */
-  public double[] toRealPoint(int scale) {
-    if (mChart instanceof XYChart) {
-      XYChart chart = (XYChart) mChart;
-      return chart.toRealPoint(oldX, oldY, scale);
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        canvas.getClipBounds(mRect);
+        int top = mRect.top;
+        int left = mRect.left;
+        int width = mRect.width();
+        int height = mRect.height();
+        if (mRenderer.isInScroll()) {
+            top = 0;
+            left = 0;
+            width = getMeasuredWidth();
+            height = getMeasuredHeight();
+        }
+        mChart.draw(canvas, left, top, width, height, mPaint);
+        if (mRenderer != null && mRenderer.isZoomEnabled() && mRenderer.isZoomButtonsVisible()) {
+            mPaint.setColor(ZOOM_BUTTONS_COLOR);
+            zoomSize = (int) (zoomInImage.getScaledHeight(canvas) * 2);
+            float zLeft, zTop, zRight, zBottom;
+            DefaultRenderer.Location loc = mRenderer.getZoomLocation();
+            if (loc.equals(DefaultRenderer.Location.TOP_LEFT) || loc.equals(DefaultRenderer.Location.TOP_RIGHT)) {
+                zTop = top;
+                zBottom = top + zoomSize * 0.775f;
+            } else {
+                zTop = top + height - zoomSize * 0.775f;
+                zBottom = top + height;
+            }
+            if (loc.equals(DefaultRenderer.Location.TOP_LEFT) || loc.equals(DefaultRenderer.Location.BOTTOM_LEFT)) {
+                zLeft = left;
+                zRight = left + zoomSize * 3;
+            } else {
+                zLeft = left + width - zoomSize * 3;
+                zRight = width + left;
+            }
+            mZoomR.set(zLeft, zTop, zRight, zBottom);
+            canvas.drawRoundRect(mZoomR, zoomSize / 3, zoomSize / 3, mPaint);
+            float buttonY = zBottom - zoomSize * 0.625f;
+            canvas.drawBitmap(zoomInImage, zLeft + zoomSize * 0.25f, buttonY, null);
+            canvas.drawBitmap(zoomOutImage, zLeft + zoomSize * 1.25f, buttonY, null);
+            canvas.drawBitmap(fitZoomImage, zLeft + zoomSize * 2.25f, buttonY, null);
+        }
+        mDrawn = true;
     }
-    return null;
-  }
 
-  public AbstractChart getChart() {
-    return mChart;
-  }
-
-  @Override
-  protected void onDraw(Canvas canvas) {
-    super.onDraw(canvas);
-    canvas.getClipBounds(mRect);
-    int top = mRect.top;
-    int left = mRect.left;
-    int width = mRect.width();
-    int height = mRect.height();
-    if (mRenderer.isInScroll()) {
-      top = 0;
-      left = 0;
-      width = getMeasuredWidth();
-      height = getMeasuredHeight();
+    /**
+     * Sets the zoom rate.
+     *
+     * @param rate the zoom rate
+     */
+    public void setZoomRate(float rate) {
+        if (mZoomIn != null && mZoomOut != null) {
+            mZoomIn.setZoomRate(rate);
+            mZoomOut.setZoomRate(rate);
+        }
     }
-    mChart.draw(canvas, left, top, width, height, mPaint);
-    if (mRenderer != null && mRenderer.isZoomEnabled() && mRenderer.isZoomButtonsVisible()) {
-      mPaint.setColor(ZOOM_BUTTONS_COLOR);
-      zoomSize = Math.max(zoomSize, Math.min(width, height) / 7);
-      mZoomR.set(left + width - zoomSize * 3, top + height - zoomSize * 0.775f, left + width, top
-          + height);
-      canvas.drawRoundRect(mZoomR, zoomSize / 3, zoomSize / 3, mPaint);
-      float buttonY = top + height - zoomSize * 0.625f;
-      canvas.drawBitmap(zoomInImage, left + width - zoomSize * 2.75f, buttonY, null);
-      canvas.drawBitmap(zoomOutImage, left + width - zoomSize * 1.75f, buttonY, null);
-      canvas.drawBitmap(fitZoomImage, left + width - zoomSize * 0.75f, buttonY, null);
+
+    /**
+     * Do a chart zoom in.
+     */
+    public void zoomIn() {
+        if (mZoomIn != null) {
+            mZoomIn.apply(Zoom.ZOOM_AXIS_XY);
+            repaint();
+        }
     }
-    mDrawn = true;
-  }
 
-  /**
-   * Sets the zoom rate.
-   * 
-   * @param rate the zoom rate
-   */
-  public void setZoomRate(float rate) {
-    if (mZoomIn != null && mZoomOut != null) {
-      mZoomIn.setZoomRate(rate);
-      mZoomOut.setZoomRate(rate);
+    /**
+     * Do a chart zoom out.
+     */
+    public void zoomOut() {
+        if (mZoomOut != null) {
+            mZoomOut.apply(Zoom.ZOOM_AXIS_XY);
+            repaint();
+        }
     }
-  }
 
-  /**
-   * Do a chart zoom in.
-   */
-  public void zoomIn() {
-    if (mZoomIn != null) {
-      mZoomIn.apply(Zoom.ZOOM_AXIS_XY);
-      repaint();
+    /**
+     * Do a chart zoom reset / fit zoom.
+     */
+    public void zoomReset() {
+        if (mFitZoom != null) {
+            mFitZoom.apply();
+            mZoomIn.notifyZoomResetListeners();
+            repaint();
+        }
     }
-  }
 
-  /**
-   * Do a chart zoom out.
-   */
-  public void zoomOut() {
-    if (mZoomOut != null) {
-      mZoomOut.apply(Zoom.ZOOM_AXIS_XY);
-      repaint();
+    /**
+     * Adds a new zoom listener.
+     *
+     * @param listener zoom listener
+     */
+    public void addZoomListener(ZoomListener listener, boolean onButtons, boolean onPinch) {
+        if (onButtons) {
+            if (mZoomIn != null) {
+                mZoomIn.addZoomListener(listener);
+                mZoomOut.addZoomListener(listener);
+            }
+        }
+        if (onPinch) {
+            mTouchHandler.addZoomListener(listener);
+        }
     }
-  }
 
-  /**
-   * Do a chart zoom reset / fit zoom.
-   */
-  public void zoomReset() {
-    if (mFitZoom != null) {
-      mFitZoom.apply();
-      mZoomIn.notifyZoomResetListeners();
-      repaint();
+    /**
+     * Removes a zoom listener.
+     *
+     * @param listener zoom listener
+     */
+    public synchronized void removeZoomListener(ZoomListener listener) {
+        if (mZoomIn != null) {
+            mZoomIn.removeZoomListener(listener);
+            mZoomOut.removeZoomListener(listener);
+        }
+        mTouchHandler.removeZoomListener(listener);
     }
-  }
 
-  /**
-   * Adds a new zoom listener.
-   * 
-   * @param listener zoom listener
-   */
-  public void addZoomListener(ZoomListener listener, boolean onButtons, boolean onPinch) {
-    if (onButtons) {
-      if (mZoomIn != null) {
-        mZoomIn.addZoomListener(listener);
-        mZoomOut.addZoomListener(listener);
-      }
+    /**
+     * Adds a new pan listener.
+     *
+     * @param listener pan listener
+     */
+    public void addPanListener(PanListener listener) {
+        mTouchHandler.addPanListener(listener);
     }
-    if (onPinch) {
-      mTouchHandler.addZoomListener(listener);
+
+    /**
+     * Removes a pan listener.
+     *
+     * @param listener pan listener
+     */
+    public void removePanListener(PanListener listener) {
+        mTouchHandler.removePanListener(listener);
     }
-  }
 
-  /**
-   * Removes a zoom listener.
-   * 
-   * @param listener zoom listener
-   */
-  public synchronized void removeZoomListener(ZoomListener listener) {
-    if (mZoomIn != null) {
-      mZoomIn.removeZoomListener(listener);
-      mZoomOut.removeZoomListener(listener);
+    protected RectF getZoomRectangle() {
+        return mZoomR;
     }
-    mTouchHandler.removeZoomListener(listener);
-  }
 
-  /**
-   * Adds a new pan listener.
-   * 
-   * @param listener pan listener
-   */
-  public void addPanListener(PanListener listener) {
-    mTouchHandler.addPanListener(listener);
-  }
-
-  /**
-   * Removes a pan listener.
-   * 
-   * @param listener pan listener
-   */
-  public void removePanListener(PanListener listener) {
-    mTouchHandler.removePanListener(listener);
-  }
-
-  protected RectF getZoomRectangle() {
-    return mZoomR;
-  }
-
-  @Override
-  public boolean onTouchEvent(MotionEvent event) {
-    if (event.getAction() == MotionEvent.ACTION_DOWN) {
-      // save the x and y so they can be used in the click and long press
-      // listeners
-      oldX = event.getX();
-      oldY = event.getY();
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            // save the x and y so they can be used in the click and long press
+            // listeners
+            oldX = event.getX();
+            oldY = event.getY();
+        }
+        if (mRenderer != null && mDrawn && (mRenderer.isPanEnabled() || mRenderer.isZoomEnabled())) {
+            if (mTouchHandler.handleTouch(event)) {
+                return true;
+            }
+        }
+        return super.onTouchEvent(event);
     }
-    if (mRenderer != null && mDrawn && (mRenderer.isPanEnabled() || mRenderer.isZoomEnabled())) {
-      if (mTouchHandler.handleTouch(event)) {
-        return true;
-      }
-    }
-    return super.onTouchEvent(event);
-  }
 
-  /**
-   * Schedule a view content repaint.
-   */
-  public void repaint() {
-    mHandler.post(new Runnable() {
-      public void run() {
-        invalidate();
-      }
-    });
-  }
-
-  /**
-   * Schedule a view content repaint, in the specified rectangle area.
-   * 
-   * @param left the left position of the area to be repainted
-   * @param top the top position of the area to be repainted
-   * @param right the right position of the area to be repainted
-   * @param bottom the bottom position of the area to be repainted
-   */
-  public void repaint(final int left, final int top, final int right, final int bottom) {
-    mHandler.post(new Runnable() {
-      public void run() {
-        invalidate(left, top, right, bottom);
-      }
-    });
-  }
-
-  /**
-   * Saves the content of the graphical view to a bitmap.
-   * 
-   * @return the bitmap
-   */
-  public Bitmap toBitmap() {
-    setDrawingCacheEnabled(false);
-    if (!isDrawingCacheEnabled()) {
-      setDrawingCacheEnabled(true);
+    /**
+     * Schedule a view content repaint.
+     */
+    public void repaint() {
+        mHandler.post(new Runnable() {
+            public void run() {
+                invalidate();
+            }
+        });
     }
-    if (mRenderer.isApplyBackgroundColor()) {
-      setDrawingCacheBackgroundColor(mRenderer.getBackgroundColor());
+
+    /**
+     * Schedule a view content repaint, in the specified rectangle area.
+     *
+     * @param left   the left position of the area to be repainted
+     * @param top    the top position of the area to be repainted
+     * @param right  the right position of the area to be repainted
+     * @param bottom the bottom position of the area to be repainted
+     */
+    public void repaint(final int left, final int top, final int right, final int bottom) {
+        mHandler.post(new Runnable() {
+            public void run() {
+                invalidate(left, top, right, bottom);
+            }
+        });
     }
-    setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
-    return getDrawingCache(true);
-  }
+
+    /**
+     * Saves the content of the graphical view to a bitmap.
+     *
+     * @return the bitmap
+     */
+    public Bitmap toBitmap() {
+        setDrawingCacheEnabled(false);
+        if (!isDrawingCacheEnabled()) {
+            setDrawingCacheEnabled(true);
+        }
+        if (mRenderer.isApplyBackgroundColor()) {
+            setDrawingCacheBackgroundColor(mRenderer.getBackgroundColor());
+        }
+        setDrawingCacheQuality(View.DRAWING_CACHE_QUALITY_HIGH);
+        return getDrawingCache(true);
+    }
 
 }

--- a/libraries/achartengine/achartengine/src/org/achartengine/renderer/DefaultRenderer.java
+++ b/libraries/achartengine/achartengine/src/org/achartengine/renderer/DefaultRenderer.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2009 - 2013 SC 4ViewSoft SRL
- *  
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
- *      http://www.apache.org/licenses/LICENSE-2.0
- *  
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,852 +15,961 @@
  */
 package org.achartengine.renderer;
 
+import android.graphics.Color;
+import android.graphics.Typeface;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import android.graphics.Color;
-import android.graphics.Typeface;
 
 /**
  * An abstract renderer to be extended by the multiple series classes.
  */
 public class DefaultRenderer implements Serializable {
-  /** The chart title. */
-  private String mChartTitle = "";
-  /** The chart title text size. */
-  private float mChartTitleTextSize = 15;
-  /** A no color constant. */
-  public static final int NO_COLOR = 0;
-  /** The default background color. */
-  public static final int BACKGROUND_COLOR = Color.BLACK;
-  /** The default color for text. */
-  public static final int TEXT_COLOR = Color.LTGRAY;
-  /** A text font for regular text, like the chart labels. */
-  private static final Typeface REGULAR_TEXT_FONT = Typeface
-      .create(Typeface.SERIF, Typeface.NORMAL);
-  /** The typeface name for the texts. */
-  private String mTextTypefaceName = REGULAR_TEXT_FONT.toString();
-  /** The typeface style for the texts. */
-  private int mTextTypefaceStyle = Typeface.NORMAL;
-  /** The typeface for the texts */
-  private Typeface mTextTypeface;
-  /** The chart background color. */
-  private int mBackgroundColor;
-  /** If the background color is applied. */
-  private boolean mApplyBackgroundColor;
-  /** If the axes are visible. */
-  private boolean mShowAxes = true;
-  /** The Y axis color. */
-  private int mYAxisColor = TEXT_COLOR;
-  /** The X axis color. */
-  private int mXAxisColor = TEXT_COLOR;
-  /** If the labels are visible. */
-  private boolean mShowLabels = true;
-  /** If the tick marks are visible. */
-  private boolean mShowTickMarks = true;
-  /** The labels color. */
-  private int mLabelsColor = TEXT_COLOR;
-  /** The labels text size. */
-  private float mLabelsTextSize = 10;
-  /** If the legend is visible. */
-  private boolean mShowLegend = true;
-  /** The legend text size. */
-  private float mLegendTextSize = 12;
-  /** If the legend should size to fit. */
-  private boolean mFitLegend = false;
-  /** If the X axis grid should be displayed. */
-  private boolean mShowGridX = false;
-  /** If the Y axis grid should be displayed. */
-  private boolean mShowGridY = false;
-  /** If the custom text grid should be displayed on the X axis. */
-  private boolean mShowCustomTextGridX = false;
-  /** If the custom text grid should be displayed on the Y axis. */
-  private boolean mShowCustomTextGridY = false;
-  /** The simple renderers that are included in this multiple series renderer. */
-  private List<SimpleSeriesRenderer> mRenderers = new ArrayList<SimpleSeriesRenderer>();
-  /** The antialiasing flag. */
-  private boolean mAntialiasing = true;
-  /** The legend height. */
-  private int mLegendHeight = 0;
-  /** The margins size. */
-  private int[] mMargins = new int[] { 20, 30, 10, 20 };
-  /** A value to be used for scaling the chart. */
-  private float mScale = 1;
-  /** A flag for enabling the pan. */
-  private boolean mPanEnabled = true;
-  /** A flag for enabling the zoom. */
-  private boolean mZoomEnabled = true;
-  /** A flag for enabling the visibility of the zoom buttons. */
-  private boolean mZoomButtonsVisible = false;
-  /** The zoom rate. */
-  private float mZoomRate = 1.5f;
-  /** A flag for enabling the external zoom. */
-  private boolean mExternalZoomEnabled = false;
-  /** The original chart scale. */
-  private float mOriginalScale = mScale;
-  /** A flag for enabling the click on elements. */
-  private boolean mClickEnabled = false;
-  /** The selectable radius around a clickable point. */
-  private int selectableBuffer = 15;
-  /** If the chart should display the values (available for pie chart). */
-  private boolean mDisplayValues;
+    /**
+     * The chart title.
+     */
+    private String mChartTitle = "";
+    /**
+     * The chart title text size.
+     */
+    private float mChartTitleTextSize = 15;
+    /**
+     * A no color constant.
+     */
+    public static final int NO_COLOR = 0;
+    /**
+     * The default background color.
+     */
+    public static final int BACKGROUND_COLOR = Color.BLACK;
+    /**
+     * The default color for text.
+     */
+    public static final int TEXT_COLOR = Color.LTGRAY;
+    /**
+     * A text font for regular text, like the chart labels.
+     */
+    private static final Typeface REGULAR_TEXT_FONT = Typeface
+            .create(Typeface.SERIF, Typeface.NORMAL);
+    /**
+     * The typeface name for the texts.
+     */
+    private String mTextTypefaceName = REGULAR_TEXT_FONT.toString();
+    /**
+     * The typeface style for the texts.
+     */
+    private int mTextTypefaceStyle = Typeface.NORMAL;
+    /**
+     * The typeface for the texts
+     */
+    private Typeface mTextTypeface;
+    /**
+     * The chart background color.
+     */
+    private int mBackgroundColor;
+    /**
+     * If the background color is applied.
+     */
+    private boolean mApplyBackgroundColor;
+    /**
+     * If the axes are visible.
+     */
+    private boolean mShowAxes = true;
+    /**
+     * The Y axis color.
+     */
+    private int mYAxisColor = TEXT_COLOR;
+    /**
+     * The X axis color.
+     */
+    private int mXAxisColor = TEXT_COLOR;
+    /**
+     * If the labels are visible.
+     */
+    private boolean mShowLabels = true;
+    /**
+     * If the tick marks are visible.
+     */
+    private boolean mShowTickMarks = true;
+    /**
+     * The labels color.
+     */
+    private int mLabelsColor = TEXT_COLOR;
+    /**
+     * The labels text size.
+     */
+    private float mLabelsTextSize = 10;
+    /**
+     * If the legend is visible.
+     */
+    private boolean mShowLegend = true;
+    /**
+     * The legend text size.
+     */
+    private float mLegendTextSize = 12;
+    /**
+     * If the legend should size to fit.
+     */
+    private boolean mFitLegend = false;
+    /**
+     * If the X axis grid should be displayed.
+     */
+    private boolean mShowGridX = false;
+    /**
+     * If the Y axis grid should be displayed.
+     */
+    private boolean mShowGridY = false;
+    /**
+     * If the custom text grid should be displayed on the X axis.
+     */
+    private boolean mShowCustomTextGridX = false;
+    /**
+     * If the custom text grid should be displayed on the Y axis.
+     */
+    private boolean mShowCustomTextGridY = false;
+    /**
+     * The simple renderers that are included in this multiple series renderer.
+     */
+    private List<SimpleSeriesRenderer> mRenderers = new ArrayList<SimpleSeriesRenderer>();
+    /**
+     * The antialiasing flag.
+     */
+    private boolean mAntialiasing = true;
+    /**
+     * The legend height.
+     */
+    private int mLegendHeight = 0;
+    /**
+     * The margins size.
+     */
+    private int[] mMargins = new int[]{20, 30, 10, 20};
+    /**
+     * A value to be used for scaling the chart.
+     */
+    private float mScale = 1;
+    /**
+     * A flag for enabling the pan.
+     */
+    private boolean mPanEnabled = true;
+    /**
+     * A flag for enabling the zoom.
+     */
+    private boolean mZoomEnabled = true;
+    /**
+     * The corner in which to draw zoom controls
+     */
+    private Location mZoomLocation = Location.BOTTOM_RIGHT;
+    /**
+     * A flag for enabling the visibility of the zoom buttons.
+     */
+    private boolean mZoomButtonsVisible = false;
+    /**
+     * The zoom rate.
+     */
+    private float mZoomRate = 1.5f;
+    /**
+     * A flag for enabling the external zoom.
+     */
+    private boolean mExternalZoomEnabled = false;
+    /**
+     * The original chart scale.
+     */
+    private float mOriginalScale = mScale;
+    /**
+     * A flag for enabling the click on elements.
+     */
+    private boolean mClickEnabled = false;
+    /**
+     * The selectable radius around a clickable point.
+     */
+    private int selectableBuffer = 15;
+    /**
+     * If the chart should display the values (available for pie chart).
+     */
+    private boolean mDisplayValues;
 
-  /**
-   * A flag to be set if the chart is inside a scroll and doesn't need to shrink
-   * when not enough space.
-   */
-  private boolean mInScroll;
-  /** The start angle for circular charts such as pie, doughnut, etc. */
-  private float mStartAngle = 0;
+    /**
+     * A flag to be set if the chart is inside a scroll and doesn't need to shrink
+     * when not enough space.
+     */
+    private boolean mInScroll;
+    /**
+     * The start angle for circular charts such as pie, doughnut, etc.
+     */
+    private float mStartAngle = 0;
 
-  /**
-   * Returns the chart title.
-   * 
-   * @return the chart title
-   */
-  public String getChartTitle() {
-    return mChartTitle;
-  }
-
-  /**
-   * Sets the chart title.
-   * 
-   * @param title the chart title
-   */
-  public void setChartTitle(String title) {
-    mChartTitle = title;
-  }
-
-  /**
-   * Returns the chart title text size.
-   * 
-   * @return the chart title text size
-   */
-  public float getChartTitleTextSize() {
-    return mChartTitleTextSize;
-  }
-
-  /**
-   * Sets the chart title text size.
-   * 
-   * @param textSize the chart title text size
-   */
-  public void setChartTitleTextSize(float textSize) {
-    mChartTitleTextSize = textSize;
-  }
-
-  /**
-   * Adds a simple renderer to the multiple renderer.
-   * 
-   * @param renderer the renderer to be added
-   */
-  public void addSeriesRenderer(SimpleSeriesRenderer renderer) {
-    mRenderers.add(renderer);
-  }
-
-  /**
-   * Adds a simple renderer to the multiple renderer.
-   * 
-   * @param index the index in the renderers list
-   * @param renderer the renderer to be added
-   */
-  public void addSeriesRenderer(int index, SimpleSeriesRenderer renderer) {
-    mRenderers.add(index, renderer);
-  }
-
-  /**
-   * Removes a simple renderer from the multiple renderer.
-   * 
-   * @param renderer the renderer to be removed
-   */
-  public void removeSeriesRenderer(SimpleSeriesRenderer renderer) {
-    mRenderers.remove(renderer);
-  }
-
-  /**
-   * Removes all renderers from the multiple renderer.
-   */
-  public void removeAllRenderers() {
-    mRenderers.clear();
-  }
-
-  /**
-   * Returns the simple renderer from the multiple renderer list.
-   * 
-   * @param index the index in the simple renderers list
-   * @return the simple renderer at the specified index
-   */
-  public SimpleSeriesRenderer getSeriesRendererAt(int index) {
-    return mRenderers.get(index);
-  }
-
-  /**
-   * Returns the simple renderers count in the multiple renderer list.
-   * 
-   * @return the simple renderers count
-   */
-  public int getSeriesRendererCount() {
-    return mRenderers.size();
-  }
-
-  /**
-   * Returns an array of the simple renderers in the multiple renderer list.
-   * 
-   * @return the simple renderers array
-   */
-  public SimpleSeriesRenderer[] getSeriesRenderers() {
-    return mRenderers.toArray(new SimpleSeriesRenderer[0]);
-  }
-
-  /**
-   * Returns the background color.
-   * 
-   * @return the background color
-   */
-  public int getBackgroundColor() {
-    return mBackgroundColor;
-  }
-
-  /**
-   * Sets the background color.
-   * 
-   * @param color the background color
-   */
-  public void setBackgroundColor(int color) {
-    mBackgroundColor = color;
-  }
-
-  /**
-   * Returns if the background color should be applied.
-   * 
-   * @return the apply flag for the background color.
-   */
-  public boolean isApplyBackgroundColor() {
-    return mApplyBackgroundColor;
-  }
-
-  /**
-   * Sets if the background color should be applied.
-   * 
-   * @param apply the apply flag for the background color
-   */
-  public void setApplyBackgroundColor(boolean apply) {
-    mApplyBackgroundColor = apply;
-  }
-
-  /**
-   * Returns the axes color.
-   * 
-   * @return the axes color
-   */
-  public int getAxesColor() {
-    if (mXAxisColor != TEXT_COLOR) {
-      return mXAxisColor;
-    } else {
-      return mYAxisColor;
+    /**
+     * Returns the chart title.
+     *
+     * @return the chart title
+     */
+    public String getChartTitle() {
+        return mChartTitle;
     }
-  }
 
-  /**
-   * Sets the axes color.
-   * 
-   * @param color the axes color
-   */
-  public void setAxesColor(int color) {
-    this.setXAxisColor(color);
-    this.setYAxisColor(color);
-  }
-
-  /**
-   * Returns the color of the Y axis
-   * 
-   * @return the Y axis color
-   */
-  public int getYAxisColor() {
-    return mYAxisColor;
-  }
-
-  /**
-   * Sets the Y axis color.
-   * 
-   * @param color the Y axis color
-   */
-  public void setYAxisColor(int color) {
-    mYAxisColor = color;
-  }
-
-  /**
-   * Returns the color of the X axis
-   * 
-   * @return the X axis color
-   */
-  public int getXAxisColor() {
-    return mXAxisColor;
-  }
-
-  /**
-   * Sets the X axis color.
-   * 
-   * @param color the X axis color
-   */
-  public void setXAxisColor(int color) {
-    mXAxisColor = color;
-  }
-
-  /**
-   * Returns the labels color.
-   * 
-   * @return the labels color
-   */
-  public int getLabelsColor() {
-    return mLabelsColor;
-  }
-
-  /**
-   * Sets the labels color.
-   * 
-   * @param color the labels color
-   */
-  public void setLabelsColor(int color) {
-    mLabelsColor = color;
-  }
-
-  /**
-   * Returns the labels text size.
-   * 
-   * @return the labels text size
-   */
-  public float getLabelsTextSize() {
-    return mLabelsTextSize;
-  }
-
-  /**
-   * Sets the labels text size.
-   * 
-   * @param textSize the labels text size
-   */
-  public void setLabelsTextSize(float textSize) {
-    mLabelsTextSize = textSize;
-  }
-
-  /**
-   * Returns if the axes should be visible.
-   * 
-   * @return the visibility flag for the axes
-   */
-  public boolean isShowAxes() {
-    return mShowAxes;
-  }
-
-  /**
-   * Sets if the axes should be visible.
-   * 
-   * @param showAxes the visibility flag for the axes
-   */
-  public void setShowAxes(boolean showAxes) {
-    mShowAxes = showAxes;
-  }
-
-  /**
-   * Returns if the labels should be visible.
-   * 
-   * @return the visibility flag for the labels
-   */
-  public boolean isShowLabels() {
-    return mShowLabels;
-  }
-
-  /**
-   * Sets if the labels should be visible.
-   * 
-   * @param showLabels the visibility flag for the labels
-   */
-  public void setShowLabels(boolean showLabels) {
-    mShowLabels = showLabels;
-  }
-
-  /**
-   * Returns if the tick marks should be visible.
-   * 
-   * @return
-   */
-  public boolean isShowTickMarks() {
-    return mShowTickMarks;
-  }
-
-  /**
-   * Sets if the tick marks should be visible.
-   * 
-   * @param showTickMarks the visibility flag for the tick marks
-   */
-  public void setShowTickMarks(boolean mShowTickMarks) {
-    this.mShowTickMarks = mShowTickMarks;
-  }
-
-  /**
-   * Returns if the X axis grid should be visible.
-   * 
-   * @return the visibility flag for the X axis grid
-   */
-  public boolean isShowGridX() {
-    return mShowGridX;
-  }
-
-  /**
-   * Returns if the Y axis grid should be visible.
-   * 
-   * @return the visibility flag for the Y axis grid
-   */
-  public boolean isShowGridY() {
-    return mShowGridY;
-  }
-
-  /**
-   * Sets if the X axis grid should be visible.
-   * 
-   * @param showGrid the visibility flag for the X axis grid
-   */
-  public void setShowGridX(boolean showGrid) {
-    mShowGridX = showGrid;
-  }
-
-  /**
-   * Sets if the Y axis grid should be visible.
-   * 
-   * @param showGrid the visibility flag for the Y axis grid
-   */
-  public void setShowGridY(boolean showGrid) {
-    mShowGridY = showGrid;
-  }
-
-  /**
-   * Sets if the grid should be visible.
-   * 
-   * @param showGrid the visibility flag for the grid
-   */
-  public void setShowGrid(boolean showGrid) {
-    setShowGridX(showGrid);
-    setShowGridY(showGrid);
-  }
-
-  /**
-   * Returns if the X axis custom text grid should be visible.
-   * 
-   * @return the visibility flag for the X axis custom text grid
-   */
-  public boolean isShowCustomTextGridX() {
-    return mShowCustomTextGridX;
-  }
-
-  /**
-   * Returns if the Y axis custom text grid should be visible.
-   * 
-   * @return the visibility flag for the custom text Y axis grid
-   */
-  public boolean isShowCustomTextGridY() {
-    return mShowCustomTextGridY;
-  }
-
-  /**
-   * Sets if the X axis custom text grid should be visible.
-   * 
-   * @param showGrid the visibility flag for the X axis custom text grid
-   */
-  public void setShowCustomTextGridX(boolean showGrid) {
-    mShowCustomTextGridX = showGrid;
-  }
-
-  /**
-   * Sets if the Y axis custom text grid should be visible.
-   * 
-   * @param showGrid the visibility flag for the Y axis custom text grid
-   */
-  public void setShowCustomTextGridY(boolean showGrid) {
-    mShowCustomTextGridY = showGrid;
-  }
-
-  /**
-   * Sets if the grid for custom X or Y labels should be visible.
-   * 
-   * @param showGrid the visibility flag for the custom text grid
-   */
-  public void setShowCustomTextGrid(boolean showGrid) {
-    setShowCustomTextGridX(showGrid);
-    setShowCustomTextGridY(showGrid);
-  }
-
-  /**
-   * Returns if the legend should be visible.
-   * 
-   * @return the visibility flag for the legend
-   */
-  public boolean isShowLegend() {
-    return mShowLegend;
-  }
-
-  /**
-   * Sets if the legend should be visible.
-   * 
-   * @param showLegend the visibility flag for the legend
-   */
-  public void setShowLegend(boolean showLegend) {
-    mShowLegend = showLegend;
-  }
-
-  /**
-   * Returns if the legend should size to fit.
-   * 
-   * @return the fit behavior
-   */
-  public boolean isFitLegend() {
-    return mFitLegend;
-  }
-
-  /**
-   * Sets if the legend should size to fit.
-   * 
-   * @param fit the fit behavior
-   */
-  public void setFitLegend(boolean fit) {
-    mFitLegend = fit;
-  }
-
-  /**
-   * Returns the text typeface name.
-   * 
-   * @return the text typeface name
-   */
-  public String getTextTypefaceName() {
-    return mTextTypefaceName;
-  }
-
-  /**
-   * Returns the text typeface style.
-   * 
-   * @return the text typeface style
-   */
-  public int getTextTypefaceStyle() {
-    return mTextTypefaceStyle;
-  }
-
-  /**
-   * Returns the text typeface.
-   * 
-   * @return the text typeface
-   */
-  public Typeface getTextTypeface() {
-    return mTextTypeface;
-  }
-
-  /**
-   * Returns the legend text size.
-   * 
-   * @return the legend text size
-   */
-  public float getLegendTextSize() {
-    return mLegendTextSize;
-  }
-
-  /**
-   * Sets the legend text size.
-   * 
-   * @param textSize the legend text size
-   */
-  public void setLegendTextSize(float textSize) {
-    mLegendTextSize = textSize;
-  }
-
-  /**
-   * Sets the text typeface name and style.
-   * 
-   * @param typefaceName the text typeface name
-   * @param style the text typeface style
-   */
-  public void setTextTypeface(String typefaceName, int style) {
-    mTextTypefaceName = typefaceName;
-    mTextTypefaceStyle = style;
-  }
-
-  /**
-   * Sets the text typeface.
-   * 
-   * @param typeface the typeface
-   */
-  public void setTextTypeface(Typeface typeface) {
-    mTextTypeface = typeface;
-  }
-
-  /**
-   * Returns the antialiasing flag value.
-   * 
-   * @return the antialiasing value
-   */
-  public boolean isAntialiasing() {
-    return mAntialiasing;
-  }
-
-  /**
-   * Sets the antialiasing value.
-   * 
-   * @param antialiasing the antialiasing
-   */
-  public void setAntialiasing(boolean antialiasing) {
-    mAntialiasing = antialiasing;
-  }
-
-  /**
-   * Returns the value to be used for scaling the chart.
-   * 
-   * @return the scale value
-   */
-  public float getScale() {
-    return mScale;
-  }
-
-  /**
-   * Returns the original value to be used for scaling the chart.
-   * 
-   * @return the original scale value
-   */
-  public float getOriginalScale() {
-    return mOriginalScale;
-  }
-
-  /**
-   * Sets the value to be used for scaling the chart. It works on some charts
-   * like pie, doughnut, dial.
-   * 
-   * @param scale the scale value
-   */
-  public void setScale(float scale) {
-    mScale = scale;
-  }
-
-  /**
-   * Returns the enabled state of the zoom.
-   * 
-   * @return if zoom is enabled
-   */
-  public boolean isZoomEnabled() {
-    return mZoomEnabled;
-  }
-
-  /**
-   * Sets the enabled state of the zoom.
-   * 
-   * @param enabled zoom enabled
-   */
-  public void setZoomEnabled(boolean enabled) {
-    mZoomEnabled = enabled;
-  }
-
-  /**
-   * Returns the visible state of the zoom buttons.
-   * 
-   * @return if zoom buttons are visible
-   */
-  public boolean isZoomButtonsVisible() {
-    return mZoomButtonsVisible;
-  }
-
-  /**
-   * Sets the visible state of the zoom buttons.
-   * 
-   * @param visible if the zoom buttons are visible
-   */
-  public void setZoomButtonsVisible(boolean visible) {
-    mZoomButtonsVisible = visible;
-  }
-
-  /**
-   * Returns the enabled state of the external (application implemented) zoom.
-   * 
-   * @return if external zoom is enabled
-   */
-  public boolean isExternalZoomEnabled() {
-    return mExternalZoomEnabled;
-  }
-
-  /**
-   * Sets the enabled state of the external (application implemented) zoom.
-   * 
-   * @param enabled external zoom enabled
-   */
-  public void setExternalZoomEnabled(boolean enabled) {
-    mExternalZoomEnabled = enabled;
-  }
-
-  /**
-   * Returns the zoom rate.
-   * 
-   * @return the zoom rate
-   */
-  public float getZoomRate() {
-    return mZoomRate;
-  }
-
-  /**
-   * Returns the enabled state of the pan.
-   * 
-   * @return if pan is enabled
-   */
-  public boolean isPanEnabled() {
-    return mPanEnabled;
-  }
-
-  /**
-   * Sets the enabled state of the pan.
-   * 
-   * @param enabled pan enabled
-   */
-  public void setPanEnabled(boolean enabled) {
-    mPanEnabled = enabled;
-  }
-
-  /**
-   * Sets the zoom rate.
-   * 
-   * @param rate the zoom rate
-   */
-  public void setZoomRate(float rate) {
-    mZoomRate = rate;
-  }
-
-  /**
-   * Returns the enabled state of the click.
-   * 
-   * @return if click is enabled
-   */
-  public boolean isClickEnabled() {
-    return mClickEnabled;
-  }
-
-  /**
-   * Sets the enabled state of the click.
-   * 
-   * @param enabled click enabled
-   */
-  public void setClickEnabled(boolean enabled) {
-    mClickEnabled = enabled;
-  }
-
-  /**
-   * Returns the selectable radius value around clickable points.
-   * 
-   * @return the selectable radius
-   */
-  public int getSelectableBuffer() {
-    return selectableBuffer;
-  }
-
-  /**
-   * Sets the selectable radius value around clickable points.
-   * 
-   * @param buffer the selectable radius
-   */
-  public void setSelectableBuffer(int buffer) {
-    selectableBuffer = buffer;
-  }
-
-  /**
-   * Returns the legend height.
-   * 
-   * @return the legend height
-   */
-  public int getLegendHeight() {
-    return mLegendHeight;
-  }
-
-  /**
-   * Sets the legend height, in pixels.
-   * 
-   * @param height the legend height
-   */
-  public void setLegendHeight(int height) {
-    mLegendHeight = height;
-  }
-
-  /**
-   * Returns the margin sizes. An array containing the margins in this order:
-   * top, left, bottom, right
-   * 
-   * @return the margin sizes
-   */
-  public int[] getMargins() {
-    return mMargins;
-  }
-
-  /**
-   * Sets the margins, in pixels.
-   * 
-   * @param margins an array containing the margin size values, in this order:
-   *          top, left, bottom, right
-   */
-  public void setMargins(int[] margins) {
-    mMargins = margins;
-  }
-
-  /**
-   * Returns if the chart is inside a scroll view and doesn't need to shrink.
-   * 
-   * @return if it is inside a scroll view
-   */
-  public boolean isInScroll() {
-    return mInScroll;
-  }
-
-  /**
-   * To be set if the chart is inside a scroll view and doesn't need to shrink
-   * when not enough space.
-   * 
-   * @param inScroll if it is inside a scroll view
-   */
-  public void setInScroll(boolean inScroll) {
-    mInScroll = inScroll;
-  }
-
-  /**
-   * Returns the start angle for circular charts such as pie, doughnut. An angle
-   * of 0 degrees correspond to the geometric angle of 0 degrees (3 o'clock on a
-   * watch.)
-   * 
-   * @return the start angle in degrees
-   */
-  public float getStartAngle() {
-    return mStartAngle;
-  }
-
-  /**
-   * Sets the start angle for circular charts such as pie, doughnut, etc. An
-   * angle of 0 degrees correspond to the geometric angle of 0 degrees (3
-   * o'clock on a watch.)
-   * 
-   * @param startAngle the start angle in degrees
-   */
-  public void setStartAngle(float startAngle) {
-    while (startAngle < 0) {
-      startAngle += 360;
+    /**
+     * Sets the chart title.
+     *
+     * @param title the chart title
+     */
+    public void setChartTitle(String title) {
+        mChartTitle = title;
     }
-    mStartAngle = startAngle;
-  }
 
-  /**
-   * Returns if the values should be displayed as text.
-   * 
-   * @return if the values should be displayed as text
-   */
-  public boolean isDisplayValues() {
-    return mDisplayValues;
-  }
+    /**
+     * Returns the chart title text size.
+     *
+     * @return the chart title text size
+     */
+    public float getChartTitleTextSize() {
+        return mChartTitleTextSize;
+    }
 
-  /**
-   * Sets if the values should be displayed as text (supported by pie chart).
-   * 
-   * @param display if the values should be displayed as text
-   */
-  public void setDisplayValues(boolean display) {
-    mDisplayValues = display;
-  }
+    /**
+     * Sets the chart title text size.
+     *
+     * @param textSize the chart title text size
+     */
+    public void setChartTitleTextSize(float textSize) {
+        mChartTitleTextSize = textSize;
+    }
+
+    /**
+     * Adds a simple renderer to the multiple renderer.
+     *
+     * @param renderer the renderer to be added
+     */
+    public void addSeriesRenderer(SimpleSeriesRenderer renderer) {
+        mRenderers.add(renderer);
+    }
+
+    /**
+     * Adds a simple renderer to the multiple renderer.
+     *
+     * @param index    the index in the renderers list
+     * @param renderer the renderer to be added
+     */
+    public void addSeriesRenderer(int index, SimpleSeriesRenderer renderer) {
+        mRenderers.add(index, renderer);
+    }
+
+    /**
+     * Removes a simple renderer from the multiple renderer.
+     *
+     * @param renderer the renderer to be removed
+     */
+    public void removeSeriesRenderer(SimpleSeriesRenderer renderer) {
+        mRenderers.remove(renderer);
+    }
+
+    /**
+     * Removes all renderers from the multiple renderer.
+     */
+    public void removeAllRenderers() {
+        mRenderers.clear();
+    }
+
+    /**
+     * Returns the simple renderer from the multiple renderer list.
+     *
+     * @param index the index in the simple renderers list
+     * @return the simple renderer at the specified index
+     */
+    public SimpleSeriesRenderer getSeriesRendererAt(int index) {
+        return mRenderers.get(index);
+    }
+
+    /**
+     * Returns the simple renderers count in the multiple renderer list.
+     *
+     * @return the simple renderers count
+     */
+    public int getSeriesRendererCount() {
+        return mRenderers.size();
+    }
+
+    /**
+     * Returns an array of the simple renderers in the multiple renderer list.
+     *
+     * @return the simple renderers array
+     */
+    public SimpleSeriesRenderer[] getSeriesRenderers() {
+        return mRenderers.toArray(new SimpleSeriesRenderer[0]);
+    }
+
+    /**
+     * Returns the background color.
+     *
+     * @return the background color
+     */
+    public int getBackgroundColor() {
+        return mBackgroundColor;
+    }
+
+    /**
+     * Sets the background color.
+     *
+     * @param color the background color
+     */
+    public void setBackgroundColor(int color) {
+        mBackgroundColor = color;
+    }
+
+    /**
+     * Returns if the background color should be applied.
+     *
+     * @return the apply flag for the background color.
+     */
+    public boolean isApplyBackgroundColor() {
+        return mApplyBackgroundColor;
+    }
+
+    /**
+     * Sets if the background color should be applied.
+     *
+     * @param apply the apply flag for the background color
+     */
+    public void setApplyBackgroundColor(boolean apply) {
+        mApplyBackgroundColor = apply;
+    }
+
+    /**
+     * Returns the axes color.
+     *
+     * @return the axes color
+     */
+    public int getAxesColor() {
+        if (mXAxisColor != TEXT_COLOR) {
+            return mXAxisColor;
+        } else {
+            return mYAxisColor;
+        }
+    }
+
+    /**
+     * Sets the axes color.
+     *
+     * @param color the axes color
+     */
+    public void setAxesColor(int color) {
+        this.setXAxisColor(color);
+        this.setYAxisColor(color);
+    }
+
+    /**
+     * Returns the color of the Y axis
+     *
+     * @return the Y axis color
+     */
+    public int getYAxisColor() {
+        return mYAxisColor;
+    }
+
+    /**
+     * Sets the Y axis color.
+     *
+     * @param color the Y axis color
+     */
+    public void setYAxisColor(int color) {
+        mYAxisColor = color;
+    }
+
+    /**
+     * Returns the color of the X axis
+     *
+     * @return the X axis color
+     */
+    public int getXAxisColor() {
+        return mXAxisColor;
+    }
+
+    /**
+     * Sets the X axis color.
+     *
+     * @param color the X axis color
+     */
+    public void setXAxisColor(int color) {
+        mXAxisColor = color;
+    }
+
+    /**
+     * Returns the labels color.
+     *
+     * @return the labels color
+     */
+    public int getLabelsColor() {
+        return mLabelsColor;
+    }
+
+    /**
+     * Sets the labels color.
+     *
+     * @param color the labels color
+     */
+    public void setLabelsColor(int color) {
+        mLabelsColor = color;
+    }
+
+    /**
+     * Returns the labels text size.
+     *
+     * @return the labels text size
+     */
+    public float getLabelsTextSize() {
+        return mLabelsTextSize;
+    }
+
+    /**
+     * Sets the labels text size.
+     *
+     * @param textSize the labels text size
+     */
+    public void setLabelsTextSize(float textSize) {
+        mLabelsTextSize = textSize;
+    }
+
+    /**
+     * Returns if the axes should be visible.
+     *
+     * @return the visibility flag for the axes
+     */
+    public boolean isShowAxes() {
+        return mShowAxes;
+    }
+
+    /**
+     * Sets if the axes should be visible.
+     *
+     * @param showAxes the visibility flag for the axes
+     */
+    public void setShowAxes(boolean showAxes) {
+        mShowAxes = showAxes;
+    }
+
+    /**
+     * Returns if the labels should be visible.
+     *
+     * @return the visibility flag for the labels
+     */
+    public boolean isShowLabels() {
+        return mShowLabels;
+    }
+
+    /**
+     * Sets if the labels should be visible.
+     *
+     * @param showLabels the visibility flag for the labels
+     */
+    public void setShowLabels(boolean showLabels) {
+        mShowLabels = showLabels;
+    }
+
+    /**
+     * Returns if the tick marks should be visible.
+     *
+     * @return
+     */
+    public boolean isShowTickMarks() {
+        return mShowTickMarks;
+    }
+
+    /**
+     * Sets if the tick marks should be visible.
+     *
+     * @param showTickMarks the visibility flag for the tick marks
+     */
+    public void setShowTickMarks(boolean mShowTickMarks) {
+        this.mShowTickMarks = mShowTickMarks;
+    }
+
+    /**
+     * Returns if the X axis grid should be visible.
+     *
+     * @return the visibility flag for the X axis grid
+     */
+    public boolean isShowGridX() {
+        return mShowGridX;
+    }
+
+    /**
+     * Returns if the Y axis grid should be visible.
+     *
+     * @return the visibility flag for the Y axis grid
+     */
+    public boolean isShowGridY() {
+        return mShowGridY;
+    }
+
+    /**
+     * Sets if the X axis grid should be visible.
+     *
+     * @param showGrid the visibility flag for the X axis grid
+     */
+    public void setShowGridX(boolean showGrid) {
+        mShowGridX = showGrid;
+    }
+
+    /**
+     * Sets if the Y axis grid should be visible.
+     *
+     * @param showGrid the visibility flag for the Y axis grid
+     */
+    public void setShowGridY(boolean showGrid) {
+        mShowGridY = showGrid;
+    }
+
+    /**
+     * Sets if the grid should be visible.
+     *
+     * @param showGrid the visibility flag for the grid
+     */
+    public void setShowGrid(boolean showGrid) {
+        setShowGridX(showGrid);
+        setShowGridY(showGrid);
+    }
+
+    /**
+     * Returns if the X axis custom text grid should be visible.
+     *
+     * @return the visibility flag for the X axis custom text grid
+     */
+    public boolean isShowCustomTextGridX() {
+        return mShowCustomTextGridX;
+    }
+
+    /**
+     * Returns if the Y axis custom text grid should be visible.
+     *
+     * @return the visibility flag for the custom text Y axis grid
+     */
+    public boolean isShowCustomTextGridY() {
+        return mShowCustomTextGridY;
+    }
+
+    /**
+     * Sets if the X axis custom text grid should be visible.
+     *
+     * @param showGrid the visibility flag for the X axis custom text grid
+     */
+    public void setShowCustomTextGridX(boolean showGrid) {
+        mShowCustomTextGridX = showGrid;
+    }
+
+    /**
+     * Sets if the Y axis custom text grid should be visible.
+     *
+     * @param showGrid the visibility flag for the Y axis custom text grid
+     */
+    public void setShowCustomTextGridY(boolean showGrid) {
+        mShowCustomTextGridY = showGrid;
+    }
+
+    /**
+     * Sets if the grid for custom X or Y labels should be visible.
+     *
+     * @param showGrid the visibility flag for the custom text grid
+     */
+    public void setShowCustomTextGrid(boolean showGrid) {
+        setShowCustomTextGridX(showGrid);
+        setShowCustomTextGridY(showGrid);
+    }
+
+    /**
+     * Returns if the legend should be visible.
+     *
+     * @return the visibility flag for the legend
+     */
+    public boolean isShowLegend() {
+        return mShowLegend;
+    }
+
+    /**
+     * Sets if the legend should be visible.
+     *
+     * @param showLegend the visibility flag for the legend
+     */
+    public void setShowLegend(boolean showLegend) {
+        mShowLegend = showLegend;
+    }
+
+    /**
+     * Returns if the legend should size to fit.
+     *
+     * @return the fit behavior
+     */
+    public boolean isFitLegend() {
+        return mFitLegend;
+    }
+
+    /**
+     * Sets if the legend should size to fit.
+     *
+     * @param fit the fit behavior
+     */
+    public void setFitLegend(boolean fit) {
+        mFitLegend = fit;
+    }
+
+    /**
+     * Returns the text typeface name.
+     *
+     * @return the text typeface name
+     */
+    public String getTextTypefaceName() {
+        return mTextTypefaceName;
+    }
+
+    /**
+     * Returns the text typeface style.
+     *
+     * @return the text typeface style
+     */
+    public int getTextTypefaceStyle() {
+        return mTextTypefaceStyle;
+    }
+
+    /**
+     * Returns the text typeface.
+     *
+     * @return the text typeface
+     */
+    public Typeface getTextTypeface() {
+        return mTextTypeface;
+    }
+
+    /**
+     * Returns the legend text size.
+     *
+     * @return the legend text size
+     */
+    public float getLegendTextSize() {
+        return mLegendTextSize;
+    }
+
+    /**
+     * Sets the legend text size.
+     *
+     * @param textSize the legend text size
+     */
+    public void setLegendTextSize(float textSize) {
+        mLegendTextSize = textSize;
+    }
+
+    /**
+     * Sets the text typeface name and style.
+     *
+     * @param typefaceName the text typeface name
+     * @param style        the text typeface style
+     */
+    public void setTextTypeface(String typefaceName, int style) {
+        mTextTypefaceName = typefaceName;
+        mTextTypefaceStyle = style;
+    }
+
+    /**
+     * Sets the text typeface.
+     *
+     * @param typeface the typeface
+     */
+    public void setTextTypeface(Typeface typeface) {
+        mTextTypeface = typeface;
+    }
+
+    /**
+     * Returns the antialiasing flag value.
+     *
+     * @return the antialiasing value
+     */
+    public boolean isAntialiasing() {
+        return mAntialiasing;
+    }
+
+    /**
+     * Sets the antialiasing value.
+     *
+     * @param antialiasing the antialiasing
+     */
+    public void setAntialiasing(boolean antialiasing) {
+        mAntialiasing = antialiasing;
+    }
+
+    /**
+     * Returns the value to be used for scaling the chart.
+     *
+     * @return the scale value
+     */
+    public float getScale() {
+        return mScale;
+    }
+
+    /**
+     * Returns the original value to be used for scaling the chart.
+     *
+     * @return the original scale value
+     */
+    public float getOriginalScale() {
+        return mOriginalScale;
+    }
+
+    /**
+     * Sets the value to be used for scaling the chart. It works on some charts
+     * like pie, doughnut, dial.
+     *
+     * @param scale the scale value
+     */
+    public void setScale(float scale) {
+        mScale = scale;
+    }
+
+    /**
+     * Returns the enabled state of the zoom.
+     *
+     * @return if zoom is enabled
+     */
+    public boolean isZoomEnabled() {
+        return mZoomEnabled;
+    }
+
+    /**
+     * Sets the enabled state of the zoom.
+     *
+     * @param enabled zoom enabled
+     */
+    public void setZoomEnabled(boolean enabled) {
+        mZoomEnabled = enabled;
+    }
+
+    /**
+     * Returns the corner in which to the zoom controls are drawn.
+     *
+     * @return Location
+     */
+    public Location getZoomLocation() {
+        return mZoomLocation;
+    }
+
+    /**
+     * Set the corner in which to draw the zoom controls.
+     *
+     * @param location zoom location
+     */
+    public void setZoomLocation(DefaultRenderer.Location location) {
+        mZoomLocation = location;
+    }
+
+    public enum Location {
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT
+    }
+
+    /**
+     * Returns the visible state of the zoom buttons.
+     *
+     * @return if zoom buttons are visible
+     */
+    public boolean isZoomButtonsVisible() {
+        return mZoomButtonsVisible;
+    }
+
+    /**
+     * Sets the visible state of the zoom buttons.
+     *
+     * @param visible if the zoom buttons are visible
+     */
+    public void setZoomButtonsVisible(boolean visible) {
+        mZoomButtonsVisible = visible;
+    }
+
+    /**
+     * Returns the enabled state of the external (application implemented) zoom.
+     *
+     * @return if external zoom is enabled
+     */
+    public boolean isExternalZoomEnabled() {
+        return mExternalZoomEnabled;
+    }
+
+    /**
+     * Sets the enabled state of the external (application implemented) zoom.
+     *
+     * @param enabled external zoom enabled
+     */
+    public void setExternalZoomEnabled(boolean enabled) {
+        mExternalZoomEnabled = enabled;
+    }
+
+    /**
+     * Returns the zoom rate.
+     *
+     * @return the zoom rate
+     */
+    public float getZoomRate() {
+        return mZoomRate;
+    }
+
+    /**
+     * Returns the enabled state of the pan.
+     *
+     * @return if pan is enabled
+     */
+    public boolean isPanEnabled() {
+        return mPanEnabled;
+    }
+
+    /**
+     * Sets the enabled state of the pan.
+     *
+     * @param enabled pan enabled
+     */
+    public void setPanEnabled(boolean enabled) {
+        mPanEnabled = enabled;
+    }
+
+    /**
+     * Sets the zoom rate.
+     *
+     * @param rate the zoom rate
+     */
+    public void setZoomRate(float rate) {
+        mZoomRate = rate;
+    }
+
+    /**
+     * Returns the enabled state of the click.
+     *
+     * @return if click is enabled
+     */
+    public boolean isClickEnabled() {
+        return mClickEnabled;
+    }
+
+    /**
+     * Sets the enabled state of the click.
+     *
+     * @param enabled click enabled
+     */
+    public void setClickEnabled(boolean enabled) {
+        mClickEnabled = enabled;
+    }
+
+    /**
+     * Returns the selectable radius value around clickable points.
+     *
+     * @return the selectable radius
+     */
+    public int getSelectableBuffer() {
+        return selectableBuffer;
+    }
+
+    /**
+     * Sets the selectable radius value around clickable points.
+     *
+     * @param buffer the selectable radius
+     */
+    public void setSelectableBuffer(int buffer) {
+        selectableBuffer = buffer;
+    }
+
+    /**
+     * Returns the legend height.
+     *
+     * @return the legend height
+     */
+    public int getLegendHeight() {
+        return mLegendHeight;
+    }
+
+    /**
+     * Sets the legend height, in pixels.
+     *
+     * @param height the legend height
+     */
+    public void setLegendHeight(int height) {
+        mLegendHeight = height;
+    }
+
+    /**
+     * Returns the margin sizes. An array containing the margins in this order:
+     * top, left, bottom, right
+     *
+     * @return the margin sizes
+     */
+    public int[] getMargins() {
+        return mMargins;
+    }
+
+    /**
+     * Sets the margins, in pixels.
+     *
+     * @param margins an array containing the margin size values, in this order:
+     *                top, left, bottom, right
+     */
+    public void setMargins(int[] margins) {
+        mMargins = margins;
+    }
+
+    /**
+     * Returns if the chart is inside a scroll view and doesn't need to shrink.
+     *
+     * @return if it is inside a scroll view
+     */
+    public boolean isInScroll() {
+        return mInScroll;
+    }
+
+    /**
+     * To be set if the chart is inside a scroll view and doesn't need to shrink
+     * when not enough space.
+     *
+     * @param inScroll if it is inside a scroll view
+     */
+    public void setInScroll(boolean inScroll) {
+        mInScroll = inScroll;
+    }
+
+    /**
+     * Returns the start angle for circular charts such as pie, doughnut. An angle
+     * of 0 degrees correspond to the geometric angle of 0 degrees (3 o'clock on a
+     * watch.)
+     *
+     * @return the start angle in degrees
+     */
+    public float getStartAngle() {
+        return mStartAngle;
+    }
+
+    /**
+     * Sets the start angle for circular charts such as pie, doughnut, etc. An
+     * angle of 0 degrees correspond to the geometric angle of 0 degrees (3
+     * o'clock on a watch.)
+     *
+     * @param startAngle the start angle in degrees
+     */
+    public void setStartAngle(float startAngle) {
+        while (startAngle < 0) {
+            startAngle += 360;
+        }
+        mStartAngle = startAngle;
+    }
+
+    /**
+     * Returns if the values should be displayed as text.
+     *
+     * @return if the values should be displayed as text
+     */
+    public boolean isDisplayValues() {
+        return mDisplayValues;
+    }
+
+    /**
+     * Sets if the values should be displayed as text (supported by pie chart).
+     *
+     * @param display if the values should be displayed as text
+     */
+    public void setDisplayValues(boolean display) {
+        mDisplayValues = display;
+    }
 
 }


### PR DESCRIPTION
More from http://manage.dimagi.com/default.asp?179685

Allow zoom controls to be placed in different corners of graph instead of always bottom right, and make it a little less obtrusive. No way to do this without fiddling with AChartEngine. Increasingly considering switching chart libraries.

Most changes are AS reformatting AChartEngine code.

Before:
![screenshot_2015-08-28-11-10-40](https://cloud.githubusercontent.com/assets/1486591/9549887/4cec8e24-4d76-11e5-9e93-e10f1838e400.png)

After:
![screenshot_2015-08-28-10-59-48](https://cloud.githubusercontent.com/assets/1486591/9549882/48b7f15e-4d76-11e5-8f00-6ad30058b8c7.png)