### PR TITLE
Image-above-text configuration option in QuestionWidgets

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -114,11 +114,6 @@ Copyright (c) 2012 readyState Software Ltd.</string>
         <item>Enabled</item>
         <item>Disabled</item>
     </string-array>
-    <string-array name="question_text_layout_vals">
-        <item>side-by-side</item>
-        <item>image-below-text</item>
-        <item>image-above-text</item>
-    </string-array>
 
     <item name="detail_size_cutoff" format="integer" type="integer">500</item>
 

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -110,9 +110,14 @@ Copyright (c) 2012 readyState Software Ltd.</string>
         <item>yes</item>
         <item>no</item>
     </string-array>
-    <string-array name="pref_enabled_lables">
+    <string-array name="pref_enabled_labels">
         <item>Enabled</item>
         <item>Disabled</item>
+    </string-array>
+    <string-array name="question_text_layout_vals">
+        <item>side-by-side</item>
+        <item>image-below-text</item>
+        <item>image-above-text</item>
     </string-array>
 
     <item name="detail_size_cutoff" format="integer" type="integer">500</item>

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -15,13 +15,13 @@ the License.
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-superuser-enabled"
         android:title="Developer Mode Enabled" />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-action-nav-enabled"
         android:title="Action Bar Enabled"
@@ -29,13 +29,13 @@ the License.
         />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-grid-menus"
         android:title="Grid Menus Enabled" />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-nav-ui-enabled"
         android:title="Navigation UI"
@@ -43,26 +43,33 @@ the License.
         />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-list-refresh"
         android:title="Entity List Screen Auto-Refresh" />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-newest-version-from-hq"
         android:title="Use Newest App Version From HQ" />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-css-enabled"
         android:title="CSS Enabled" />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/pref_enabled_lables"
+        android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-markdown-enabled"
         android:title="Markdown Enabled" />
+    <ListPreference
+        android:enabled="true"
+        android:entries="@array/question_text_layout_vals"
+        android:entryValues="@array/question_text_layout_vals"
+        android:key="cc-question-text-format"
+        android:title="Question Text Format Options"
+        android:defaultValue="image-below-text" />
 </PreferenceScreen>

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -67,9 +67,8 @@ the License.
         android:title="Markdown Enabled" />
     <ListPreference
         android:enabled="true"
-        android:entries="@array/question_text_layout_vals"
-        android:entryValues="@array/question_text_layout_vals"
-        android:key="cc-question-text-format"
-        android:title="Question Text Format Options"
-        android:defaultValue="image-below-text" />
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-alternate-question-text-format"
+        android:title="Image Above Question Text Enabled" />
 </PreferenceScreen>

--- a/app/res/xml/server_preferences.xml
+++ b/app/res/xml/server_preferences.xml
@@ -27,7 +27,7 @@ the License.
     <EditTextPreference android:key="default_key_server" android:enabled="true" android:title="Key Server" android:defaultValue="@string/key_server"></EditTextPreference>
     <EditTextPreference android:key="form-record-url" android:enabled="true" android:title="Form Record Server" android:defaultValue="@string/form_record_url"></EditTextPreference>
     <ListPreference android:key="cc-autoup-freq" android:enabled="true" android:title="Auto Update Frequency" android:entryValues="@array/frequency_vals" android:entries="@array/frequency_vals_labels"/>
-    <ListPreference android:key="cc-fuzzy-search-enabled" android:enabled="true" android:title="Fuzzy Search Matches" android:entryValues="@array/pref_enabled_vals" android:entries="@array/pref_enabled_lables" android:defaultValue="no"/>
+    <ListPreference android:key="cc-fuzzy-search-enabled" android:enabled="true" android:title="Fuzzy Search Matches" android:entryValues="@array/pref_enabled_vals" android:entries="@array/pref_enabled_labels" android:defaultValue="no"/>
     <PreferenceScreen android:key="print-doc-location" android:enabled="true" android:title="Set Print Template" android:dialogTitle="Set Print Template Location" android:id="@+id/printlocation"/>
 
 </PreferenceScreen>

--- a/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
@@ -37,7 +37,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity {
     // Does the user want to download the latest app version deployed (built),
     // not just the latest app version released (starred)?
     public final static String NEWEST_APP_VERSION_ENABLED = "cc-newest-version-from-hq";
-    public final static String QUESTION_TEXT_FORMAT = "cc-question-text-format";
+    public final static String ALTERNATE_QUESTION_LAYOUT_ENABLED = "cc-alternate-question-text-format";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -117,14 +117,9 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity {
         return doesPropertyMatch(MARKDOWN_ENABLED, CommCarePreferences.NO, CommCarePreferences.YES);
     }
 
-    public static String getQuestionTextFormat() {
-        String defaultValue = "image-below-text";
-        CommCareApp app = CommCareApplication._().getCurrentApp();
-        if (app == null) {
-            return defaultValue;
-        }
-        SharedPreferences properties = app.getAppPreferences();
-        return properties.getString(QUESTION_TEXT_FORMAT, defaultValue);
+    public static boolean imageAboveTextEnabled() {
+        return doesPropertyMatch(ALTERNATE_QUESTION_LAYOUT_ENABLED, CommCarePreferences.NO,
+                CommCarePreferences.YES);
     }
 
 }

--- a/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
@@ -37,6 +37,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity {
     // Does the user want to download the latest app version deployed (built),
     // not just the latest app version released (starred)?
     public final static String NEWEST_APP_VERSION_ENABLED = "cc-newest-version-from-hq";
+    public final static String QUESTION_TEXT_FORMAT = "cc-question-text-format";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -102,7 +103,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity {
         return properties.getString(LIST_REFRESH_ENABLED, CommCarePreferences.NO).equals(CommCarePreferences.YES);
     }
 
-
     /**
      * @return true if developer option to download the latest app version
      * deployed (built) is enabled.  Otherwise the latest released (starred)
@@ -115,6 +115,16 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity {
 
     public static boolean isMarkdownEnabled(){
         return doesPropertyMatch(MARKDOWN_ENABLED, CommCarePreferences.NO, CommCarePreferences.YES);
+    }
+
+    public static String getQuestionTextFormat() {
+        String defaultValue = "image-below-text";
+        CommCareApp app = CommCareApplication._().getCurrentApp();
+        if (app == null) {
+            return defaultValue;
+        }
+        SharedPreferences properties = app.getAppPreferences();
+        return properties.getString(QUESTION_TEXT_FORMAT, defaultValue);
     }
 
 }

--- a/app/src/org/odk/collect/android/views/media/MediaLayout.java
+++ b/app/src/org/odk/collect/android/views/media/MediaLayout.java
@@ -281,26 +281,16 @@ public class MediaLayout extends RelativeLayout {
                     questionTextPane.addView(mediaPane, mediaPaneParams);
                 }
             } else {
-                String questionTextFormat = DeveloperPreferences.getQuestionTextFormat();
-                switch(questionTextFormat) {
-                    case "side-by-side":
-                        mediaPaneParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                        this.addView(mediaPane, mediaPaneParams);
-                        questionTextPaneParams.addRule(RelativeLayout.LEFT_OF, mediaPane.getId());
-                        this.addView(questionTextPane, questionTextPaneParams);
-                        break;
-                    case "image-below-text":
-                        this.addView(questionTextPane, questionTextPaneParams);
-                        mediaPaneParams.addRule(RelativeLayout.BELOW, questionTextPane.getId());
-                        mediaPaneParams.addRule(CENTER_HORIZONTAL);
-                        this.addView(mediaPane, mediaPaneParams);
-                        break;
-                    case "image-above-text":
-                        mediaPaneParams.addRule(CENTER_HORIZONTAL);
-                        this.addView(mediaPane, mediaPaneParams);
-                        questionTextPaneParams.addRule(RelativeLayout.BELOW, mediaPane.getId());
-                        this.addView(questionTextPane, questionTextPaneParams);
-                        break;
+                if (DeveloperPreferences.imageAboveTextEnabled()) {
+                    mediaPaneParams.addRule(CENTER_HORIZONTAL);
+                    this.addView(mediaPane, mediaPaneParams);
+                    questionTextPaneParams.addRule(RelativeLayout.BELOW, mediaPane.getId());
+                    this.addView(questionTextPane, questionTextPaneParams);
+                } else {
+                    this.addView(questionTextPane, questionTextPaneParams);
+                    mediaPaneParams.addRule(RelativeLayout.BELOW, questionTextPane.getId());
+                    mediaPaneParams.addRule(CENTER_HORIZONTAL);
+                    this.addView(mediaPane, mediaPaneParams);
                 }
             }
         } else {

--- a/app/src/org/odk/collect/android/views/media/MediaLayout.java
+++ b/app/src/org/odk/collect/android/views/media/MediaLayout.java
@@ -270,38 +270,39 @@ public class MediaLayout extends RelativeLayout {
 
         if (mediaPane != null) {
 
-            String questionTextFormat = DeveloperPreferences.getQuestionTextFormat();
-            switch(questionTextFormat) {
-                case "side-by-side":
-                    mediaPaneParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                    this.addView(mediaPane, mediaPaneParams);
-                    questionTextPaneParams.addRule(RelativeLayout.LEFT_OF, mediaPane.getId());
-                    this.addView(questionTextPane, questionTextPaneParams);
-                    break;
-                case "image-below-text":
-                    this.addView(questionTextPane, questionTextPaneParams);
-                    mediaPaneParams.addRule(RelativeLayout.BELOW, questionTextPane.getId());
-                    mediaPaneParams.addRule(CENTER_HORIZONTAL);
-                    this.addView(mediaPane, mediaPaneParams);
-                    break;
-                case "image-above-text":
-                    mediaPaneParams.addRule(CENTER_HORIZONTAL);
-                    this.addView(mediaPane, mediaPaneParams);
-                    questionTextPaneParams.addRule(RelativeLayout.BELOW, mediaPane.getId());
-                    this.addView(questionTextPane, questionTextPaneParams);
-                    break;
+            if (!textVisible) {
+                this.addView(questionTextPane, questionTextPaneParams);
+                if (mAudioButton != null) {
+                    mediaPaneParams.addRule(RelativeLayout.LEFT_OF, mAudioButton.getId());
+                    questionTextPane.addView(mediaPane, mediaPaneParams);
+                }
+                if (mVideoButton != null) {
+                    mediaPaneParams.addRule(RelativeLayout.LEFT_OF, mVideoButton.getId());
+                    questionTextPane.addView(mediaPane, mediaPaneParams);
+                }
+            } else {
+                String questionTextFormat = DeveloperPreferences.getQuestionTextFormat();
+                switch(questionTextFormat) {
+                    case "side-by-side":
+                        mediaPaneParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                        this.addView(mediaPane, mediaPaneParams);
+                        questionTextPaneParams.addRule(RelativeLayout.LEFT_OF, mediaPane.getId());
+                        this.addView(questionTextPane, questionTextPaneParams);
+                        break;
+                    case "image-below-text":
+                        this.addView(questionTextPane, questionTextPaneParams);
+                        mediaPaneParams.addRule(RelativeLayout.BELOW, questionTextPane.getId());
+                        mediaPaneParams.addRule(CENTER_HORIZONTAL);
+                        this.addView(mediaPane, mediaPaneParams);
+                        break;
+                    case "image-above-text":
+                        mediaPaneParams.addRule(CENTER_HORIZONTAL);
+                        this.addView(mediaPane, mediaPaneParams);
+                        questionTextPaneParams.addRule(RelativeLayout.BELOW, mediaPane.getId());
+                        this.addView(questionTextPane, questionTextPaneParams);
+                        break;
+                }
             }
-
-            RelativeLayout parent = this;
-            if (mAudioButton != null && !textVisible) {
-                mediaPaneParams.addRule(RelativeLayout.LEFT_OF, mAudioButton.getId());
-                parent = questionTextPane;
-            }
-            if (mVideoButton != null && !textVisible) {
-                mediaPaneParams.addRule(RelativeLayout.LEFT_OF, mVideoButton.getId());
-                parent = questionTextPane;
-            }
-
         } else {
             this.addView(questionTextPane, questionTextPaneParams);
         }


### PR DESCRIPTION
Creates a developer preference which, if enabled, places images above question text in a question widget, instead of below.