### PR TITLE
Login username text field focus when seating app w/o LAST_LOGGED_IN_USER field

### DIFF
--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -600,6 +600,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
         } else {
             // Otherwise, clear the username text so it does not show a username from a different app
             username.setText("");
+            username.requestFocus();
         }
 
         // Clear any password text that was entered for a different app


### PR DESCRIPTION
When seating an app in the login screen, text entry focus should be set to the username field if there isn't a last logged in user entry in the preferences.