### PR TITLE
ManagedUi and UiElement annotations are useless outside of CommCareActivity

### DIFF
--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -34,7 +34,6 @@ public class SetupEnterURLFragment extends Fragment {
     private Spinner prefixURLSpinner;
     private EditText profileLocation;
 
-
     public interface URLInstaller {
         /**
          * Called when user fills in an URL and presses 'Start Install'.
@@ -82,47 +81,6 @@ public class SetupEnterURLFragment extends Fragment {
         return view;
     }
 
-    @Override
-    public void onPause() {
-        super.onPause();
-        Activity activity = this.getActivity();
-
-        if (activity != null) {
-            if (activity.getCurrentFocus() != null) {
-                InputMethodManager imm = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
-                imm.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
-            }
-
-        }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        Activity activity = this.getActivity();
-
-
-        if (activity != null) {
-            View editBox = activity.findViewById(R.id.edit_profile_location);
-            editBox.requestFocus();
-
-            InputMethodManager inputMethodManager = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
-            inputMethodManager.showSoftInput(editBox, InputMethodManager.SHOW_IMPLICIT);
-        }
-    }
-
-    @Override
-    public void onAttach(Activity activity) {
-        activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-
-        super.onAttach(activity);
-        if (!(activity instanceof URLInstaller)) {
-            throw new ClassCastException(activity + " must implemement " + interfaceName);
-        } else {
-            listener = (URLInstaller)activity;
-        }
-    }
-
     /**
      * Returns the chosen URL in the UI, prefixing it with http:// if not set.
      *
@@ -145,5 +103,44 @@ public class SetupEnterURLFragment extends Fragment {
             url = "http://" + url;
         }
         return url;
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        Activity activity = this.getActivity();
+
+        if (activity != null) {
+            if (activity.getCurrentFocus() != null) {
+                InputMethodManager imm = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+            }
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        Activity activity = this.getActivity();
+
+        if (activity != null) {
+            View editBox = activity.findViewById(R.id.edit_profile_location);
+            editBox.requestFocus();
+
+            InputMethodManager inputMethodManager = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+            inputMethodManager.showSoftInput(editBox, InputMethodManager.SHOW_IMPLICIT);
+        }
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+
+        super.onAttach(activity);
+        if (!(activity instanceof URLInstaller)) {
+            throw new ClassCastException(activity + " must implemement " + interfaceName);
+        } else {
+            listener = (URLInstaller)activity;
+        }
     }
 }

--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -48,9 +48,9 @@ public class SetupEnterURLFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_enter_url, container, false);
-        Button installButton = (Button) view.findViewById(R.id.start_install);
+        Button installButton = (Button)view.findViewById(R.id.start_install);
         installButton.setText(Localization.get("install.button.start"));
-        prefixURLSpinner = (Spinner) view.findViewById(R.id.url_spinner);
+        prefixURLSpinner = (Spinner)view.findViewById(R.id.url_spinner);
         prefixURLSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
@@ -66,8 +66,8 @@ public class SetupEnterURLFragment extends Fragment {
             public void onNothingSelected(AdapterView<?> parent) {
             }
         });
-        profileLocation = (EditText) view.findViewById(R.id.edit_profile_location);
-        TextView appProfile = (TextView) view.findViewById(R.id.app_profile_txt_view);
+        profileLocation = (EditText)view.findViewById(R.id.edit_profile_location);
+        TextView appProfile = (TextView)view.findViewById(R.id.app_profile_txt_view);
         appProfile.setText(Localization.get("install.appprofile"));
 
         installButton.setOnClickListener(new View.OnClickListener() {
@@ -87,10 +87,10 @@ public class SetupEnterURLFragment extends Fragment {
         super.onPause();
         Activity activity = this.getActivity();
 
-        if(activity != null) {
+        if (activity != null) {
             if (activity.getCurrentFocus() != null) {
-                InputMethodManager imm = (InputMethodManager) activity.getSystemService(Context.INPUT_METHOD_SERVICE);
-                imm.hideSoftInputFromWindow( activity.getCurrentFocus().getWindowToken(), 0);
+                InputMethodManager imm = (InputMethodManager)activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
             }
 
         }
@@ -102,7 +102,7 @@ public class SetupEnterURLFragment extends Fragment {
         Activity activity = this.getActivity();
 
 
-        if(activity != null ) {
+        if (activity != null) {
             View editBox = activity.findViewById(R.id.edit_profile_location);
             editBox.requestFocus();
 
@@ -119,7 +119,7 @@ public class SetupEnterURLFragment extends Fragment {
         if (!(activity instanceof URLInstaller)) {
             throw new ClassCastException(activity + " must implemement " + interfaceName);
         } else {
-            listener = (URLInstaller) activity;
+            listener = (URLInstaller)activity;
         }
     }
 

--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -24,11 +24,19 @@ import org.javarosa.core.services.locale.Localization;
 
 /**
  * Fragment for inputting app installation URL, "returned" through the URLInstaller interface.
- * Created by dancluna on 3/17/15.
+ *
+ * @author Daniel Luna (dcluna@dimagi.com)
  */
-@ManagedUi(R.layout.fragment_setup_enter_url)
 public class SetupEnterURLFragment extends Fragment {
     public static final String TAG = SetupEnterURLFragment.class.getSimpleName();
+    public static final String interfaceName = URLInstaller.class.getName();
+
+    private URLInstaller listener;
+
+    Button installButton;
+    Spinner prefixURLSpinner;
+    EditText profileLocation;
+
 
     public interface URLInstaller {
         /**
@@ -37,21 +45,8 @@ public class SetupEnterURLFragment extends Fragment {
          *
          * @param url URL typed by the user
          */
-        public void onURLChosen(String url);
+        void onURLChosen(String url);
     }
-
-    public static final String interfaceName = URLInstaller.class.getName();
-
-    private URLInstaller listener;
-
-    @UiElement(R.id.start_install)
-    Button installButton;
-
-    @UiElement(R.id.url_spinner)
-    Spinner prefixURLSpinner;
-
-    @UiElement(R.id.edit_profile_location)
-    EditText profileLocation;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -16,8 +16,6 @@ import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
 
-import org.commcare.android.framework.ManagedUi;
-import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.javarosa.core.services.locale.Localization;
@@ -28,14 +26,13 @@ import org.javarosa.core.services.locale.Localization;
  * @author Daniel Luna (dcluna@dimagi.com)
  */
 public class SetupEnterURLFragment extends Fragment {
-    public static final String TAG = SetupEnterURLFragment.class.getSimpleName();
-    public static final String interfaceName = URLInstaller.class.getName();
+    private static final String TAG = SetupEnterURLFragment.class.getSimpleName();
+    private static final String interfaceName = URLInstaller.class.getName();
 
     private URLInstaller listener;
 
-    Button installButton;
-    Spinner prefixURLSpinner;
-    EditText profileLocation;
+    private Spinner prefixURLSpinner;
+    private EditText profileLocation;
 
 
     public interface URLInstaller {
@@ -51,7 +48,7 @@ public class SetupEnterURLFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_enter_url, container, false);
-        installButton = (Button) view.findViewById(R.id.start_install);
+        Button installButton = (Button) view.findViewById(R.id.start_install);
         installButton.setText(Localization.get("install.button.start"));
         prefixURLSpinner = (Spinner) view.findViewById(R.id.url_spinner);
         prefixURLSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -131,7 +128,7 @@ public class SetupEnterURLFragment extends Fragment {
      *
      * @return The current URL
      */
-    public String getURL() {
+    private String getURL() {
         int selectedPrefix = prefixURLSpinner.getSelectedItemPosition();
         String url = profileLocation.getText().toString();
         if (url == null || url.length() == 0) {

--- a/app/src/org/commcare/android/fragments/SetupInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupInstallFragment.java
@@ -24,9 +24,6 @@ import org.javarosa.core.services.locale.Localization;
  * @author Daniel Luna (dcluna@dimagi.com)
  */
 public class SetupInstallFragment extends Fragment {
-    SquareButtonWithText scanBarcodeButton;
-    SquareButtonWithText enterURLButton;
-
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_install, container, false);
@@ -34,8 +31,8 @@ public class SetupInstallFragment extends Fragment {
         TextView setupMsg2 = (TextView) view.findViewById(R.id.str_setup_message_2);
         setupMsg.setText(Localization.get("install.barcode.top"));
         setupMsg2.setText(Localization.get("install.barcode.bottom"));
-        scanBarcodeButton = (SquareButtonWithText) view.findViewById(R.id.btn_fetch_uri);
-        enterURLButton = (SquareButtonWithText) view.findViewById(R.id.enter_app_location);
+        SquareButtonWithText scanBarcodeButton = (SquareButtonWithText) view.findViewById(R.id.btn_fetch_uri);
+        SquareButtonWithText enterURLButton = (SquareButtonWithText) view.findViewById(R.id.enter_app_location);
         final View barcodeButtonContainer = view.findViewById(R.id.btn_fetch_uri_container);
         scanBarcodeButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/org/commcare/android/fragments/SetupInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupInstallFragment.java
@@ -13,7 +13,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.commcare.android.framework.UiElement;
 import org.commcare.android.view.SquareButtonWithText;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.activities.CommCareSetupActivity;
@@ -21,13 +20,11 @@ import org.javarosa.core.services.locale.Localization;
 
 /**
  * Fragment for choosing app installation mode (barcode or manual install).
- * Created by dancluna on 3/17/15.
+ *
+ * @author Daniel Luna (dcluna@dimagi.com)
  */
 public class SetupInstallFragment extends Fragment {
-    @UiElement(R.id.btn_fetch_uri)
     SquareButtonWithText scanBarcodeButton;
-
-    @UiElement(R.id.enter_app_location)
     SquareButtonWithText enterURLButton;
 
     @Override

--- a/app/src/org/commcare/android/fragments/SetupInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupInstallFragment.java
@@ -27,12 +27,14 @@ public class SetupInstallFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_install, container, false);
+
         TextView setupMsg = (TextView)view.findViewById(R.id.str_setup_message);
-        TextView setupMsg2 = (TextView)view.findViewById(R.id.str_setup_message_2);
         setupMsg.setText(Localization.get("install.barcode.top"));
+
+        TextView setupMsg2 = (TextView)view.findViewById(R.id.str_setup_message_2);
         setupMsg2.setText(Localization.get("install.barcode.bottom"));
+
         SquareButtonWithText scanBarcodeButton = (SquareButtonWithText)view.findViewById(R.id.btn_fetch_uri);
-        SquareButtonWithText enterURLButton = (SquareButtonWithText)view.findViewById(R.id.enter_app_location);
         final View barcodeButtonContainer = view.findViewById(R.id.btn_fetch_uri_container);
         scanBarcodeButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -48,6 +50,8 @@ public class SetupInstallFragment extends Fragment {
                 }
             }
         });
+
+        SquareButtonWithText enterURLButton = (SquareButtonWithText)view.findViewById(R.id.enter_app_location);
         enterURLButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -64,6 +68,7 @@ public class SetupInstallFragment extends Fragment {
                 ft.commit();
             }
         });
+
         return view;
     }
 }

--- a/app/src/org/commcare/android/fragments/SetupInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupInstallFragment.java
@@ -27,12 +27,12 @@ public class SetupInstallFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_install, container, false);
-        TextView setupMsg = (TextView) view.findViewById(R.id.str_setup_message);
-        TextView setupMsg2 = (TextView) view.findViewById(R.id.str_setup_message_2);
+        TextView setupMsg = (TextView)view.findViewById(R.id.str_setup_message);
+        TextView setupMsg2 = (TextView)view.findViewById(R.id.str_setup_message_2);
         setupMsg.setText(Localization.get("install.barcode.top"));
         setupMsg2.setText(Localization.get("install.barcode.bottom"));
-        SquareButtonWithText scanBarcodeButton = (SquareButtonWithText) view.findViewById(R.id.btn_fetch_uri);
-        SquareButtonWithText enterURLButton = (SquareButtonWithText) view.findViewById(R.id.enter_app_location);
+        SquareButtonWithText scanBarcodeButton = (SquareButtonWithText)view.findViewById(R.id.btn_fetch_uri);
+        SquareButtonWithText enterURLButton = (SquareButtonWithText)view.findViewById(R.id.enter_app_location);
         final View barcodeButtonContainer = view.findViewById(R.id.btn_fetch_uri_container);
         scanBarcodeButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -54,7 +54,7 @@ public class SetupInstallFragment extends Fragment {
                 SetupEnterURLFragment enterUrl = new SetupEnterURLFragment();
                 Activity currentActivity = getActivity();
                 if (currentActivity instanceof CommCareSetupActivity) {
-                    ((CommCareSetupActivity) currentActivity).setUiState(CommCareSetupActivity.UiState.IN_URL_ENTRY);
+                    ((CommCareSetupActivity)currentActivity).setUiState(CommCareSetupActivity.UiState.IN_URL_ENTRY);
                 }
                 // if we use getChildFragmentManager, we're going to have a crash
                 FragmentManager fm = getActivity().getSupportFragmentManager();

--- a/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
@@ -8,29 +8,25 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import org.commcare.android.framework.UiElement;
 import org.commcare.android.view.SquareButtonWithText;
 import org.commcare.dalvik.R;
 import org.javarosa.core.services.locale.Localization;
 
 /**
  * Fragment to start, update or cancel an app installation.
- * Created by dancluna on 4/10/15.
+ *
+ * @author Daniel Luna (dcluna@dimagi.com)
  */
 public class SetupKeepInstallFragment extends Fragment {
-    @UiElement(R.id.btn_start_install)
     SquareButtonWithText btnStartInstall;
-
-    @UiElement(R.id.btn_stop_install)
     SquareButtonWithText btnStopInstall;
+    StartStopInstallCommands buttonCommands;
 
     public interface StartStopInstallCommands {
         void onStartInstallClicked();
 
         void onStopInstallClicked();
     }
-
-    StartStopInstallCommands buttonCommands;
 
     public void setButtonCommands(StartStopInstallCommands buttonCommands) {
         this.buttonCommands = buttonCommands;

--- a/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
@@ -18,9 +18,7 @@ import org.javarosa.core.services.locale.Localization;
  * @author Daniel Luna (dcluna@dimagi.com)
  */
 public class SetupKeepInstallFragment extends Fragment {
-    SquareButtonWithText btnStartInstall;
-    SquareButtonWithText btnStopInstall;
-    StartStopInstallCommands buttonCommands;
+    private StartStopInstallCommands buttonCommands;
 
     public interface StartStopInstallCommands {
         void onStartInstallClicked();
@@ -28,7 +26,7 @@ public class SetupKeepInstallFragment extends Fragment {
         void onStopInstallClicked();
     }
 
-    public void setButtonCommands(StartStopInstallCommands buttonCommands) {
+    private void setButtonCommands(StartStopInstallCommands buttonCommands) {
         this.buttonCommands = buttonCommands;
     }
 
@@ -44,9 +42,9 @@ public class SetupKeepInstallFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_keepinstall, container, false);
-        btnStartInstall = (SquareButtonWithText) view.findViewById(R.id.btn_start_install);
+        SquareButtonWithText btnStartInstall = (SquareButtonWithText) view.findViewById(R.id.btn_start_install);
         btnStartInstall.setText(Localization.get("install.button.start"));
-        btnStopInstall = (SquareButtonWithText) view.findViewById(R.id.btn_stop_install);
+        SquareButtonWithText btnStopInstall = (SquareButtonWithText) view.findViewById(R.id.btn_stop_install);
         btnStopInstall.setText(Localization.get("install.button.startover"));
         TextView setupMsg = (TextView) view.findViewById(R.id.str_setup_message);
         setupMsg.setText(Localization.get("install.ready.top"));

--- a/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
@@ -36,21 +36,21 @@ public class SetupKeepInstallFragment extends Fragment {
         if (!(activity instanceof StartStopInstallCommands)) {
             throw new ClassCastException(activity + " must implemement " + StartStopInstallCommands.class.getName());
         }
-        setButtonCommands((StartStopInstallCommands) activity);
+        setButtonCommands((StartStopInstallCommands)activity);
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_keepinstall, container, false);
-        SquareButtonWithText btnStartInstall = (SquareButtonWithText) view.findViewById(R.id.btn_start_install);
+        SquareButtonWithText btnStartInstall = (SquareButtonWithText)view.findViewById(R.id.btn_start_install);
         btnStartInstall.setText(Localization.get("install.button.start"));
-        SquareButtonWithText btnStopInstall = (SquareButtonWithText) view.findViewById(R.id.btn_stop_install);
+        SquareButtonWithText btnStopInstall = (SquareButtonWithText)view.findViewById(R.id.btn_stop_install);
         btnStopInstall.setText(Localization.get("install.button.startover"));
-        TextView setupMsg = (TextView) view.findViewById(R.id.str_setup_message);
+        TextView setupMsg = (TextView)view.findViewById(R.id.str_setup_message);
         setupMsg.setText(Localization.get("install.ready.top"));
-        TextView setupMsg2 = (TextView) view.findViewById(R.id.str_setup_message_2);
+        TextView setupMsg2 = (TextView)view.findViewById(R.id.str_setup_message_2);
         setupMsg2.setText(Localization.get("install.ready.bottom"));
-        TextView netWarn = (TextView) view.findViewById(R.id.net_warn);
+        TextView netWarn = (TextView)view.findViewById(R.id.net_warn);
         netWarn.setText(Localization.get("install.netwarn"));
         btnStartInstall.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
@@ -26,44 +26,47 @@ public class SetupKeepInstallFragment extends Fragment {
         void onStopInstallClicked();
     }
 
-    private void setButtonCommands(StartStopInstallCommands buttonCommands) {
-        this.buttonCommands = buttonCommands;
-    }
-
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
         if (!(activity instanceof StartStopInstallCommands)) {
             throw new ClassCastException(activity + " must implemement " + StartStopInstallCommands.class.getName());
         }
-        setButtonCommands((StartStopInstallCommands)activity);
+
+        this.buttonCommands = (StartStopInstallCommands)activity;
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_setup_keepinstall, container, false);
+
         SquareButtonWithText btnStartInstall = (SquareButtonWithText)view.findViewById(R.id.btn_start_install);
         btnStartInstall.setText(Localization.get("install.button.start"));
-        SquareButtonWithText btnStopInstall = (SquareButtonWithText)view.findViewById(R.id.btn_stop_install);
-        btnStopInstall.setText(Localization.get("install.button.startover"));
-        TextView setupMsg = (TextView)view.findViewById(R.id.str_setup_message);
-        setupMsg.setText(Localization.get("install.ready.top"));
-        TextView setupMsg2 = (TextView)view.findViewById(R.id.str_setup_message_2);
-        setupMsg2.setText(Localization.get("install.ready.bottom"));
-        TextView netWarn = (TextView)view.findViewById(R.id.net_warn);
-        netWarn.setText(Localization.get("install.netwarn"));
         btnStartInstall.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (buttonCommands != null) buttonCommands.onStartInstallClicked();
             }
         });
+
+        SquareButtonWithText btnStopInstall = (SquareButtonWithText)view.findViewById(R.id.btn_stop_install);
+        btnStopInstall.setText(Localization.get("install.button.startover"));
         btnStopInstall.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (buttonCommands != null) buttonCommands.onStopInstallClicked();
             }
         });
+
+        TextView setupMsg = (TextView)view.findViewById(R.id.str_setup_message);
+        setupMsg.setText(Localization.get("install.ready.top"));
+
+        TextView setupMsg2 = (TextView)view.findViewById(R.id.str_setup_message_2);
+        setupMsg2.setText(Localization.get("install.ready.bottom"));
+
+        TextView netWarn = (TextView)view.findViewById(R.id.net_warn);
+        netWarn.setText(Localization.get("install.netwarn"));
+
         return view;
     }
 }

--- a/app/src/org/commcare/android/view/SquareButtonWithNotification.java
+++ b/app/src/org/commcare/android/view/SquareButtonWithNotification.java
@@ -23,33 +23,6 @@ public class SquareButtonWithNotification extends RelativeLayout {
     private int colorButtonText = R.color.white;
     private int colorNotificationText = R.color.black;
 
-    public void setOnClickListener(OnClickListener l) {
-        buttonWithText.setOnClickListener(l);
-    }
-
-    public void setNotificationText(String textNotification) {
-        this.setNotificationText(textNotification == null ? null : new SpannableString(textNotification));
-    }
-
-    public void setNotificationText(Spannable textNotification) {
-        if (textNotification != null && textNotification.length() != 0) {
-            subText.setVisibility(VISIBLE);
-            subText.setText(textNotification);
-            subText.setBackgroundResource(backgroundColorNotification);
-        } else {
-            subText.setVisibility(GONE);
-        }
-    }
-
-    public void setText(String text) {
-        buttonWithText.setText(text);
-    }
-
-
-    public void setText(Spannable text) {
-        buttonWithText.setText(text.toString());
-    }
-
     public SquareButtonWithNotification(Context context, AttributeSet attrs) {
         super(context, attrs);
 
@@ -88,4 +61,32 @@ public class SquareButtonWithNotification extends RelativeLayout {
             subText.setTextColor(getResources().getColor(colorNotificationText));
         }
     }
+
+    @Override
+    public void setOnClickListener(OnClickListener l) {
+        buttonWithText.setOnClickListener(l);
+    }
+
+    public void setNotificationText(String textNotification) {
+        this.setNotificationText(textNotification == null ? null : new SpannableString(textNotification));
+    }
+
+    public void setNotificationText(Spannable textNotification) {
+        if (textNotification != null && textNotification.length() != 0) {
+            subText.setVisibility(VISIBLE);
+            subText.setText(textNotification);
+            subText.setBackgroundResource(backgroundColorNotification);
+        } else {
+            subText.setVisibility(GONE);
+        }
+    }
+
+    public void setText(String text) {
+        buttonWithText.setText(text);
+    }
+
+    public void setText(Spannable text) {
+        buttonWithText.setText(text.toString());
+    }
+
 }

--- a/app/src/org/commcare/android/view/SquareButtonWithNotification.java
+++ b/app/src/org/commcare/android/view/SquareButtonWithNotification.java
@@ -10,20 +10,14 @@ import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.R;
 
 /**
- * Created by dancluna on 3/18/15.
+ * @author Daniel Luna (dcluna@dimagi.com)
  */
 public class SquareButtonWithNotification extends RelativeLayout {
-    @UiElement(R.id.square_button_text)
     SquareButtonWithText buttonWithText;
-
-    @UiElement(R.id.button_subtext)
     TextView subText;
-
-    //region View parameters
 
     Drawable backgroundImg;
     int backgroundColorButton = android.R.drawable.btn_default;
@@ -32,10 +26,6 @@ public class SquareButtonWithNotification extends RelativeLayout {
     String textNotification = "";
     private int colorButtonText = R.color.white;
     private int colorNotificationText = R.color.black;
-
-    //endregion
-
-    //region Public methods
 
     public void setOnClickListener(OnClickListener l) {
         buttonWithText.setOnClickListener(l);
@@ -64,10 +54,6 @@ public class SquareButtonWithNotification extends RelativeLayout {
         buttonWithText.setText(text.toString());
     }
 
-    //endregion
-
-    //region Constructors
-
     public SquareButtonWithNotification(Context context, AttributeSet attrs) {
         super(context, attrs);
 
@@ -79,10 +65,6 @@ public class SquareButtonWithNotification extends RelativeLayout {
 
         setUI(context, attrs);
     }
-
-    //endregion
-
-    //region Private methods
 
     private void setUI(Context context, AttributeSet attrs) {
         View view = inflate(context, R.layout.square_button_notification, this);
@@ -110,6 +92,4 @@ public class SquareButtonWithNotification extends RelativeLayout {
             subText.setTextColor(getResources().getColor(colorNotificationText));
         }
     }
-
-    //endregion
 }

--- a/app/src/org/commcare/android/view/SquareButtonWithNotification.java
+++ b/app/src/org/commcare/android/view/SquareButtonWithNotification.java
@@ -64,8 +64,8 @@ public class SquareButtonWithNotification extends RelativeLayout {
 
     private void setUI(Context context, AttributeSet attrs) {
         View view = inflate(context, R.layout.square_button_notification, this);
-        buttonWithText = (SquareButtonWithText) view.findViewById(R.id.square_button_text);
-        subText = (TextView) view.findViewById(R.id.button_subtext);
+        buttonWithText = (SquareButtonWithText)view.findViewById(R.id.square_button_text);
+        subText = (TextView)view.findViewById(R.id.button_subtext);
 
         if (attrs != null) {
             TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.SquareButtonWithNotification, 0, 0);

--- a/app/src/org/commcare/android/view/SquareButtonWithNotification.java
+++ b/app/src/org/commcare/android/view/SquareButtonWithNotification.java
@@ -16,14 +16,10 @@ import org.commcare.dalvik.R;
  * @author Daniel Luna (dcluna@dimagi.com)
  */
 public class SquareButtonWithNotification extends RelativeLayout {
-    SquareButtonWithText buttonWithText;
-    TextView subText;
-
-    Drawable backgroundImg;
-    int backgroundColorButton = android.R.drawable.btn_default;
-    int backgroundColorNotification = R.color.solid_green;
-    String subtitleButton = "";
-    String textNotification = "";
+    private SquareButtonWithText buttonWithText;
+    private TextView subText;
+    private int backgroundColorButton = android.R.drawable.btn_default;
+    private int backgroundColorNotification = R.color.solid_green;
     private int colorButtonText = R.color.white;
     private int colorNotificationText = R.color.black;
 
@@ -32,7 +28,7 @@ public class SquareButtonWithNotification extends RelativeLayout {
     }
 
     public void setNotificationText(String textNotification) {
-        this.setNotificationText((Spannable) (textNotification == null ? null : new SpannableString(textNotification)));
+        this.setNotificationText(textNotification == null ? null : new SpannableString(textNotification));
     }
 
     public void setNotificationText(Spannable textNotification) {
@@ -74,11 +70,11 @@ public class SquareButtonWithNotification extends RelativeLayout {
         if (attrs != null) {
             TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.SquareButtonWithNotification, 0, 0);
 
-            backgroundImg = typedArray.getDrawable(R.styleable.SquareButtonWithNotification_sbn_img);
+            Drawable backgroundImg = typedArray.getDrawable(R.styleable.SquareButtonWithNotification_sbn_img);
             backgroundColorButton = typedArray.getResourceId(R.styleable.SquareButtonWithNotification_backgroundcolorButton, backgroundColorButton);
             backgroundColorNotification = typedArray.getResourceId(R.styleable.SquareButtonWithNotification_backgroundcolorNotification, backgroundColorNotification);
-            subtitleButton = typedArray.getString(R.styleable.SquareButtonWithNotification_sbn_subtitle);
-            textNotification = typedArray.getString(R.styleable.SquareButtonWithNotification_notificationText);
+            String subtitleButton = typedArray.getString(R.styleable.SquareButtonWithNotification_sbn_subtitle);
+            String textNotification = typedArray.getString(R.styleable.SquareButtonWithNotification_notificationText);
             colorButtonText = typedArray.getResourceId(R.styleable.SquareButtonWithNotification_colorButtonText, colorButtonText);
             colorNotificationText = typedArray.getResourceId(R.styleable.SquareButtonWithNotification_colorNotificationText, colorNotificationText);
 

--- a/app/src/org/commcare/android/view/SquareButtonWithText.java
+++ b/app/src/org/commcare/android/view/SquareButtonWithText.java
@@ -13,27 +13,19 @@ import android.util.StateSet;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import org.commcare.android.framework.ManagedUi;
-import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.R;
 
 /**
- * Created by dancluna on 3/14/15.
+ * @author Daniel Luna (dluna@dimagi.com)
  */
-@ManagedUi(R.layout.square_button_text)
 public class SquareButtonWithText extends RelativeLayout {
-    @UiElement(R.id.square_button)
     SquareButton squareButton;
-
-    @UiElement(R.id.text_view)
     TextView textView;
 
     Drawable backgroundImg;
     int backgroundColor = android.R.drawable.btn_default;
     String text = "";
     private int colorButtonText = R.color.cc_core_bg;
-
-    //region Constructors
 
     public SquareButtonWithText(Context context) {
         super(context);
@@ -50,10 +42,6 @@ public class SquareButtonWithText extends RelativeLayout {
 
         inflateAndExtractCustomParams(context, attrs);
     }
-
-    //endregion
-
-    //region Custom parameter processing
 
     private void inflateAndExtractCustomParams(Context context, AttributeSet attrs) {
         inflate(context, R.layout.square_button_text, this);
@@ -85,16 +73,11 @@ public class SquareButtonWithText extends RelativeLayout {
         setTextColor(colorButtonText);
     }
 
-    //endregion
-
-    //region Compatibility methods
-
     public void setText(String text) {
         if (textView != null) {
             textView.setText(text);
         }
     }
-
 
     public void setImage(Drawable backgroundImg) {
         squareButton.setImageDrawable(backgroundImg);
@@ -123,12 +106,9 @@ public class SquareButtonWithText extends RelativeLayout {
         } else {
             this.setBackgroundDrawable(sld);
         }
-
     }
 
     public void setTextColor(int textColor) {
         textView.setTextColor(getResources().getColor(textColor));
     }
-
-    //endregion
 }

--- a/app/src/org/commcare/android/view/SquareButtonWithText.java
+++ b/app/src/org/commcare/android/view/SquareButtonWithText.java
@@ -19,13 +19,10 @@ import org.commcare.dalvik.R;
  * @author Daniel Luna (dluna@dimagi.com)
  */
 public class SquareButtonWithText extends RelativeLayout {
-    SquareButton squareButton;
-    TextView textView;
+    private SquareButton squareButton;
+    private TextView textView;
 
-    Drawable backgroundImg;
-    int backgroundColor = android.R.drawable.btn_default;
-    String text = "";
-    private int colorButtonText = R.color.cc_core_bg;
+    private static final int DEFAULT_TEXT_COLOR = R.color.cc_core_bg;
 
     public SquareButtonWithText(Context context) {
         super(context);
@@ -49,10 +46,10 @@ public class SquareButtonWithText extends RelativeLayout {
 
         TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.SquareButtonWithText);
 
-        backgroundImg = typedArray.getDrawable(R.styleable.SquareButtonWithText_img);
-        backgroundColor = getResources().getColor(typedArray.getResourceId(R.styleable.SquareButtonWithText_backgroundcolor, android.R.color.transparent));
-        text = typedArray.getString(R.styleable.SquareButtonWithText_subtitle);
-        colorButtonText = typedArray.getResourceId(R.styleable.SquareButtonWithText_colorText, colorButtonText);
+        Drawable backgroundImg = typedArray.getDrawable(R.styleable.SquareButtonWithText_img);
+        int backgroundColor = getResources().getColor(typedArray.getResourceId(R.styleable.SquareButtonWithText_backgroundcolor, android.R.color.transparent));
+        String text = typedArray.getString(R.styleable.SquareButtonWithText_subtitle);
+        int colorButtonText = typedArray.getResourceId(R.styleable.SquareButtonWithText_colorText, DEFAULT_TEXT_COLOR);
 
         typedArray.recycle();
 


### PR DESCRIPTION
The `@ManagedUi` and `@UiElement` annotations that flag ui elements to inflate automatically in CommCareActivity are useless when present in classes that don't extend `CommCareActivity`. Remove them.

Also lint, code style, method order, and other minor refactors. __Review commit-by-commit__