### PR TITLE
Revert resizing change

### DIFF
--- a/app/src/org/odk/collect/android/views/ResizingImageView.java
+++ b/app/src/org/odk/collect/android/views/ResizingImageView.java
@@ -140,14 +140,14 @@ public class ResizingImageView extends ImageView {
     }
 
     private Pair<Integer,Integer> getWidthHeight(int widthMeasureSpec, int heightMeasureSpec, double imageScaleFactor) {
-        double maxWidth = mMaxWidth;
-        double maxHeight = mMaxHeight;
+        int maxWidth = mMaxWidth;
+        int maxHeight = mMaxHeight;
 
         if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.AT_MOST) {
-            maxWidth = Math.min(MeasureSpec.getSize(widthMeasureSpec), mMaxWidth) * imageScaleFactor;
+            maxWidth = Math.min(MeasureSpec.getSize(widthMeasureSpec), mMaxWidth);
         }
         if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.AT_MOST) {
-            maxHeight = Math.min(MeasureSpec.getSize(heightMeasureSpec), mMaxHeight) * imageScaleFactor;
+            maxHeight = Math.min(MeasureSpec.getSize(heightMeasureSpec), mMaxHeight);
         }
 
         Drawable drawable = getDrawable();
@@ -156,8 +156,8 @@ public class ResizingImageView extends ImageView {
         float dHeight = dipToPixels(getContext(), drawable.getIntrinsicHeight());
         float ratio = (dWidth) / dHeight;
 
-        double width = (int) Math.min(Math.max(dWidth, getSuggestedMinimumWidth()), maxWidth);
-        double height = (int) (width / ratio);
+        int width = (int) Math.min(Math.max(dWidth, getSuggestedMinimumWidth()), maxWidth);
+        int height = (int) (width / ratio);
 
         height = Math.min(Math.max(height, getSuggestedMinimumHeight()), maxHeight);
         width = (int) (height * ratio);
@@ -167,7 +167,8 @@ public class ResizingImageView extends ImageView {
             height = (int) (width / ratio);
         }
 
-        return new Pair<Integer, Integer>(new Double(width).intValue(), new Double(height).intValue());
+        return new Pair<Integer, Integer>(new Double(width * imageScaleFactor).intValue(),
+                new Double(height * imageScaleFactor).intValue());
     }
     /*
      * The meat and potatoes of the class. Determines what algorithm to use

--- a/app/src/org/odk/collect/android/views/ResizingImageView.java
+++ b/app/src/org/odk/collect/android/views/ResizingImageView.java
@@ -156,15 +156,15 @@ public class ResizingImageView extends ImageView {
         float dHeight = dipToPixels(getContext(), drawable.getIntrinsicHeight());
         float ratio = (dWidth) / dHeight;
 
-        double width = Math.min(Math.max(dWidth, getSuggestedMinimumWidth()), maxWidth);
-        double height = width / ratio;
+        double width = (int) Math.min(Math.max(dWidth, getSuggestedMinimumWidth()), maxWidth);
+        double height = (int) (width / ratio);
 
         height = Math.min(Math.max(height, getSuggestedMinimumHeight()), maxHeight);
-        width = height * ratio;
+        width = (int) (height * ratio);
 
         if (width > maxWidth) {
             width = maxWidth;
-            height = width / ratio;
+            height = (int) (width / ratio);
         }
 
         return new Pair<Integer, Integer>(new Double(width).intValue(), new Double(height).intValue());


### PR DESCRIPTION
@wpride: https://github.com/dimagi/commcare-odk/pull/695 broke half-size image resizing for ICDS, in that the earlier issues from this ticket http://manage.dimagi.com/default.asp?179788 returned (images that should be half size are taking up the full screen).  Haven't looked closely as to why, but reverting for now. Any new fixes should definitely be tested on ICDS itself to see what things look like there. 

Worth noting that I'm working on a more robust/consistent way of doing image inflation that should render the ResizingImageView stuff unnecessary. But that's not going to be done in time for them to start rolling out next week, so this solution has to work for them for now.