### PR TITLE
GridView Row Density Fix

### DIFF
--- a/app/src/org/commcare/android/view/GridEntityView.java
+++ b/app/src/org/commcare/android/view/GridEntityView.java
@@ -129,14 +129,13 @@ public class GridEntityView extends GridLayout {
 		DisplayMetrics metrics = getResources().getDisplayMetrics();
 		
 		int densityDpi = metrics.densityDpi;
-		
-		if(densityDpi == DisplayMetrics.DENSITY_XHIGH){
-			densityRowMultiplier = 2.0;
-		} else if(densityDpi == DisplayMetrics.DENSITY_HIGH){
-			densityRowMultiplier = 1.5;
-		} else if(densityDpi == DisplayMetrics.DENSITY_MEDIUM){
-		    
-		} 
+
+		int defaultDensityDpi = DisplayMetrics.DENSITY_MEDIUM;
+
+        //an additional row for every 160dpi
+        double extraDensity = (int)((densityDpi - defaultDensityDpi / 80)) * 0.5;
+
+        densityRowMultiplier = 1 + extraDensity;
 		
 		this.mFuzzySearchEnabled = fuzzySearchEnabled;
 		


### PR DESCRIPTION
Fix for there being a maximum boundary on row size scaling, causing odd gridview grids on XXHigh res screens

On my Galaxy S5 this fixes a bug where the tiles would have a ton of empty space below the content.