### PR TITLE
Enable analysis tools in odk builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
+apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
+
 
 buildscript {
     repositories {
@@ -12,12 +14,30 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.application'
-
 // we need mavenCentral to fetch eventual dependencies, such as GridViewWithHeaderAndFooter
 repositories {
   mavenCentral()
 }
+
+checkstyle {
+    toolVersion = "6.7"
+}
+
+findbugs {
+  ignoreFailures = true
+  sourceSets = [sourceSets.main]
+  effort = "max"
+}
+
+pmd {
+  ignoreFailures = true
+  sourceSets = [sourceSets.main]
+}
+
+test {
+  reports.junitXml.destination = file('build/reports/tests')
+}
+
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'

--- a/build.gradle
+++ b/build.gradle
@@ -190,5 +190,15 @@ android {
               jvmArgs '-noverify'
         }
     }
-
 }
+
+task jenkinsTest {
+    inputs.files test.outputs.files
+    doLast {
+        def timestamp = System.currentTimeMillis()
+        test.getReports().getJunitXml().getDestination().eachFile { it.lastModified = timestamp }
+    }
+}
+
+checkDebug.dependsOn(jenkinsTest)
+checkRelease.dependsOn(jenkinsTest)

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'jacoco'
 
 buildscript {
     repositories {
@@ -14,6 +15,11 @@ buildscript {
 repositories {
   mavenCentral()
 }
+
+jacoco {
+    toolVersion = "0.7.4.+"
+}
+
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
@@ -169,6 +175,8 @@ android {
       debug {
         sourceSets.main.java.srcDirs = sourceLocations + ['debug']
         debuggable true
+
+        testCoverageEnabled true
         proguardFiles getDefaultProguardFile('proguard-android.txt'), 'app/proguard.cfg'
       }
 
@@ -185,5 +193,30 @@ android {
               // bizarre reason
               jvmArgs '-noverify'
         }
+    }
+}
+
+
+task jacocoTestReport(type:JacocoReport, dependsOn: "testDebug") {
+    group = "Reporting"
+
+    description = "Generate Jacoco coverage reports"
+
+    classDirectories = fileTree(
+            dir: 'build/intermediates/classes/debug',
+            excludes: ['**/R.class',
+                       '**/R$*.class',
+                       '**/*$ViewInjector*.*',
+                       '**/BuildConfig.*',
+                       '**/Manifest*.*']
+    )
+
+    additionalSourceDirs = files(android.sourceSets.main.java.srcDirs)
+    sourceDirectories = files(android.sourceSets.main.java.srcDirs)
+    executionData = files('build/jacoco/testDebug.exec')
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'checkstyle'
-apply plugin: 'findbugs'
-apply plugin: 'pmd'
-
 
 buildscript {
     repositories {
@@ -18,20 +14,6 @@ buildscript {
 repositories {
   mavenCentral()
 }
-
-checkstyle {
-    toolVersion = "6.7"
-}
-
-findbugs {
-  ignoreFailures = true
-  effort = "max"
-}
-
-pmd {
-  ignoreFailures = true
-}
-
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'

--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,13 @@ checkstyle {
 
 findbugs {
   ignoreFailures = true
-  sourceSets = [sourceSets.main]
+  sourceSets = [android.sourceSets.main]
   effort = "max"
 }
 
 pmd {
   ignoreFailures = true
-  sourceSets = [sourceSets.main]
+  sourceSets = [android.sourceSets.main]
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,11 @@ checkstyle {
 
 findbugs {
   ignoreFailures = true
-  sourceSets = [android.sourceSets.main]
   effort = "max"
 }
 
 pmd {
   ignoreFailures = true
-  sourceSets = [android.sourceSets.main]
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,6 @@
-////////////
-// README //
-////////////
-
-// This build script assumes the following directory structure:
-// - somewhere/your/code/directory/is
-// -- commcare-odk (github: https://github.com/dimagi/commcare-odk/)
-// -- commcare (github: https://github.com/dimagi/commcare/)
-// -- javarosa (github: https://github.com/dimagi/javarosa/)
-// these directories MUST be named like this, or it won't work
+apply plugin: 'checkstyle'
+apply plugin: 'findbugs'
+apply plugin: 'pmd'
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,6 @@ pmd {
   sourceSets = [android.sourceSets.main]
 }
 
-test {
-  reports.junitXml.destination = file('build/reports/tests')
-}
-
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
@@ -211,14 +207,3 @@ android {
         }
     }
 }
-
-task jenkinsTest {
-    inputs.files test.outputs.files
-    doLast {
-        def timestamp = System.currentTimeMillis()
-        test.getReports().getJunitXml().getDestination().eachFile { it.lastModified = timestamp }
-    }
-}
-
-checkDebug.dependsOn(jenkinsTest)
-checkRelease.dependsOn(jenkinsTest)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,9 @@
+// These build settings assume the following directory structure:
+// - somewhere/your/code/directory/is
+// -- commcare-odk (github: https://github.com/dimagi/commcare-odk/)
+// -- commcare (github: https://github.com/dimagi/commcare/)
+// -- javarosa (github: https://github.com/dimagi/javarosa/)
+
 include ':libraries:mapballoons'
 include ':libraries:achartengine'
 include ':libraries:AndroidStaggeredGrid:library'


### PR DESCRIPTION
Enable checkstyle, pmd, and findbugs tools.

Run `gradle check` to generate analysis results for the odk repository.