### PR TITLE
Remove javarosa/commcare android build settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,20 +64,6 @@ project(':libraries:mapballoons') {
   }
 }
 
-project(':commcare') {
-  android{
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
-  }
-}
-
-project(':javarosa') {
-  android{
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
-  }
-}
-
 ext {
   // Obtained from ~/.gradle/gradle.properites on build server or load default
   // empty strings.


### PR DESCRIPTION
The sdk version settings for javarosa/commcare shouldn't be needed and make it easier to config odk jenkins builds.

Will require updating the odk jenkins build.