### PR TITLE
Show user error message for XPathTypeMismatchException app crashes

### DIFF
--- a/app/src/org/commcare/android/util/CommCareExceptionHandler.java
+++ b/app/src/org/commcare/android/util/CommCareExceptionHandler.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import org.commcare.android.tasks.ExceptionReportTask;
 import org.commcare.dalvik.activities.CrashWarningActivity;
 import org.javarosa.core.util.NoLocalizedTextException;
+import org.javarosa.xpath.XPathTypeMismatchException;
 
 import java.lang.Thread.UncaughtExceptionHandler;
 
@@ -33,9 +34,8 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
         ExceptionReportTask task = new ExceptionReportTask();
         task.execute(ex);
 
-        if (warnUserAndExit(ex)) {
-            // You must close the crashed thread in order to start a new activity.
-            System.exit(0);
+        if (isUserCreatedCrash(ex)) {
+            warnUserAndExit(ex);
         } else {
             // handle error normally (report to ACRA/play store)
             parent.uncaughtException(thread, ex);
@@ -44,17 +44,20 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
 
     /**
      * Launch activity showing user details of the crash if it is something
-     * they can fix.
+     * they can fix then exit.
      */
-    private boolean warnUserAndExit(Throwable ex) {
-        if (ex instanceof NoLocalizedTextException) {
-            Intent i = new Intent(ctx, CrashWarningActivity.class);
-            i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            i.putExtra(WARNING_MESSAGE_KEY, ex.getMessage());
-            ctx.startActivity(i);
-            return true;
-        }
-        return false;
+    private void warnUserAndExit(Throwable ex) {
+        Intent i = new Intent(ctx, CrashWarningActivity.class);
+        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.putExtra(WARNING_MESSAGE_KEY, ex.getMessage());
+        ctx.startActivity(i);
+        // You must close the crashed thread in order to start a new activity.
+        System.exit(0);
+    }
+
+    private boolean isUserCreatedCrash(Throwable ex) {
+        return (ex instanceof NoLocalizedTextException ||
+                ex instanceof XPathTypeMismatchException);
     }
 }


### PR DESCRIPTION
Helped Kriti debug an app today by simply providing her with the `XPathTypeMismatchException` error message `Location /data/ql_dep_drug_history/dep_other_detail was not found`.

She said it would be really helpful if the app just told her that, so I decided to enable it for the https://github.com/dimagi/commcare-odk/pull/606 feature I implemented.

NOTE: this prevents the crash from being reported on ACRA. I don't think there is any way to report to ACRA due to threading issues. Figure it is much more valuable for the user to see these crashes than for us to see them. I did make sure the exception log submission task is called when crashes are caught this way.