### PR TITLE
FormHierarchyActivity fixes: entry background color, back button in nested entry

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -3,8 +3,6 @@ package org.odk.collect.android.activities;
 import android.app.ListActivity;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -27,18 +25,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class FormHierarchyActivity extends ListActivity {
-    private static final String TAG = FormHierarchyActivity.class.getSimpleName();
-
     private static final int CHILD = 1;
     private static final int EXPANDED = 2;
     private static final int COLLAPSED = 3;
     private static final int QUESTION = 4;
 
     private Button jumpPreviousButton;
-
     private List<HierarchyElement> formList;
     private TextView mPath;
-
     private FormIndex mStartIndex;
 
     @Override
@@ -154,7 +148,6 @@ public class FormHierarchyActivity extends ListActivity {
 
         String path = "";
         while (index != null) {
-
             path =
                     FormEntryActivity.mFormController.getCaptionPrompt(index).getLongText()
                             + " ("
@@ -408,9 +401,7 @@ public class FormHierarchyActivity extends ListActivity {
                 h.setType(EXPANDED);
                 ArrayList<HierarchyElement> children1 = h.getChildren();
                 for (int i = 0; i < children1.size(); i++) {
-                    Log.i(TAG, "adding child: " + children1.get(i).getFormIndex());
                     formList.add(position + 1 + i, children1.get(i));
-
                 }
                 h.setIcon(getResources().getDrawable(R.drawable.expander_ic_maximized));
                 h.setColor(Color.WHITE);
@@ -422,7 +413,6 @@ public class FormHierarchyActivity extends ListActivity {
                 return;
             case CHILD:
                 FormEntryActivity.mFormController.jumpToIndex(h.getFormIndex());
-                setResult(RESULT_OK);
                 refreshView();
                 return;
         }
@@ -435,11 +425,11 @@ public class FormHierarchyActivity extends ListActivity {
     }
 
     @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        switch (keyCode) {
-            case KeyEvent.KEYCODE_BACK:
-                FormEntryActivity.mFormController.jumpToIndex(mStartIndex);
+    public void onBackPressed() {
+        if (FormEntryActivity.mFormController.getFormIndex().isTerminal()) {
+            super.onBackPressed();
+        } else {
+            goUpLevel();
         }
-        return super.onKeyDown(keyCode, event);
     }
 }

--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -12,7 +12,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import org.commcare.android.framework.SessionActivityRegistration;
-import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormIndex;
@@ -42,7 +41,6 @@ public class FormHierarchyActivity extends ListActivity {
 
     private FormIndex mStartIndex;
 
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -53,9 +51,9 @@ public class FormHierarchyActivity extends ListActivity {
 
         setTitle(Localization.get("home.menu.saved.forms"));
 
-        mPath = (TextView) findViewById(R.id.pathtext);
+        mPath = (TextView)findViewById(R.id.pathtext);
 
-        jumpPreviousButton = (Button) findViewById(R.id.jumpPreviousButton);
+        jumpPreviousButton = (Button)findViewById(R.id.jumpPreviousButton);
         jumpPreviousButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -63,7 +61,7 @@ public class FormHierarchyActivity extends ListActivity {
             }
         });
 
-        Button jumpBeginningButton = (Button) findViewById(R.id.jumpBeginningButton);
+        Button jumpBeginningButton = (Button)findViewById(R.id.jumpBeginningButton);
         jumpBeginningButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -74,7 +72,7 @@ public class FormHierarchyActivity extends ListActivity {
             }
         });
 
-        Button jumpEndButton = (Button) findViewById(R.id.jumpEndButton);
+        Button jumpEndButton = (Button)findViewById(R.id.jumpEndButton);
         jumpEndButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -91,7 +89,7 @@ public class FormHierarchyActivity extends ListActivity {
             public void run() {
                 int position = 0;
                 for (int i = 0; i < getListAdapter().getCount(); i++) {
-                    HierarchyElement he = (HierarchyElement) getListAdapter().getItem(i);
+                    HierarchyElement he = (HierarchyElement)getListAdapter().getItem(i);
                     if (mStartIndex.equals(he.getFormIndex())) {
                         position = i;
                         break;
@@ -117,7 +115,6 @@ public class FormHierarchyActivity extends ListActivity {
 
         SessionActivityRegistration.unregisterSessionExpirationReceiver(this);
     }
-
 
     private void goUpLevel() {
         FormIndex index = stepIndexOut(FormEntryActivity.mFormController.getFormIndex());
@@ -152,7 +149,6 @@ public class FormHierarchyActivity extends ListActivity {
         refreshView();
     }
 
-
     private String getCurrentPath() {
         FormIndex index = stepIndexOut(FormEntryActivity.mFormController.getFormIndex());
 
@@ -160,17 +156,16 @@ public class FormHierarchyActivity extends ListActivity {
         while (index != null) {
 
             path =
-                FormEntryActivity.mFormController.getCaptionPrompt(index).getLongText()
-                        + " ("
-                        + (FormEntryActivity.mFormController.getCaptionPrompt(index)
-                                .getMultiplicity() + 1) + ") > " + path;
+                    FormEntryActivity.mFormController.getCaptionPrompt(index).getLongText()
+                            + " ("
+                            + (FormEntryActivity.mFormController.getCaptionPrompt(index)
+                            .getMultiplicity() + 1) + ") > " + path;
 
             index = stepIndexOut(index);
         }
         // return path?
         return path.substring(0, path.length() - 2);
     }
-
 
     private void refreshView() {
         // Record the current index so we can return to the same place if the user hits 'back'.
@@ -179,13 +174,13 @@ public class FormHierarchyActivity extends ListActivity {
         // If we're not at the first level, we're inside a repeated group so we want to only display
         // everything enclosed within that group.
         String enclosingGroupRef = "";
-        formList = new ArrayList<HierarchyElement>();
+        formList = new ArrayList<>();
 
         // If we're currently at a repeat node, record the name of the node and step to the next
         // node to display.
         if (FormEntryActivity.mFormController.getEvent() == FormEntryController.EVENT_REPEAT) {
             enclosingGroupRef =
-                FormEntryActivity.mFormController.getFormIndex().getReference().toString(false);
+                    FormEntryActivity.mFormController.getFormIndex().getReference().toString(false);
             FormEntryActivity.mFormController.stepToNextEvent(FormController.STEP_INTO_GROUP);
         } else {
             FormIndex startTest = stepIndexOut(currentIndex);
@@ -209,7 +204,7 @@ public class FormHierarchyActivity extends ListActivity {
             // beginning
             if (FormEntryActivity.mFormController.getEvent() == FormEntryController.EVENT_REPEAT) {
                 enclosingGroupRef =
-                    FormEntryActivity.mFormController.getFormIndex().getReference().toString(false);
+                        FormEntryActivity.mFormController.getFormIndex().getReference().toString(false);
                 FormEntryActivity.mFormController.stepToNextEvent(FormController.STEP_INTO_GROUP);
             }
         }
@@ -235,15 +230,16 @@ public class FormHierarchyActivity extends ListActivity {
         // keep track of them.
         String repeatedGroupRef = "";
 
-        event_search: while (event != FormEntryController.EVENT_END_OF_FORM) {
+        event_search:
+        while (event != FormEntryController.EVENT_END_OF_FORM) {
             switch (event) {
                 case FormEntryController.EVENT_QUESTION:
                     if (!repeatedGroupRef.equalsIgnoreCase("")) {
                         // We're in a repeating group, so skip this question and move to the next
                         // index.
                         event =
-                            FormEntryActivity.mFormController
-                                    .stepToNextEvent(FormController.STEP_INTO_GROUP);
+                                FormEntryActivity.mFormController
+                                        .stepToNextEvent(FormController.STEP_INTO_GROUP);
                         continue;
                     }
 
@@ -268,8 +264,8 @@ public class FormHierarchyActivity extends ListActivity {
                         // We're in a repeating group, so skip this repeat prompt and move to the
                         // next event.
                         event =
-                            FormEntryActivity.mFormController
-                                    .stepToNextEvent(FormController.STEP_INTO_GROUP);
+                                FormEntryActivity.mFormController
+                                        .stepToNextEvent(FormController.STEP_INTO_GROUP);
                         continue;
                     }
 
@@ -292,12 +288,12 @@ public class FormHierarchyActivity extends ListActivity {
                         // This is the start of a repeating group. We only want to display
                         // "Group #", so we mark this as the beginning and skip all of its children
                         HierarchyElement group =
-                            new HierarchyElement(fc.getLongText(), null, getResources()
-                                    .getDrawable(R.drawable.expander_ic_minimized), Color.WHITE,
-                                    COLLAPSED, fc.getIndex());
+                                new HierarchyElement(fc.getLongText(), null, getResources()
+                                        .getDrawable(R.drawable.expander_ic_minimized), Color.WHITE,
+                                        COLLAPSED, fc.getIndex());
                         repeatedGroupRef =
-                            FormEntryActivity.mFormController.getFormIndex().getReference()
-                                    .toString(false);
+                                FormEntryActivity.mFormController.getFormIndex().getReference()
+                                        .toString(false);
                         formList.add(group);
                     }
 
@@ -313,7 +309,7 @@ public class FormHierarchyActivity extends ListActivity {
                     break;
             }
             event =
-                FormEntryActivity.mFormController.stepToNextEvent(FormController.STEP_INTO_GROUP);
+                    FormEntryActivity.mFormController.stepToNextEvent(FormController.STEP_INTO_GROUP);
         }
 
         HierarchyListAdapter itla = new HierarchyListAdapter(this);
@@ -324,11 +320,8 @@ public class FormHierarchyActivity extends ListActivity {
         FormEntryActivity.mFormController.jumpToIndex(currentIndex);
     }
 
-    private int getFormEntryPromptIcon(FormEntryPrompt fep){
-        if (BuildConfig.DEBUG) {
-            Log.i("FEPICON", "FEP (" + fep.hashCode() + ") data type is: " + fep.getDataType() + " | control type is: " + fep.getControlType());
-        }
-        switch(fep.getControlType()){
+    private int getFormEntryPromptIcon(FormEntryPrompt fep) {
+        switch (fep.getControlType()) {
             case Constants.CONTROL_SELECT_ONE:
                 return R.drawable.avatar_vellum_single_answer;
             case Constants.CONTROL_SELECT_MULTI:
@@ -356,8 +349,8 @@ public class FormHierarchyActivity extends ListActivity {
         return -1;
     }
 
-    private static int getDrawableIDFor(FormEntryPrompt fep){
-        switch(fep.getDataType()){
+    private static int getDrawableIDFor(FormEntryPrompt fep) {
+        switch (fep.getDataType()) {
             case Constants.DATATYPE_TEXT:
                 return R.drawable.avatar_vellum_text;
             case Constants.DATATYPE_INTEGER:
@@ -380,7 +373,6 @@ public class FormHierarchyActivity extends ListActivity {
         return -1;
     }
 
-
     /**
      * used to go up one level in the formIndex. That is, if you're at 5_0, 1 (the second question
      * in a repeating group), this method will return a FormInex of 5_0 (the start of the repeating
@@ -394,10 +386,9 @@ public class FormHierarchyActivity extends ListActivity {
         }
     }
 
-
     @Override
     protected void onListItemClick(ListView l, View v, int position, long id) {
-        HierarchyElement h = (HierarchyElement) l.getItemAtPosition(position);
+        HierarchyElement h = (HierarchyElement)l.getItemAtPosition(position);
         if (h.getFormIndex() == null) {
             goUpLevel();
             return;
@@ -442,7 +433,6 @@ public class FormHierarchyActivity extends ListActivity {
         setListAdapter(itla);
         getListView().setSelection(position);
     }
-
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {

--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -1,8 +1,10 @@
 package org.odk.collect.android.activities;
 
+import android.app.ActionBar;
 import android.app.ListActivity;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -39,6 +41,8 @@ public class FormHierarchyActivity extends ListActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.hierarchy_layout);
+
+        addActionBarBack();
 
         // We use a static FormEntryController to make jumping faster.
         mStartIndex = FormEntryActivity.mFormController.getFormIndex();
@@ -94,6 +98,16 @@ public class FormHierarchyActivity extends ListActivity {
         });
 
         refreshView();
+    }
+
+    private void addActionBarBack() {
+        if (android.os.Build.VERSION.SDK_INT >= 11) {
+            ActionBar bar = getActionBar();
+            if (bar != null){
+                bar.setDisplayShowHomeEnabled(true);
+                bar.setDisplayHomeAsUpEnabled(true);
+            }
+        }
     }
 
     @Override
@@ -431,5 +445,15 @@ public class FormHierarchyActivity extends ListActivity {
         } else {
             goUpLevel();
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            this.onBackPressed();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/org/odk/collect/android/adapters/HierarchyListAdapter.java
+++ b/app/src/org/odk/collect/android/adapters/HierarchyListAdapter.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.odk.collect.android.adapters;
 
 import android.content.Context;
@@ -26,33 +12,27 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class HierarchyListAdapter extends BaseAdapter {
-
-    private Context mContext;
-    private List<HierarchyElement> mItems = new ArrayList<HierarchyElement>();
-
+    private final Context mContext;
+    private List<HierarchyElement> mItems = new ArrayList<>();
 
     public HierarchyListAdapter(Context context) {
         mContext = context;
     }
-
 
     @Override
     public int getCount() {
         return mItems.size();
     }
 
-
     @Override
     public Object getItem(int position) {
         return mItems.get(position);
     }
 
-
     @Override
     public long getItemId(int position) {
         return position;
     }
-
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
@@ -60,7 +40,7 @@ public class HierarchyListAdapter extends BaseAdapter {
         if (convertView == null) {
             hev = new HierarchyElementView(mContext, mItems.get(position));
         } else {
-            hev = (HierarchyElementView) convertView;
+            hev = (HierarchyElementView)convertView;
             hev.setPrimaryText(mItems.get(position).getPrimaryText());
             hev.setSecondaryText(mItems.get(position).getSecondaryText());
             hev.setIcon(mItems.get(position).getIcon());
@@ -74,9 +54,7 @@ public class HierarchyListAdapter extends BaseAdapter {
             hev.showSecondary(true);
         }
         return hev;
-
     }
-
 
     /**
      * Sets the list of items for this adapter to use.
@@ -84,5 +62,4 @@ public class HierarchyListAdapter extends BaseAdapter {
     public void setListItems(List<HierarchyElement> it) {
         mItems = it;
     }
-
 }

--- a/app/src/org/odk/collect/android/logic/HierarchyElement.java
+++ b/app/src/org/odk/collect/android/logic/HierarchyElement.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.odk.collect.android.logic;
 
 import android.graphics.drawable.Drawable;
@@ -29,86 +15,58 @@ public class HierarchyElement {
     FormIndex mFormIndex;
     ArrayList<HierarchyElement> mChildren;
 
-
     public HierarchyElement(String text1, String text2, Drawable bullet, int color, int type,
-            FormIndex f) {
+                            FormIndex f) {
         mIcon = bullet;
         mPrimaryText = text1;
         mSecondaryText = text2;
         mColor = color;
         mFormIndex = f;
         mType = type;
-        mChildren = new ArrayList<HierarchyElement>();
+        mChildren = new ArrayList<>();
     }
-
 
     public String getPrimaryText() {
         return mPrimaryText;
     }
 
-
     public String getSecondaryText() {
         return mSecondaryText;
     }
-
-
-    public void setPrimaryText(String text) {
-        mPrimaryText = text;
-    }
-
-
-    public void setSecondaryText(String text) {
-        mSecondaryText = text;
-    }
-
 
     public void setIcon(Drawable icon) {
         mIcon = icon;
     }
 
-
     public Drawable getIcon() {
         return mIcon;
     }
-
 
     public FormIndex getFormIndex() {
         return mFormIndex;
     }
 
-
     public int getType() {
         return mType;
     }
-
 
     public void setType(int newType) {
         mType = newType;
     }
 
-
     public ArrayList<HierarchyElement> getChildren() {
         return mChildren;
     }
-
 
     public void addChild(HierarchyElement h) {
         mChildren.add(h);
     }
 
-
-    public void setChildren(ArrayList<HierarchyElement> children) {
-        mChildren = children;
-    }
-
-
     public void setColor(int color) {
         mColor = color;
     }
 
-
     public int getColor() {
         return mColor;
     }
-
 }

--- a/app/src/org/odk/collect/android/views/HierarchyElementView.java
+++ b/app/src/org/odk/collect/android/views/HierarchyElementView.java
@@ -19,7 +19,7 @@ public class HierarchyElementView extends RelativeLayout {
 
         RelativeLayout layout = (RelativeLayout)inflate(context, R.layout.hierarchy_element_view, null);
 
-        layout.setBackgroundColor(it.getColor());
+        setBackgroundColor(it.getColor());
 
         mPrimaryTextView = ((TextView)layout.findViewById(R.id.hev_primary_text));
         mPrimaryTextView.setText(it.getPrimaryText());

--- a/app/src/org/odk/collect/android/views/HierarchyElementView.java
+++ b/app/src/org/odk/collect/android/views/HierarchyElementView.java
@@ -1,42 +1,23 @@
-/*
- * Copyright (C) 2009 University of Washington
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.odk.collect.android.views;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.util.Log;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.odk.collect.android.logic.HierarchyElement;
 
 public class HierarchyElementView extends RelativeLayout {
-    public static final String TAG = HierarchyElementView.class.getSimpleName();
-
-    private TextView mPrimaryTextView;
-    private TextView mSecondaryTextView;
-    private ImageView mIcon;
-
+    private final TextView mPrimaryTextView;
+    private final TextView mSecondaryTextView;
+    private final ImageView mIcon;
 
     public HierarchyElementView(Context context, HierarchyElement it) {
         super(context);
 
-        RelativeLayout layout = (RelativeLayout) inflate(context, R.layout.hierarchy_element_view, null);
+        RelativeLayout layout = (RelativeLayout)inflate(context, R.layout.hierarchy_element_view, null);
 
         layout.setBackgroundColor(it.getColor());
 
@@ -48,11 +29,6 @@ public class HierarchyElementView extends RelativeLayout {
         mIcon.setImageDrawable(it.getIcon());
 
         addView(layout);
-
-        if (BuildConfig.DEBUG) {
-            Log.i(TAG, "Type of HEV (" + hashCode() + ") is " + it.getType());
-            Log.i(TAG, "Icon of HEV (" + hashCode() + ") is " + (it.getIcon() == null ? "null" : it.getIcon().toString()));
-        }
     }
 
 
@@ -60,36 +36,29 @@ public class HierarchyElementView extends RelativeLayout {
         mPrimaryTextView.setText(text);
     }
 
-
     public void setSecondaryText(String text) {
         mSecondaryTextView.setText(text);
     }
-
 
     public void setIcon(Drawable icon) {
         mIcon.setImageDrawable(icon);
     }
 
-
     public void setColor(int color) {
         setBackgroundColor(color);
     }
-
 
     public void showSecondary(boolean bool) {
         if (bool) {
             mSecondaryTextView.setVisibility(VISIBLE);
             setMinimumHeight(dipToPx(64));
-
         } else {
             mSecondaryTextView.setVisibility(GONE);
             setMinimumHeight(dipToPx(32));
-
         }
     }
-    
-    public int dipToPx(int dip) {
-        return (int) (dip * getResources().getDisplayMetrics().density + 0.5f);
-    }
 
+    private int dipToPx(int dip) {
+        return (int)(dip * getResources().getDisplayMetrics().density + 0.5f);
+    }
 }


### PR DESCRIPTION
In the form hierarchy view for an incomplete form instance, which shows a forms questions in a list view, the back button redirects to editing the incomplete form if you are in a nested entry. The back button should really traverse back up the form hierarchy. E.g. if you enter a repeat entry, the form hierarchy drills down into that repeat entry, at which point the back button should return you to the top level hierarchy view.

Also, correctly set the background color of form question entries in this view.

Before:
![screen](https://cloud.githubusercontent.com/assets/94817/10000773/3b50bc36-606c-11e5-9c5a-6ae54c2c9e0e.png)

After:
![screen](https://cloud.githubusercontent.com/assets/94817/10000744/07300614-606c-11e5-9c8f-0065ce33a7ba.png)

Includes linting and code reformatting. I've marked the actually bug fixes with github comments.
