### PR TITLE
stop version string and last sync message from overlapping

### DIFF
--- a/app/res/layout/mainnew.xml
+++ b/app/res/layout/mainnew.xml
@@ -30,13 +30,14 @@
         android:layout_alignParentTop="true"
         android:adjustViewBounds="true"
         android:paddingTop="10dp"/>
-
+
+
     <LinearLayout
         android:id="@+id/main_center_pane"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
-        android:orientation="vertical" android:layout_above="@id/home.logout" android:gravity="center_vertical|center_horizontal" android:layout_below="@id/main_top_banner">
+        android:orientation="vertical" android:layout_above="@id/str_version" android:gravity="center_vertical|center_horizontal" android:layout_below="@id/main_top_banner">
 
         <Button
             android:id="@+id/home.start"


### PR DESCRIPTION
Fix for the version string and last sync message on the home screen overlapping on some device screens (reported in Value Labs' latest response on this ticket http://manage.dimagi.com/default.asp?181690).

This is the commit where the diff is just wrong. The actual change that I made is just the following to the LinearLayout with id 'main_center_pane':

-android:layout_above="@id/home.logout"
+android:layout_above="@id/str_version"

ALL of the other additions it's showing are actually lines that were already in this file on oldui/commcare_2.23 (I double-triple-quadruple checked this because I feel like I'm going crazy). Decided I'm ok with just merging this anyway because the actual resulting change is still only what I said above. If anyone has any objections though, or any thoughts on what might be causing this, let me know.

Also worth noting that the local git diff for this commit (when I run git show f419300387e13c2015d257c93d4e38c1df1b89c4 on my computer) IS correct.

Also, I triple checked that my local branch of oldui/commcare_2.23 that I branched off of is up to date.