### PR TITLE
Use the latest support libs | Round 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.+'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.robolectric:robolectric:3.0"
     testCompile project(path: ':javarosa', configuration: 'testsAsJar')
     // release build type expects javarosa and commcare jars to be in app/libs
@@ -40,8 +40,8 @@ dependencies {
     compile project(':libraries:AndroidStaggeredGrid:library')
     compile fileTree(dir: 'app/libs', include: '*.jar')
     compile 'in.srain.cube:grid-view-with-header-footer:1.0.12'
-    compile 'com.android.support:support-v4:22.2.1'
-    compile 'com.android.support:gridlayout-v7:22.2.1'
+    compile 'com.android.support:support-v4:23.0.1'
+    compile 'com.android.support:gridlayout-v7:23.0.1'
     debugCompile 'com.facebook.stetho:stetho:1.1.1'
     compile 'com.madgag.spongycastle:core:1.52.0.0'
     compile 'com.madgag.spongycastle:prov:1.52.0.0'


### PR DESCRIPTION
Retrying https://github.com/dimagi/commcare-odk/pull/684, but this time verified it builds on jenkins http://jenkins.dimagi.com/job/test-odk-build/1/console