### PR TITLE
Logged in notification text change for multiple apps

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -268,6 +268,8 @@ select.detail.title=Details
 select.list.title=Select
 
 home.logged.in.message=Logged In: ${0}
+notification.logged.in=Logged Into ${0}
+
 title.datum.wrapper=[${0}]
 
 activity.task.error.generic=Unexpected error! Please try again.

--- a/app/src/org/commcare/android/database/global/models/ApplicationRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ApplicationRecord.java
@@ -9,6 +9,7 @@ import org.commcare.android.storage.framework.Persisting;
 import org.commcare.android.storage.framework.Table;
 import org.commcare.suite.model.Profile;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 
 /**
@@ -169,8 +170,13 @@ public class ApplicationRecord extends Persisted {
         this.uniqueId = p.getUniqueId();
         this.displayName = p.getDisplayName();
         if ("".equals(displayName)) {
-            // If this profile didn't have a display name, get it from Localization strings instead
-            displayName = Localization.get("app.display.name");
+            // If this profile didn't have a display name, try to get it from Localization
+            // strings instead
+            try {
+                displayName = Localization.get("app.display.name");
+            } catch (NoLocalizedTextException e) {
+                displayName = "CommCare";
+            }
         }
         this.versionNumber = p.getVersion();
         this.preMultipleAppsProfile = p.isOldVersion();

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -28,6 +28,7 @@ import org.commcare.dalvik.activities.CommCareHomeActivity;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.preferences.CommCarePreferences;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 import org.odk.collect.android.listeners.FormSaveCallback;
 
 import java.security.InvalidKeyException;
@@ -83,9 +84,9 @@ public class CommCareSessionService extends Service  {
 
     private SQLiteDatabase userDatabase;
 
-    // Unique Identification Number for the Notification.
-    // We use it on Notification start, and to cancel it.
+    // unique id for logged in notification
     private final int NOTIFICATION = org.commcare.dalvik.R.string.notificationtitle;
+
     private final int SUBMISSION_NOTIFICATION = org.commcare.dalvik.R.string.submission_notification_title;
 
     // How long to wait until we force the session to finish logging out. Set
@@ -175,9 +176,17 @@ public class CommCareSessionService extends Service  {
         // The PendingIntent to launch our activity if the user selects this notification
         PendingIntent contentIntent = PendingIntent.getActivity(this, 0, callable, 0);
 
+        String notificationText;
+        if (CommCareApplication._().getInstalledAppRecords().size() > 1) {
+            notificationText = Localization.get("notification.logged.in",
+                    new String[]{Localization.get("app.display.name")});
+        } else {
+            notificationText = getString(NOTIFICATION);
+        }
+
         // Set the icon, scrolling text and timestamp
         Notification notification = new NotificationCompat.Builder(this)
-                .setContentTitle(this.getString(org.commcare.dalvik.R.string.notificationtitle))
+                .setContentTitle(notificationText)
                 .setContentText("Session Expires: " + DateFormat.format("MMM dd h:mmaa", sessionExpireDate))
                 .setSmallIcon(org.commcare.dalvik.R.drawable.notification)
                 .setContentIntent(contentIntent)

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -29,6 +29,7 @@ import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.preferences.CommCarePreferences;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 import org.odk.collect.android.listeners.FormSaveCallback;
 
 import java.security.InvalidKeyException;
@@ -178,8 +179,12 @@ public class CommCareSessionService extends Service  {
 
         String notificationText;
         if (CommCareApplication._().getInstalledAppRecords().size() > 1) {
-            notificationText = Localization.get("notification.logged.in",
-                    new String[]{Localization.get("app.display.name")});
+            try {
+                notificationText = Localization.get("notification.logged.in",
+                        new String[]{Localization.get("app.display.name")});
+            } catch (NoLocalizedTextException e) {
+                notificationText = getString(NOTIFICATION);
+            }
         } else {
             notificationText = getString(NOTIFICATION);
         }


### PR DESCRIPTION
In response to: http://manage.dimagi.com/default.asp?183315#1021983

Release Note: If more than one app is installed, the logged in notification will include the display name of the current app.