### PR TITLE
Don't crash unregistering a receiver that wasn't previously registered

### DIFF
--- a/app/src/org/commcare/android/framework/SessionActivityRegistration.java
+++ b/app/src/org/commcare/android/framework/SessionActivityRegistration.java
@@ -41,13 +41,14 @@ public class SessionActivityRegistration {
      * methods of activities that are session sensitive.
      */
     public static void handleOrListenForSessionExpiration(Activity activity) {
+        activity.registerReceiver(userSessionExpiredReceiver, expirationFilter);
+
         synchronized (registrationLock) {
             if (unredirectedSessionExpiration) {
                 unredirectedSessionExpiration = false;
                 letHomeScreenRedirectToLogin(activity);
             }
         }
-        activity.registerReceiver(userSessionExpiredReceiver, expirationFilter);
     }
 
     /**

--- a/app/src/org/commcare/android/framework/SessionActivityRegistration.java
+++ b/app/src/org/commcare/android/framework/SessionActivityRegistration.java
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.util.Log;
 
 import org.commcare.dalvik.activities.CommCareHomeActivity;
 
@@ -14,6 +15,8 @@ import org.commcare.dalvik.activities.CommCareHomeActivity;
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public class SessionActivityRegistration {
+    private static final String TAG = SessionActivityRegistration.class.getSimpleName();
+
     public static final String USER_SESSION_EXPIRED =
             "org.commcare.dalvik.application.user_session_expired";
 
@@ -52,7 +55,12 @@ public class SessionActivityRegistration {
      * this method in onPause methods of activities that are session sensitive.
      */
     public static void unregisterSessionExpirationReceiver(Activity activity) {
-        activity.unregisterReceiver(userSessionExpiredReceiver);
+        try {
+            activity.unregisterReceiver(userSessionExpiredReceiver);
+        } catch (IllegalArgumentException e) {
+            Log.w(TAG, "Trying to unregister the session expiration receiver " +
+                    "that wasn't previously registerd.");
+        }
     }
 
     /**


### PR DESCRIPTION
Fix crash being seen on ACRA where, in onPause, unregistering the session expiration receiver that wasn't previously registered causes force close. Not sure how this could ever happen, because it should always be registered in onResume, but might as well not fail hard when this happens.

https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/524bbfea0dcd4c2ba3c645f0bb97e485