### PR TITLE
Fix for new Fixture Size error not being shown to the user

### DIFF
--- a/app/src/org/commcare/android/tasks/DataPullTask.java
+++ b/app/src/org/commcare/android/tasks/DataPullTask.java
@@ -281,7 +281,8 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
                     } catch (RecordTooLargeException e) {
                         e.printStackTrace();
                         Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, "Storage Full during user sync |" + e.getMessage());
-                    } 
+                        return STORAGE_FULL;
+                    }
                 } else if(pullResponse.responseCode == 412) {
                     //Our local state is bad. We need to do a full restore.
                     int returnCode = recover(requestor, factory);
@@ -533,7 +534,7 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
         SQLiteDatabase db = CommCareApplication._().getUserDbHandle();
         try {
             db.beginTransaction();
-            parser = new DataModelPullParser(stream, factory, this);
+            parser = new DataModelPullParser(stream, factory, true, false, this);
             parser.parse();
             db.setTransactionSuccessful();
         } finally {


### PR DESCRIPTION
Fixed issue where the user couldn't see the fixture message because we weren't failing fast on parse errors. Note: Will also affect apps where an individual case record is broken, but I think that'-s something we should be doing-