### PR TITLE
Use stable robolectric version over 3.1 snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,11 @@ apply plugin: 'com.android.application'
 // we need mavenCentral to fetch eventual dependencies, such as GridViewWithHeaderAndFooter
 repositories {
   mavenCentral()
-  maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
-    testCompile "org.robolectric:robolectric:3.1-SNAPSHOT"
+    testCompile "org.robolectric:robolectric:3.0"
 
     // release build type expects javarosa and commcare jars to be in app/libs
     debugCompile project(':javarosa')


### PR DESCRIPTION
Tried to use robolectric 3.1 snapshot to see if it would fix the linking error that requires `-noverify` compiler flag. It didn't, so let's use the stable version, 3, instead of 3.1  