### PR TITLE
Fixes for Parto persistent case tile

### DIFF
--- a/app/res/drawable/background_transparent.xml
+++ b/app/res/drawable/background_transparent.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item>
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/white" />
+    		<stroke android:color="@color/white"
+       			android:width="4dp"/>
+           <corners android:radius="18dp"/>
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/org/commcare/android/view/GridEntityView.java
+++ b/app/src/org/commcare/android/view/GridEntityView.java
@@ -76,6 +76,7 @@ public class GridEntityView extends GridLayout {
 	public double densityRowMultiplier = 1;
 	
 	public String backgroundColor;
+    private boolean usingCustomBackgroundColor;
 	
 	public double cellWidth;
 	public double cellHeight;
@@ -279,9 +280,15 @@ public class GridEntityView extends GridLayout {
                         break;
                     case ("red-background"):
                         this.setBackgroundDrawable(getResources().getDrawable(R.drawable.background_red));
+                        usingCustomBackgroundColor = true;
                         break;
                     case ("yellow-background"):
                         this.setBackgroundDrawable(getResources().getDrawable(R.drawable.background_yellow));
+                        usingCustomBackgroundColor = true;
+                        break;
+                    case ("no-background"):
+                        this.setBackgroundDrawable(getResources().getDrawable(R.drawable.background_transparent));
+                        usingCustomBackgroundColor = true;
                         break;
                 }
 			}
@@ -460,7 +467,12 @@ public class GridEntityView extends GridLayout {
         this.searchTerms = currentSearchTerms;
     }
 
-    public void setTextColor(int color){
+    public void setTextColor(int color) {
+        if (usingCustomBackgroundColor) {
+            // If this case tile has a custom background color, we don't want to use a text color
+            // that was chosen to match the default background; just let the original color stand
+            return;
+        }
         for (int i = 0; i < mRowViews.length; i++) {
             View v = mRowViews[i];
             if (v == null) continue;
@@ -470,7 +482,12 @@ public class GridEntityView extends GridLayout {
         }
     }
 
-    public void setTitleTextColor(int color){
+    public void setTitleTextColor(int color) {
+        if (usingCustomBackgroundColor) {
+            // If this case tile has a custom background color, we don't want to use a text color
+            // that was chosen to match the default background; just let the original color stand
+            return;
+        }
         for (int i = 0; i < mRowViews.length; i++) {
             View v = mRowViews[i];
             if (v == null) continue;

--- a/app/src/org/commcare/android/view/TabbedDetailView.java
+++ b/app/src/org/commcare/android/view/TabbedDetailView.java
@@ -2,7 +2,6 @@ package org.commcare.android.view;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewPager;
@@ -53,7 +52,6 @@ public class TabbedDetailView extends RelativeLayout {
 
     private void loadViewConfig(Context context, AttributeSet attrs) {
         TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.TabbedDetailView);
-        Resources.Theme theme = context.getTheme();
         int[] defaults = AndroidUtil.getThemeColorIDs(context, new int[]{R.attr.detail_even_row_color, R.attr.detail_odd_row_color});
 
         mEvenColor = typedArray.getColor(R.styleable.TabbedDetailView_even_row_color, defaults[0]);

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -10,7 +10,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.RelativeLayout;
 
-import org.commcare.android.adapters.EntityDetailAdapter;
 import org.commcare.android.framework.ManagedUi;
 import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
@@ -46,7 +45,6 @@ public class EntityDetailActivity extends SessionAwareCommCareActivity implement
     public static final String DETAIL_PERSISTENT_ID = "eda_persistent_id";
 
     Entity<TreeReference> entity;
-    EntityDetailAdapter adapter;
     NodeEntityFactory factory;
     Pair<Detail, TreeReference> mEntityContext;
 


### PR DESCRIPTION
Fixes 2 related issues with the persistent case tile in the Parto app:

1)
-Problem: The app uses 3 colors for its case tiles, depending on the value a specific case property: either red, yellow, or transparent. The transparent option was causing problems in persistent tile form, because we have a default background color for persistent tiles of dark blue, so the transparent background was allowing that to show through, rather than appearing white as it does in the case list. Maryam and Joy (understandably) want the case tile to look consistent between the case list view and the detail view.
-Solution: Add an explicit "no-background" field in the custom xml for those case tiles in the Parto app, and then check for that value in the same way that "red-background" and "yellow-background" are being checked for, and set a white background in that case.

2)
-Problem: Because our default background color for persistent case tiles is dark blue, we set a white text color for those tiles. However, this looks odd against the red background, and is obviously illegible against the white and yellow backgrounds.
-Solution: Set a flag that indicates if an app is using a custom background color, and if it is, don't actually execute the contents of setTextColor() or setTitleTextColor()

..I realize both of these solutions are a bit hacky, but the whole framework for these case tiles is a little hacky and very fragile, so I wasn't really comfortable digging deeper to really refactor how things are done, given the timeframe we're aiming for.