### PR TITLE
Fix app initialization logic error, name method better

### DIFF
--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -224,7 +224,7 @@ public class CommCareApplication extends Application {
         intializeDefaultLocalizerData();
 
         if (dbState != STATE_MIGRATION_FAILED && dbState != STATE_MIGRATION_QUESTIONABLE) {
-            initializeAppResourcesOnStartup();
+            initializeAnAppOnStartup();
         }
 
         ACRAUtil.initACRA(this);
@@ -400,7 +400,7 @@ public class CommCareApplication extends Application {
      * Performs the appropriate initialization of an application when this CommCareApplication is
      * first launched
      */
-    private void initializeAppResourcesOnStartup() {
+    private void initializeAnAppOnStartup() {
         // Before we try to initialize a new app, check if any existing apps were left in a
         // partially deleted state, and finish uninstalling them if so
         for (ApplicationRecord record : getGlobalStorage(ApplicationRecord.class)) {
@@ -419,10 +419,10 @@ public class CommCareApplication extends Application {
         // want to initialize one of them to start, so that there will be currently-seated app when
         // the login screen starts up
 
-        // If there is a 'last app' set in shared preferences, try to initialize that application.
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         String lastAppId = prefs.getString(LoginActivity.KEY_LAST_APP, "");
         if (!"".equals(lastAppId)){
+            // If there is a 'last app' set in shared preferences, try to initialize that application.
             ApplicationRecord lastApp = getAppById(lastAppId);
             if (lastApp == null || !lastApp.isUsable()) {
                 // This app record could be null if it has since been uninstalled, or unusable if
@@ -432,10 +432,10 @@ public class CommCareApplication extends Application {
             } else {
                 initializeAppResources(new CommCareApp(lastApp));
             }
+        } else {
+            // Otherwise, just pick the first app in the list to initialize
+            initFirstUsableAppRecord();
         }
-
-        // Otherwise, just pick the first app in the list to initialize
-        initFirstUsableAppRecord();
     }
 
     /**
@@ -443,7 +443,7 @@ public class CommCareApplication extends Application {
      * if there is one
      */
     public void initFirstUsableAppRecord() {
-        for(ApplicationRecord record : getUsableAppRecords()) {
+        for (ApplicationRecord record : getUsableAppRecords()) {
             initializeAppResources(new CommCareApp(record));
             break;
         }


### PR DESCRIPTION
Fix bug where missing else statement caused CCApplication to always initialize the first installed app in the db, instead of being smart about it.