### PR TITLE
2.23.1 Hotfix: Add NFC permission to trigger manual new ui update

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -9,6 +9,7 @@
         tools:overrideLibrary="com.etsy.android.grid"
         tools:replace="minSdkVersion" />
 
+    <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.BROADCAST_STICKY" />


### PR DESCRIPTION
Add NFC permission to the beta to make migrating from old to new ui require user intervention 