### PR TITLE
Drop chevron from read-only entity detail (horizontal view)

### DIFF
--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -128,6 +128,7 @@ public class EntityDetailActivity extends SessionAwareCommCareActivity implement
         if (mViewMode) {
             next.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
             next.setText(Localization.get("select.detail.bypass"));
+            next.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
         }
 
         mDetailView.setRoot((ViewGroup)container.findViewById(R.id.entity_detail_tabs));

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -128,7 +128,6 @@ public class EntityDetailActivity extends SessionAwareCommCareActivity implement
         if (mViewMode) {
             next.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
             next.setText(Localization.get("select.detail.bypass"));
-            next.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
         }
 
         mDetailView.setRoot((ViewGroup)container.findViewById(R.id.entity_detail_tabs));

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -446,8 +446,8 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
      * Get an intent for displaying the confirm detail screen for an element (either just populates
      * the given intent with the necessary information, or creates a new one if it is null)
      *
-     * @param contextRef   reference to the selected element for which to display
-     *                     detailed view
+     * @param contextRef reference to the selected element for which to display
+     *                   detailed view
      * @return The intent argument, or a newly created one, with element
      * selection information attached.
      */
@@ -463,7 +463,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
      * intent
      */
     protected static Intent populateDetailIntent(Intent detailIntent, TreeReference contextRef,
-                                         SessionDatum selectDatum, AndroidSessionWrapper asw) {
+                                                 SessionDatum selectDatum, AndroidSessionWrapper asw) {
 
         String caseId = SessionDatum.getCaseIdFromReference(
                 contextRef, selectDatum, asw.getEvaluationContext());
@@ -1004,6 +1004,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
 
             if (mViewMode) {
                 next.setVisibility(View.GONE);
+                next.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
             }
 
             String passedCommand = selectedIntent.getStringExtra(SessionFrame.STATE_COMMAND_ID);


### PR DESCRIPTION
In https://github.com/dimagi/commcare-odk/pull/645 I forgot to also make the change for the horizontal entity select+detail screen.