### PR TITLE
Make gradle set version number and date

### DIFF
--- a/app/res/values/external_strings.xml
+++ b/app/res/values/external_strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- NOTICE:
-This resources file should not be edited unless you really know what you're doing 
--->
-<resources>
-    <!--@BUILDDATE@--><string name="app_build_date">UNKNOWN_DATE</string><!--@ENDBUILDDATE-->
-    <!--@BUILDNUMBER@--><string name="app_build_number">CUSTOM_BUILD</string><!--@BUILDNUMBER-->
-</resources>

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -73,6 +73,7 @@ import org.commcare.android.util.ODKPropertyManager;
 import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.activities.LoginActivity;
 import org.commcare.dalvik.activities.MessageActivity;
 import org.commcare.dalvik.activities.UnrecoverableErrorActivity;
@@ -827,8 +828,8 @@ public class CommCareApplication extends Application {
         }
 
 
-        String buildDate = getString(R.string.app_build_date);
-        String buildNumber = getString(R.string.app_build_number);
+        String buildDate = BuildConfig.BUILD_DATE;
+        String buildNumber = BuildConfig.BUILD_NUMBER;
 
         return Localization.get(getString(R.string.app_version_string), new String[]{pi.versionName, String.valueOf(pi.versionCode), ccv, buildNumber, buildDate, profileVersion});
     }

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,17 @@ ext {
   RELEASE_KEY_PASSWORD = project.properties['RELEASE_KEY_PASSWORD'] ?: ""
 }
 
+/**
+ * Get the version code from command line param
+ * 
+ * @return int If the param -PversionCode is present then return int value or -1
+ */
+def getVersionCode = { ->
+    def code = project.hasProperty('versionCode') ? versionCode.toInteger() : -1
+    println "VersionCode is set to $code"
+    return code
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -114,6 +125,13 @@ android {
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 22
+
+        versionCode getVersionCode()
+
+        buildConfigField "String", "ACRA_URL", "\"${project.ext.ACRA_URL}\""
+        buildConfigField "String", "ACRA_PASSWORD", "\"${project.ext.ACRA_PASSWORD}\""
+        buildConfigField "String", "ACRA_USER", "\"${project.ext.ACRA_USER}\""
+        buildConfigField "String", "MAPS_API_KEY", "\"${project.ext.MAPS_API_KEY}\""
     }
 
     compileOptions {
@@ -128,13 +146,6 @@ android {
            keyAlias project.ext.RELEASE_KEY_ALIAS
            keyPassword project.ext.RELEASE_KEY_PASSWORD
        }
-    }
-
-    defaultConfig {
-        buildConfigField "String", "ACRA_URL", "\"${project.ext.ACRA_URL}\""
-        buildConfigField "String", "ACRA_PASSWORD", "\"${project.ext.ACRA_PASSWORD}\""
-        buildConfigField "String", "ACRA_USER", "\"${project.ext.ACRA_USER}\""
-        buildConfigField "String", "MAPS_API_KEY", "\"${project.ext.MAPS_API_KEY}\""
     }
 
     def sourceLocations = ['app/src']

--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,10 @@ ext {
 /**
  * Get the version code from command line param
  * 
- * @return String If the param -PversionCode is present then return int value or "Dev
+ * @return int If the param -PversionCode is present then return int value or -1
  */
 def getVersionCode = { ->
-    def code = project.hasProperty('versionCode') ? versionCode : "Dev"
+    def code = project.hasProperty('versionCode') ? versionCode.toInteger() : -1
     println "VersionCode is set to $code"
     return code
 }

--- a/build.gradle
+++ b/build.gradle
@@ -94,12 +94,18 @@ ext {
 /**
  * Get the version code from command line param
  * 
- * @return int If the param -PversionCode is present then return int value or -1
+ * @return String If the param -PversionCode is present then return int value or "Dev
  */
 def getVersionCode = { ->
-    def code = project.hasProperty('versionCode') ? versionCode.toInteger() : -1
+    def code = project.hasProperty('versionCode') ? versionCode : "Dev"
     println "VersionCode is set to $code"
     return code
+}
+
+def getDate() {
+    def date = new Date()
+    def formattedDate = date.format('yyyy-MM-dd')
+    return formattedDate
 }
 
 android {
@@ -132,6 +138,8 @@ android {
         buildConfigField "String", "ACRA_PASSWORD", "\"${project.ext.ACRA_PASSWORD}\""
         buildConfigField "String", "ACRA_USER", "\"${project.ext.ACRA_USER}\""
         buildConfigField "String", "MAPS_API_KEY", "\"${project.ext.MAPS_API_KEY}\""
+        buildConfigField "String", "BUILD_DATE", "\"" + getDate() + "\""
+        buildConfigField "String", "BUILD_NUMBER", "\"" + getVersionCode() + "\""
     }
 
     compileOptions {


### PR DESCRIPTION
When we migrated to gradle we forgot to update the logic that sets the app's version number and build date.