### PR TITLE
Fix half resizing image

### DIFF
--- a/app/src/org/odk/collect/android/views/ResizingImageView.java
+++ b/app/src/org/odk/collect/android/views/ResizingImageView.java
@@ -167,7 +167,8 @@ public class ResizingImageView extends ImageView {
             height = (int) (width / ratio);
         }
 
-        return new Pair<Integer, Integer>(new Double(width * scaleFactor).intValue(), new Double(height * scaleFactor).intValue());
+        return new Pair<Integer, Integer>(new Double(width * imageScaleFactor).intValue(),
+                new Double(height * imageScaleFactor).intValue());
     }
     /*
      * The meat and potatoes of the class. Determines what algorithm to use


### PR DESCRIPTION
Fix for typo that caused image scaling to be broken, but only for the "Half" resize option

Possibly hot fixable... 

http://manage.dimagi.com/default.asp?179788
