### PR TITLE
Better error message if no connection during install

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -400,6 +400,10 @@ notification.install.duplicate.action=Navigate to the drop-down menu on your log
 notification.install.uptodate.title=CommCare is Up to Date
 notification.install.uptodate.detail=A newer version of CommCare is not available
 
+notification.install.no.connection.title=No internet connection
+notification.install.no.connection.detail=Install failed because your device is not connected to Wi-Fi currently
+notification.install.duplicate.action=Go to your device settings to check the current status of your Wi-Fi connection. If a connection is unavailable at this time, you may try offline install.
+
 notification.logger.submitted.title=Device Logs Submitted
 notification.logger.submitted.detail=Your devices logs have been successfully submitted
 

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
@@ -507,6 +509,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             titleBuf.append(" > ").append(local);
         }
         return titleBuf.toString();
+    }
+
+    public boolean isNetworkNotConnected() {
+        ConnectivityManager cm = (ConnectivityManager)getSystemService(CONNECTIVITY_SERVICE);
+        NetworkInfo netInfo = cm.getActiveNetworkInfo();
+        return (netInfo == null || !netInfo.isConnectedOrConnecting());
     }
 
     protected void createErrorDialog(String errorMsg, boolean shouldExit) {

--- a/app/src/org/commcare/android/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/android/tasks/ResourceEngineTask.java
@@ -86,7 +86,12 @@ public abstract class ResourceEngineTask<R>
         /**
          * Certificate was bad
          */
-        StatusBadCertificate("notification.install.badcert");
+        StatusBadCertificate("notification.install.badcert"),
+
+        /**
+         * There is no internet connectivity
+         */
+        StatusNoConnection("notification.install.no.connection");
 
 
         ResourceEngineOutcomes(String root) {

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -9,8 +9,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -335,12 +335,6 @@ public class CommCareHomeActivity extends SessionAwareCommCareActivity<CommCareH
         rebuildMenus();
     }
 
-    private boolean isNetworkNotConnected() {
-        ConnectivityManager cm = (ConnectivityManager)getSystemService(CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        return (netInfo == null || !netInfo.isConnectedOrConnecting());
-    }
-
     private void goToFormArchive(boolean incomplete) {
         goToFormArchive(incomplete, null);
     }


### PR DESCRIPTION
Currently if you try to install an app without an internet connection, you get a very very unhelpful "Couldn't locate part of your app" message. This does a check for connectivity before an install is actually attempted, and if there's no connection and it's not an offline install, raises an explicit "no internet connection" error right away.

While I was at it, discovered a couple of fields in CommCareSetupActivity related to multiple apps stuff that I hadn't been saving in onSavedInstanceState() as they should be, so added that in