### PR TITLE
Fix button press background color change

### DIFF
--- a/app/src/org/commcare/android/view/CustomButtonWithText.java
+++ b/app/src/org/commcare/android/view/CustomButtonWithText.java
@@ -103,9 +103,9 @@ public abstract class CustomButtonWithText extends RelativeLayout {
 
         StateListDrawable sld = new StateListDrawable();
 
-        sld.addState(new int[]{android.R.attr.state_enabled}, colorDrawable);
+        sld.addState(new int[]{-android.R.attr.state_enabled}, disabledColor);
         sld.addState(new int[]{android.R.attr.state_pressed}, pressedBackground);
-        sld.addState(StateSet.WILD_CARD, disabledColor);
+        sld.addState(StateSet.WILD_CARD, colorDrawable);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             this.setBackground(sld);
         } else {


### PR DESCRIPTION
Fix for bug introduced in https://github.com/dimagi/commcare-odk/pull/599, in which I broke the functionality where the background color of CustomButtonWithText instances changes when you press them.