### PR TITLE
Add missing empty constructor for IntentCallout serialization

### DIFF
--- a/app/src/org/odk/collect/android/jr/extensions/AndroidXFormExtensions.java
+++ b/app/src/org/odk/collect/android/jr/extensions/AndroidXFormExtensions.java
@@ -14,13 +14,11 @@ import java.util.Hashtable;
 
 /**
  * @author ctsims
- *
  */
 public class AndroidXFormExtensions implements XFormExtension {
-    Hashtable<String, IntentCallout> intents = new Hashtable<String, IntentCallout>(); 
+    private Hashtable<String, IntentCallout> intents = new Hashtable<>();
     
     public AndroidXFormExtensions() {
-        
     }
     
     public void registerIntent(String id, IntentCallout callout) {
@@ -45,6 +43,4 @@ public class AndroidXFormExtensions implements XFormExtension {
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out,  new ExtWrapMap(intents));
     }
-
-    
 }

--- a/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
+++ b/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
@@ -60,7 +60,11 @@ public class IntentCallout implements Externalizable {
     
     // Bundle of extra values
     public static final String INTENT_RESULT_BUNDLE = "odk_intent_bundle";
-    
+
+    public IntentCallout() {
+        // for serialization
+    }
+
     public IntentCallout(String className, Hashtable<String, XPathExpression> refs,
                          Hashtable<String, ArrayList<TreeReference>> responses, String type,
                          String component, String data, String buttonLabel, String appearance) {

--- a/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
+++ b/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
@@ -19,6 +19,7 @@ import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapList;
 import org.javarosa.core.util.externalizable.ExtWrapMap;
+import org.javarosa.core.util.externalizable.ExtWrapMapPoly;
 import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -30,9 +31,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Vector;
 
 /**
  * @author ctsims
@@ -43,7 +44,7 @@ public class IntentCallout implements Externalizable {
     private String className;
     private Hashtable<String, XPathExpression> refs;
     
-    private Hashtable<String, ArrayList<TreeReference>> responses;
+    private Hashtable<String, Vector<TreeReference>> responses;
     
     private FormDef form;
     
@@ -66,7 +67,7 @@ public class IntentCallout implements Externalizable {
     }
 
     public IntentCallout(String className, Hashtable<String, XPathExpression> refs,
-                         Hashtable<String, ArrayList<TreeReference>> responses, String type,
+                         Hashtable<String, Vector<TreeReference>> responses, String type,
                          String component, String data, String buttonLabel, String appearance) {
 
         this.className = className;
@@ -212,9 +213,8 @@ public class IntentCallout implements Externalizable {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         className = ExtUtil.readString(in);
-        refs = (Hashtable<String, XPathExpression>)ExtUtil.read(in, new ExtWrapMap(String.class, XPathExpression.class), pf);
-        responses = (Hashtable<String, ArrayList<TreeReference>>)
-                ExtUtil.read(in, new ExtWrapMap(String.class, new ExtWrapList(TreeReference.class)), pf);
+        refs = (Hashtable<String, XPathExpression>)ExtUtil.read(in, new ExtWrapMapPoly(String.class, true), pf);
+        responses = (Hashtable<String, Vector<TreeReference>>)ExtUtil.read(in, new ExtWrapMap(String.class, new ExtWrapList(TreeReference.class)), pf);
         appearance = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
         component = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
         buttonLabel = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
@@ -223,8 +223,8 @@ public class IntentCallout implements Externalizable {
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, className);
-        ExtUtil.write(out, new ExtWrapMap(refs));
-        ExtUtil.write(out, new ExtWrapMap(responses));
+        ExtUtil.write(out, new ExtWrapMapPoly(refs));
+        ExtUtil.write(out, new ExtWrapMap(responses, new ExtWrapList()));
         ExtUtil.write(out, new ExtWrapNullable(appearance));
         ExtUtil.write(out, new ExtWrapNullable(component));
         ExtUtil.write(out, new ExtWrapNullable(buttonLabel));

--- a/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
+++ b/app/src/org/odk/collect/android/jr/extensions/IntentCallout.java
@@ -96,7 +96,7 @@ public class IntentCallout implements Externalizable {
                 String key = en.nextElement();
 
                 String extraVal = XPathFuncExpr.toString(refs.get(key).eval(ec));
-                if(extraVal != null && extraVal != "") {
+                if(extraVal != null && !"".equals(extraVal)) {
                     i.putExtra(key, extraVal);
                 }
             }

--- a/app/src/org/odk/collect/android/jr/extensions/IntentExtensionParser.java
+++ b/app/src/org/odk/collect/android/jr/extensions/IntentExtensionParser.java
@@ -8,14 +8,13 @@ import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xform.parse.IElementHandler;
 import org.javarosa.xform.parse.XFormParseException;
 import org.javarosa.xform.parse.XFormParser;
-import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.kxml2.kdom.Element;
 
-import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.Vector;
 
 /**
  * @author ctsims
@@ -47,7 +46,7 @@ public class IntentExtensionParser implements IElementHandler {
         String label = e.getAttributeValue(null, "button-label");
 
         Hashtable<String, XPathExpression> extras = new Hashtable<String, XPathExpression>();
-        Hashtable<String, ArrayList<TreeReference>> response = new Hashtable<>();
+        Hashtable<String, Vector<TreeReference>> response = new Hashtable<>();
 
         for(int i = 0; i < e.getChildCount(); ++i) {
             if(e.getType(i) == Element.ELEMENT) {
@@ -64,7 +63,7 @@ public class IntentExtensionParser implements IElementHandler {
                         String key = child.getAttributeValue(null, "key");
                         String ref = child.getAttributeValue(null, "ref");
                         if (response.get(key) == null) {
-                            response.put(key, new ArrayList<TreeReference>());
+                            response.put(key, new Vector<TreeReference>());
                         }
                         response.get(key).add((TreeReference) new XPathReference(ref).getReference());
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
     testCompile "org.robolectric:robolectric:3.0"
-    testCompile project(path: ':javarosa', configuration: 'spi')
+    testCompile project(path: ':javarosa', configuration: 'testsAsJar')
     // release build type expects javarosa and commcare jars to be in app/libs
     debugCompile project(':javarosa')
     debugCompile project(':commcare')

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ repositories {
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.+'
     testCompile "org.robolectric:robolectric:3.0"
+    testCompile project(path: ':javarosa', configuration: 'spi')
     // release build type expects javarosa and commcare jars to be in app/libs
     debugCompile project(':javarosa')
     debugCompile project(':commcare')

--- a/unit-tests/resources/forms/intent_callout_serialization_test.xml
+++ b/unit-tests/resources/forms/intent_callout_serialization_test.xml
@@ -1,0 +1,72 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/jr/xforms"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>intent callout</h:title>
+        <model>
+            <instance>
+                <data name="intent callout"
+                      uiVersion="1"
+                      version="44"
+                      xmlns="http://openrosa.org/formdesigner/636A5976-5019-4AC3-B462-9744E81C85A6">
+                    <number_five/>
+                    <areamapper_result>5</areamapper_result>
+                    <callout_result/>
+                    <orx:meta xmlns:cc="http://commcarehq.org/xforms">
+                        <orx:deviceID/>
+                        <orx:timeStart/>
+                        <orx:timeEnd/>
+                        <orx:username/>
+                        <orx:userID/>
+                        <orx:instanceID/>
+                        <cc:appVersion/>
+                    </orx:meta>
+                </data>
+            </instance>
+            <instance id="commcaresession" src="jr://instance/session"/>
+            <bind nodeset="/data/number_five"/>
+            <bind nodeset="/data/areamapper_result" type="intent"/>
+            <bind nodeset="/data/callout_result"/>
+            <setvalue event="xforms-ready" ref="/data/number_five" value="5"/>
+            <itext>
+                <translation default="" lang="en">
+                    <text id="areamapper_result-label">
+                        <value>areamapper_result</value>
+                    </text>
+                    <text id="areamapper_result-hint">
+                        <value>hint message</value>
+                    </text>
+                    <text id="areamapper_result-help">
+                        <value>help message</value>
+                    </text>
+                </translation>
+            </itext>
+            <setvalue event="xforms-ready" ref="/data/meta/deviceID"
+                      value="instance('commcaresession')/session/context/deviceid"/>
+            <setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/>
+            <bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/>
+            <setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/>
+            <bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/>
+            <setvalue event="xforms-ready" ref="/data/meta/username"
+                      value="instance('commcaresession')/session/context/username"/>
+            <setvalue event="xforms-ready" ref="/data/meta/userID"
+                      value="instance('commcaresession')/session/context/userid"/>
+            <setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/>
+            <setvalue event="xforms-ready" ref="/data/meta/appVersion"
+                      value="instance('commcaresession')/session/context/appversion"/>
+        </model>
+        <odkx:intent class="com.richard.lu.areamapper" id="areamapper_result"
+                     button-label="Get Area"
+                     xmlns:odkx="http://opendatakit.org/xforms">
+            <extra key="five" ref="/data/number_five"/>
+            <response key="area" ref="/data/callout_result"/>
+        </odkx:intent>
+    </h:head>
+    <h:body>
+        <input appearance="intent:areamapper_result" ref="/data/areamapper_result">
+            <label ref="jr:itext('areamapper_result-label')"/>
+            <hint ref="jr:itext('areamapper_result-hint')"/>
+            <help ref="jr:itext('areamapper_result-help')"/>
+        </input>
+    </h:body>
+</h:html>

--- a/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -4,15 +4,13 @@ import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.dalvik.BuildConfig;
 import org.javarosa.core.model.FormDef;
-import org.javarosa.core.util.externalizable.DeserializationException;
-import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
+import org.javarosa.core.util.test.ExternalizableTest;
 import org.javarosa.xform.util.XFormUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-
-import java.io.IOException;
 
 /**
  * Tests for the serializaiton and deserialzation of XForms.
@@ -31,11 +29,7 @@ public class FormStorageTest {
     @Test
     public void testRegressionXFormSerializations() {
         FormDef def = XFormUtils.getFormFromResource("/forms/placeholder.xml");
-        try {
-            ExtUtil.deserialize(ExtUtil.serialize(def), FormDef.class, TestUtils.factory);
-        } catch (IOException | DeserializationException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e.getMessage());
-        } 
+        ExternalizableTest.testExternalizable(new ExtWrapTagged(def), new ExtWrapTagged(), TestUtils.factory, "FormDef");
+        //ExtUtil.deserialize(ExtUtil.serialize(def), FormDef.class, TestUtils.factory);
     }
 }

--- a/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -38,4 +38,15 @@ public class FormStorageTest {
             throw new RuntimeException(e.getMessage());
         } 
     }
+
+    @Test
+    public void testCalloutSerializations() {
+        FormDef def = XFormUtils.getFormFromResource("/forms/intent_callout_serialization_test.xml");
+        try {
+            ExtUtil.deserialize(ExtUtil.serialize(def), FormDef.class, TestUtils.factory);
+        } catch (IOException | DeserializationException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        }
+    }
 }

--- a/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -4,13 +4,15 @@ import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.dalvik.BuildConfig;
 import org.javarosa.core.model.FormDef;
-import org.javarosa.core.util.externalizable.ExtWrapTagged;
-import org.javarosa.core.util.test.ExternalizableTest;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.xform.util.XFormUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+
+import java.io.IOException;
 
 /**
  * Tests for the serializaiton and deserialzation of XForms.
@@ -29,7 +31,11 @@ public class FormStorageTest {
     @Test
     public void testRegressionXFormSerializations() {
         FormDef def = XFormUtils.getFormFromResource("/forms/placeholder.xml");
-        ExternalizableTest.testExternalizable(new ExtWrapTagged(def), new ExtWrapTagged(), TestUtils.factory, "FormDef");
-        //ExtUtil.deserialize(ExtUtil.serialize(def), FormDef.class, TestUtils.factory);
+        try {
+            ExtUtil.deserialize(ExtUtil.serialize(def), FormDef.class, TestUtils.factory);
+        } catch (IOException | DeserializationException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        } 
     }
 }

--- a/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -16,10 +16,10 @@ import java.io.IOException;
 
 /**
  * Tests for the serializaiton and deserialzation of XForms.
- * 
+ *
  * @author ctsims
  */
-@Config(application=org.commcare.dalvik.application.CommCareApplication.class,
+@Config(application = org.commcare.dalvik.application.CommCareApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class FormStorageTest {
@@ -27,7 +27,7 @@ public class FormStorageTest {
     public void setupTests() {
         TestUtils.initializeStaticTestStorage();
     }
-    
+
     @Test
     public void testRegressionXFormSerializations() {
         FormDef def = XFormUtils.getFormFromResource("/forms/placeholder.xml");
@@ -36,12 +36,16 @@ public class FormStorageTest {
         } catch (IOException | DeserializationException e) {
             e.printStackTrace();
             throw new RuntimeException(e.getMessage());
-        } 
+        }
     }
 
+    /**
+     * Ensure that a form that has intent callouts can be serialized and deserialized
+     */
     @Test
     public void testCalloutSerializations() {
-        FormDef def = XFormUtils.getFormFromResource("/forms/intent_callout_serialization_test.xml");
+        FormDef def =
+                XFormUtils.getFormFromResource("/forms/intent_callout_serialization_test.xml");
         try {
             ExtUtil.deserialize(ExtUtil.serialize(def), FormDef.class, TestUtils.factory);
         } catch (IOException | DeserializationException e) {


### PR DESCRIPTION
Add missing empty constructor for IntentCallout serialization because it was causing form deserialization to fail.