### PR TITLE
Soft assert when showing view at end of form

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -946,13 +946,17 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
                 event = mFormController.stepToNextEvent(FormController.STEP_OVER_GROUP);
                 switch (event) {
                     case FormEntryController.EVENT_QUESTION:
-                    case FormEntryController.EVENT_END_OF_FORM:
                         View next = createView();
-                        if(!resuming) {
+                        if (!resuming) {
                             showView(next, AnimationType.RIGHT);
                         } else {
                             showView(next, AnimationType.FADE, false);
                         }
+                        break group_skip;
+                    case FormEntryController.EVENT_END_OF_FORM:
+                        Logger.log(AndroidLogger.SOFT_ASSERT,
+                                "Trying to show an end of form event");
+                        showPreviousView(false);
                         break group_skip;
                     case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
                         createRepeatDialog();


### PR DESCRIPTION
View creation should never happen for an end of form event. Throw a soft assert in and move the user back one step if this occurs. 