### PR TITLE
Fix order of arguments for edit distance match

### DIFF
--- a/app/src/org/commcare/android/adapters/EntityListAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntityListAdapter.java
@@ -261,7 +261,7 @@ public class EntityListAdapter implements ListAdapter {
                             // fuzzy matching
                             if (mFuzzySearchEnabled) {
                                 for (String fieldChunk : e.getSortFieldPieces(i)) {
-                                    Pair<Boolean, Integer> match = StringUtils.fuzzyMatch(fieldChunk, filter);
+                                    Pair<Boolean, Integer> match = StringUtils.fuzzyMatch(filter, fieldChunk);
                                     if (match.first) {
                                         add = true;
                                         score += match.second;

--- a/app/src/org/commcare/android/util/StringUtils.java
+++ b/app/src/org/commcare/android/util/StringUtils.java
@@ -129,12 +129,12 @@ public class StringUtils {
      * meet CommCare's fuzzy match definition, false otherwise. Second value is the actual string
      * distance that was matched, in order to be able to rank or otherwise interpret results.
      */
-    public static Pair<Boolean, Integer> fuzzyMatch(String a, String b) {
+    public static Pair<Boolean, Integer> fuzzyMatch(String source, String target) {
         //tweakable parameter: Minimum length before edit distance
         //starts being used (this is probably not necessary, and
         //basically only makes sure that "at" doesn't match "or" or similar
-        if (b.length() > 3) {
-            int distance = StringUtils.LevenshteinDistance(a, b);
+        if (source.length() > 3) {
+            int distance = StringUtils.LevenshteinDistance(source, target);
             //tweakable parameter: edit distance past string length disparity
             if (distance <= 2) {
                 return Pair.create(true, distance);

--- a/app/src/org/commcare/android/view/EntityView.java
+++ b/app/src/org/commcare/android/view/EntityView.java
@@ -395,7 +395,7 @@ public class EntityView extends LinearLayout {
                             int indexInDisplay = normalizedDisplayString.indexOf(currentSpan);
                             int length = (curEnd - curStart);
 
-                            if (indexInDisplay != -1 && StringUtils.fuzzyMatch(currentSpan, searchText).first) {
+                            if (indexInDisplay != -1 && StringUtils.fuzzyMatch(searchText, currentSpan).first) {
                                 raw.setSpan(new BackgroundColorSpan(context.getResources().getColor(R.color.green)), indexInDisplay,
                                         indexInDisplay + length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                             }


### PR DESCRIPTION
Fixes issues where the algorithm was being triggered with too little data, and the order of arguments was being provided backwards.

Fix for http://manage.dimagi.com/default.asp?181239