### PR TITLE
Drop chevron from read-only entity detail

### DIFF
--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -126,6 +126,7 @@ public class EntityDetailActivity extends SessionAwareCommCareActivity implement
         });
 
         if (mViewMode) {
+            next.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
             next.setText(Localization.get("select.detail.bypass"));
         }
 


### PR DESCRIPTION
TDH requested that for entity details that don't go anywhere (namely, mobile UCR reports), the icon on the continue button be reversed. Chatted with @biyeun and decided to drop the icon altogether in that case.