### PR TITLE
Perform purging of invalid archived forms in backgroud

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -153,6 +153,9 @@ form.record.unsent=Unsent
 form.record.gone=[Form Removed on Current Version]
 form.record.gone.message=The form that was used to enter this data is no longer on the current version of the app, and can't be viewed.
 
+form.archive.purge.title=Removing out-of-date archived forms
+form.archive.purge.message=Removing archived forms that are past their validation date.
+
 app.storage.missing.title=SD Card Missing
 app.storage.missing.message=Your device's SD card has been removed, please return the SD card to continue using CommCare
 app.storage.missing.button=Shutdown CommCare

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -69,7 +69,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     private boolean mBannerOverriden = false;
 
-    StateFragment stateHolder;
+    StateFragment<R> stateHolder;
 
     //fields for implementing task transitions for CommCareTaskConnector
     private boolean inTaskTransition;
@@ -109,7 +109,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         // stateHolder and its previous state aren't null if the activity is
         // being created due to an orientation change.
         if (stateHolder == null) {
-            stateHolder = new StateFragment();
+            stateHolder = new StateFragment<>();
             fm.beginTransaction().add(stateHolder, "state").commit();
             // entering new activity, not just rotating one, so release old
             // media

--- a/app/src/org/commcare/android/framework/StateFragment.java
+++ b/app/src/org/commcare/android/framework/StateFragment.java
@@ -19,11 +19,11 @@ import org.commcare.android.tasks.templates.CommCareTask;
  *
  * @author ctsims
  */
-public class StateFragment extends Fragment {
-    private CommCareActivity boundActivity;
-    private CommCareActivity lastActivity;
+public class StateFragment<R> extends Fragment {
+    private CommCareActivity<R> boundActivity;
+    private CommCareActivity<R> lastActivity;
 
-    private CommCareTask currentTask;
+    private CommCareTask<?, ?, ?, R> currentTask;
 
     private WakeLock wakelock;
 
@@ -96,7 +96,7 @@ public class StateFragment extends Fragment {
         return lastActivity;
     }
 
-    public void connectTask(CommCareTask task) {
+    public void connectTask(CommCareTask<?, ?, ?, R> task) {
         acquireWakeLock();
         this.currentTask = task;
     }

--- a/app/src/org/commcare/android/tasks/PurgeStaleArchivedFormsTask.java
+++ b/app/src/org/commcare/android/tasks/PurgeStaleArchivedFormsTask.java
@@ -20,8 +20,6 @@ import java.util.Vector;
  */
 public class PurgeStaleArchivedFormsTask<FormRecordListAcivity>
         extends CommCareTask<Void, Void, Void, FormRecordListAcivity> {
-    private static final String TAG =
-            PurgeStaleArchivedFormsTask.class.getSimpleName();
     public static final int PURGE_STALE_ARCHIVED_FORMS_TASK_ID = 1283;
     private static final Object lock = new Object();
     private static final String DAYS_TO_RETAIN_SAVED_FORMS_KEY =
@@ -31,6 +29,7 @@ public class PurgeStaleArchivedFormsTask<FormRecordListAcivity>
     private final CommCareApp app;
 
     private PurgeStaleArchivedFormsTask() {
+        TAG = PurgeStaleArchivedFormsTask.class.getSimpleName();
         app = CommCareApplication._().getCurrentApp();
         this.taskId = PURGE_STALE_ARCHIVED_FORMS_TASK_ID;
     }

--- a/app/src/org/commcare/android/tasks/TaskListener.java
+++ b/app/src/org/commcare/android/tasks/TaskListener.java
@@ -1,0 +1,14 @@
+package org.commcare.android.tasks;
+
+/**
+ * For reporting update, completion, and cancellation task events.
+ *
+ * @param <B> type of update values reported by task
+ * @param <C> type of result value reported by task
+ */
+public interface TaskListener<B, C> {
+    void handleTaskUpdate(B... updateVals);
+    void handleTaskCompletion(C result);
+    void handleTaskCancellation(C result);
+}
+

--- a/app/src/org/commcare/android/tasks/TaskListenerRegistrationException.java
+++ b/app/src/org/commcare/android/tasks/TaskListenerRegistrationException.java
@@ -1,0 +1,10 @@
+package org.commcare.android.tasks;
+
+/**
+ * Signifies an issue un/registering a task with a listening process.
+ */
+public class TaskListenerRegistrationException extends Exception {
+    public TaskListenerRegistrationException(String msg) {
+        super(msg);
+    }
+}

--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -56,15 +56,12 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
         synchronized (connectorLock) {
             CommCareTaskConnector<R> connector = getConnector();
 
-            if (connector == null) {
-                //TODO: FailedConnection
-                return;
+            if (connector != null) {
+                connector.startTaskTransition();
+                connector.stopBlockingForTask(getTaskId());
+                connector.taskCancelled(getTaskId());
+                connector.stopTaskTransition();
             }
-
-            connector.startTaskTransition();
-            connector.stopBlockingForTask(getTaskId());
-            connector.taskCancelled(getTaskId());
-            connector.stopTaskTransition();
         }
     }
 
@@ -74,18 +71,16 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
         synchronized (connectorLock) {
             //TODO: extend blocking here?
             CommCareTaskConnector<R> connector = getConnector();
-            if (connector == null) {
-                //TODO: FailedConnection
-                return;
+            if (connector != null) {
+                connector.startTaskTransition();
+                connector.stopBlockingForTask(getTaskId());
+                if (unknownError != null) {
+                    deliverError(connector.getReceiver(), unknownError);
+                    return;
+                }
+                this.deliverResult(connector.getReceiver(), result);
+                connector.stopTaskTransition();
             }
-            connector.startTaskTransition();
-            connector.stopBlockingForTask(getTaskId());
-            if (unknownError != null) {
-                deliverError(connector.getReceiver(), unknownError);
-                return;
-            }
-            this.deliverResult(connector.getReceiver(), result);
-            connector.stopTaskTransition();
         }
     }
 
@@ -100,11 +95,9 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
         super.onPreExecute();
         synchronized (connectorLock) {
             CommCareTaskConnector<R> connector = getConnector();
-            if (connector == null) {
-                //TODO: FailedConnection
-                return;
+            if (connector != null) {
+                connector.startBlockingForTask(getTaskId());
             }
-            connector.startBlockingForTask(getTaskId());
         }
     }
 

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -74,7 +74,6 @@ import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
-import org.commcare.dalvik.activities.FormRecordListActivity;
 import org.commcare.dalvik.activities.LoginActivity;
 import org.commcare.dalvik.activities.MessageActivity;
 import org.commcare.dalvik.activities.UnrecoverableErrorActivity;
@@ -895,7 +894,7 @@ public class CommCareApplication extends Application {
                         if (!User.TYPE_DEMO.equals(user.getUserType())) {
                             getCurrentApp().getAppPreferences().edit().putString(CommCarePreferences.LAST_LOGGED_IN_USER, record.getUsername()).commit();
                             try {
-                                PurgeStaleArchivedFormsTask<FormRecordListActivity> purgeTask =
+                                PurgeStaleArchivedFormsTask purgeTask =
                                         PurgeStaleArchivedFormsTask.getNewInstance();
                                 purgeTask.execute();
                             } catch (IllegalStateException e) {

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -74,6 +74,7 @@ import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.activities.FormRecordListActivity;
 import org.commcare.dalvik.activities.LoginActivity;
 import org.commcare.dalvik.activities.MessageActivity;
 import org.commcare.dalvik.activities.UnrecoverableErrorActivity;
@@ -894,7 +895,8 @@ public class CommCareApplication extends Application {
                         if (!User.TYPE_DEMO.equals(user.getUserType())) {
                             getCurrentApp().getAppPreferences().edit().putString(CommCarePreferences.LAST_LOGGED_IN_USER, record.getUsername()).commit();
                             try {
-                                PurgeStaleArchivedFormsTask purgeTask = PurgeStaleArchivedFormsTask.getNewInstance();
+                                PurgeStaleArchivedFormsTask<FormRecordListActivity> purgeTask =
+                                        PurgeStaleArchivedFormsTask.getNewInstance();
                                 purgeTask.execute();
                             } catch (IllegalStateException e) {
                                 // purge task instance already exists

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -61,6 +61,7 @@ import org.commcare.android.storage.framework.Table;
 import org.commcare.android.tasks.DataSubmissionListener;
 import org.commcare.android.tasks.ExceptionReportTask;
 import org.commcare.android.tasks.LogSubmissionTask;
+import org.commcare.android.tasks.PurgeStaleArchivedFormsTask;
 import org.commcare.android.tasks.templates.ManagedAsyncTask;
 import org.commcare.android.util.ACRAUtil;
 import org.commcare.android.util.AndroidCommCarePlatform;
@@ -91,7 +92,6 @@ import org.javarosa.core.services.storage.EntityFilter;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.PropertyUtils;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.logic.ArchivedFormManagement;
 import org.odk.collect.android.utilities.StethoInitializer;
 
 import java.io.File;
@@ -893,7 +893,12 @@ public class CommCareApplication extends Application {
                         //Register that this user was the last to successfully log in if it's a real user
                         if (!User.TYPE_DEMO.equals(user.getUserType())) {
                             getCurrentApp().getAppPreferences().edit().putString(CommCarePreferences.LAST_LOGGED_IN_USER, record.getUsername()).commit();
-                            ArchivedFormManagement.performArchivedFormPurge(getCurrentApp());
+                            try {
+                                PurgeStaleArchivedFormsTask purgeTask = PurgeStaleArchivedFormsTask.getNewInstance();
+                                purgeTask.execute();
+                            } catch (IllegalStateException e) {
+                                // purge task instance already exists
+                            }
                         }
                     }
                 }

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -893,13 +893,8 @@ public class CommCareApplication extends Application {
                         //Register that this user was the last to successfully log in if it's a real user
                         if (!User.TYPE_DEMO.equals(user.getUserType())) {
                             getCurrentApp().getAppPreferences().edit().putString(CommCarePreferences.LAST_LOGGED_IN_USER, record.getUsername()).commit();
-                            try {
-                                PurgeStaleArchivedFormsTask purgeTask =
-                                        PurgeStaleArchivedFormsTask.getNewInstance();
-                                purgeTask.execute();
-                            } catch (IllegalStateException e) {
-                                // purge task instance already exists
-                            }
+
+                            PurgeStaleArchivedFormsTask.launchPurgeTask();
                         }
                     }
                 }

--- a/unit-tests/src/org/commcare/android/tests/processing/ArchivedFormPurgeTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/ArchivedFormPurgeTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.processing;
 
 import org.commcare.android.CommCareTestRunner;
+import org.commcare.android.tasks.PurgeStaleArchivedFormsTask;
 import org.commcare.android.util.SavedFormLoader;
 import org.commcare.android.util.TestAppInstaller;
 import org.commcare.dalvik.BuildConfig;
@@ -14,7 +15,6 @@ import org.joda.time.format.DateTimeFormatter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.logic.ArchivedFormManagement;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
@@ -59,22 +59,22 @@ public class ArchivedFormPurgeTest {
         DateTime twoMonthsLater = startTestDate.plusMonths(2);
         assertEquals("Only 1 form should remain if we're 2 months past the 1st form's create date.",
                 SAVED_FORM_COUNT - 1,
-                ArchivedFormManagement.getSavedFormsToPurge(twoMonthsLater).size());
+                PurgeStaleArchivedFormsTask.getSavedFormsToPurge(twoMonthsLater).size());
 
         DateTime twentyYearsLater = startTestDate.plusYears(20);
         assertEquals("All forms should be purged if we are way in the future.",
                 SAVED_FORM_COUNT,
-                ArchivedFormManagement.getSavedFormsToPurge(twentyYearsLater).size());
+                PurgeStaleArchivedFormsTask.getSavedFormsToPurge(twentyYearsLater).size());
 
         assertEquals("When the time is the 1st form's creation time, no forms should be purged",
                 0,
-                ArchivedFormManagement.getSavedFormsToPurge(startTestDate).size());
+                PurgeStaleArchivedFormsTask.getSavedFormsToPurge(startTestDate).size());
     }
 
     @Test
     public void testPurgeDateLoading() {
         CommCareApp ccApp = CommCareApplication._().getCurrentApp();
-        int daysFormValidFor = ArchivedFormManagement.getArchivedFormsValidityInDays(ccApp);
+        int daysFormValidFor = PurgeStaleArchivedFormsTask.getArchivedFormsValidityInDays(ccApp);
         assertEquals("App should try to keep forms for 31 days", 31, daysFormValidFor);
     }
 }


### PR DESCRIPTION
Users were reporting lag upon login that was probably associated with slow archived form purging. Do this in the background. Also block users from accessing the saved forms list while the purging task is running. 

Includes some linting/small refactors to the task connector framework even though I ended up not using task connectors. Instead I chose to use the framework I created in the background update PR (https://github.com/dimagi/commcare-odk/pull/507) because they both have the same pattern of launching singleton tasks in one place that need to be connected to specific activities when they are launched. I will generalize this framework when background update PR gets merged.

Can't figure out how to get the created `CustomProgressDialog` to not cancel when the back button is pressed. Ideas?