### PR TITLE
Don't use deprecated Fragment.onAttach(Activity)

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -308,7 +308,7 @@
             android:windowSoftInputMode="adjustResize" >
         </activity>
         <activity
-            android:name="org.odk.collect.android.preferences.PreferencesActivity"
+            android:name="org.odk.collect.android.preferences.FormEntryPreferences"
             android:windowSoftInputMode="adjustResize" >
         </activity>
         <activity

--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -8,7 +8,6 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.Button;
@@ -133,14 +132,13 @@ public class SetupEnterURLFragment extends Fragment {
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+    public void onAttach(Context context) {
+        super.onAttach(context);
 
-        super.onAttach(activity);
-        if (!(activity instanceof URLInstaller)) {
-            throw new ClassCastException(activity + " must implemement " + interfaceName);
+        if (!(context instanceof URLInstaller)) {
+            throw new ClassCastException(context + " must implemement " + interfaceName);
         } else {
-            listener = (URLInstaller)activity;
+            listener = (URLInstaller)context;
         }
     }
 }

--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.Button;
@@ -134,6 +135,10 @@ public class SetupEnterURLFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
+
+        if (context instanceof Activity) {
+            ((Activity)context).getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+        }
 
         if (!(context instanceof URLInstaller)) {
             throw new ClassCastException(context + " must implemement " + interfaceName);

--- a/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupKeepInstallFragment.java
@@ -1,6 +1,6 @@
 package org.commcare.android.fragments;
 
-import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -27,13 +27,13 @@ public class SetupKeepInstallFragment extends Fragment {
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        if (!(activity instanceof StartStopInstallCommands)) {
-            throw new ClassCastException(activity + " must implemement " + StartStopInstallCommands.class.getName());
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (!(context instanceof StartStopInstallCommands)) {
+            throw new ClassCastException(context + " must implemement " + StartStopInstallCommands.class.getName());
         }
 
-        this.buttonCommands = (StartStopInstallCommands)activity;
+        this.buttonCommands = (StartStopInstallCommands)context;
     }
 
     @Override

--- a/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.app.ActionBar;
 import android.app.ActionBar.LayoutParams;
 import android.app.Activity;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -25,6 +26,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.commcare.android.database.user.models.ACase;
+import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.models.AndroidSessionWrapper;
 import org.commcare.android.models.Entity;
 import org.commcare.android.models.NodeEntityFactory;
@@ -45,6 +47,7 @@ import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.Logger;
 
 import java.util.Vector;
 
@@ -78,9 +81,13 @@ public class BreadcrumbBarFragment extends Fragment {
      * reference to the newly created Activity after each configuration change.
      */
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        refresh(activity);
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof Activity) {
+            refresh((Activity)context);
+        } else {
+            Logger.log(AndroidLogger.SOFT_ASSERT, "Unable to attach breadcrumb bar fragment");
+        }
     }
 
     public void refresh(Activity activity) {

--- a/app/src/org/commcare/android/framework/FileServerFragment.java
+++ b/app/src/org/commcare/android/framework/FileServerFragment.java
@@ -1,8 +1,7 @@
 package org.commcare.android.framework;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.app.ProgressDialog;
+import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -31,10 +30,7 @@ import java.net.Socket;
  */
 @SuppressLint("NewApi")
 public class FileServerFragment extends Fragment {
-
-    protected static final int CHOOSE_FILE_RESULT_CODE = 20;
     private View mContentView = null;
-    ProgressDialog progressDialog = null;
 
     private static CommCareWiFiDirectActivity mActivity;
 
@@ -51,14 +47,13 @@ public class FileServerFragment extends Fragment {
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
+    public void onAttach(Context context) {
+        super.onAttach(context);
         try {
-            mActivity = (CommCareWiFiDirectActivity) activity;
+            mActivity = (CommCareWiFiDirectActivity)context;
         } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString() + " must implement fileServerListener");
+            throw new ClassCastException(context.toString() + " must implement fileServerListener");
         }
-
     }
 
     @Override

--- a/app/src/org/commcare/android/framework/StateFragment.java
+++ b/app/src/org/commcare/android/framework/StateFragment.java
@@ -1,6 +1,5 @@
 package org.commcare.android.framework;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -35,11 +34,11 @@ public class StateFragment<R> extends Fragment {
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
+    public void onAttach(Context context) {
+        super.onAttach(context);
 
-        if (activity instanceof CommCareActivity) {
-            this.boundActivity = (CommCareActivity) activity;
+        if (context instanceof CommCareActivity) {
+            this.boundActivity = (CommCareActivity)context;
             this.boundActivity.stateHolder = this;
 
             if (isCurrentTaskRunning()) {

--- a/app/src/org/commcare/android/framework/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/android/framework/WiFiDirectManagementFragment.java
@@ -17,8 +17,7 @@
 package org.commcare.android.framework;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.Intent;
 import android.net.wifi.p2p.WifiP2pDevice;
 import android.net.wifi.p2p.WifiP2pInfo;
@@ -46,15 +45,11 @@ import org.javarosa.core.services.Logger;
  * i.e. setting up network connection and transferring data.
  */
 @SuppressLint("NewApi")
-public class WiFiDirectManagementFragment extends Fragment implements ConnectionInfoListener, ActionListener, ChannelListener {
-
-    private View mContentView = null;
-    ProgressDialog progressDialog = null;
-
+public class WiFiDirectManagementFragment extends Fragment
+        implements ConnectionInfoListener, ActionListener, ChannelListener {
     private static CommCareWiFiDirectActivity mActivity;
 
     private TextView mStatusText;
-    private View mView;
 
     private boolean isWifiP2pEnabled;
     private boolean isHost;
@@ -73,23 +68,22 @@ public class WiFiDirectManagementFragment extends Fragment implements Connection
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
+    public void onAttach(Context context) {
+        super.onAttach(context);
         try {
-            mActivity = (CommCareWiFiDirectActivity) activity;
+            mActivity = (CommCareWiFiDirectActivity) context;
         } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString() + " must implement fileServerListener");
+            throw new ClassCastException(context.toString() + " must implement fileServerListener");
         }
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-
-        mContentView = inflater.inflate(R.layout.wifi_manager, null);
+        View mContentView = inflater.inflate(R.layout.wifi_manager, null);
 
         mStatusText = (TextView) mContentView.findViewById(R.id.wifi_manager_status_text);
 
-        mView = (View) mContentView.findViewById(R.id.wifi_manager_view);
+        View mView = (View) mContentView.findViewById(R.id.wifi_manager_view);
 
         return mContentView;
     }

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.commcare.dalvik.preferences;
 
 import android.content.ActivityNotFoundException;
@@ -42,8 +26,9 @@ import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 import org.odk.collect.android.utilities.FileUtils;
 
-public class CommCarePreferences extends SessionAwarePreferenceActivity implements OnSharedPreferenceChangeListener {
-
+public class CommCarePreferences
+        extends SessionAwarePreferenceActivity
+        implements OnSharedPreferenceChangeListener {
     //So these are stored in the R files, but I dont' seem to be able to figure out how to pull them
     //out cleanly?
     public final static String AUTO_SYNC_FREQUENCY = "cc-autosync-freq";
@@ -68,13 +53,10 @@ public class CommCarePreferences extends SessionAwarePreferenceActivity implemen
     public final static String SHORT = "log_short";
     public final static String FULL = "log_full";
 
+    // TODO PLM: these flags aren't provided by HQ built apps,
+    // should be replaced with LOG_WEEKLY_SUBMIT above!
     public final static String LOG_LAST_DAILY_SUBMIT = "log_prop_last_daily";
     public final static String LOG_NEXT_WEEKLY_SUBMIT = "log_prop_next_weekly";
-
-    public final static String FORM_MANAGEMENT = "cc-form-management";
-    public final static String PROPERTY_ENABLED = "enabled";
-    public final static String PROPERTY_DISABLED = "disabled";
-
 
     public final static String LAST_LOGGED_IN_USER = "last_logged_in_user";
     public final static String CONTENT_VALIDATED = "cc-content-valid";
@@ -107,7 +89,6 @@ public class CommCarePreferences extends SessionAwarePreferenceActivity implemen
     private static final int REQUEST_TEMPLATE = 0;
     public final static String PRINT_DOC_LOCATION = "print_doc_location";
     private final static String PREF_MANAGER_PRINT_KEY = "print-doc-location";
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -166,7 +147,6 @@ public class CommCarePreferences extends SessionAwarePreferenceActivity implemen
                 Toast.makeText(this, Localization.get("template.not.set"), Toast.LENGTH_SHORT).show();
             }
         }
-
     }
 
     @Override
@@ -181,7 +161,6 @@ public class CommCarePreferences extends SessionAwarePreferenceActivity implemen
 
         return true;
     }
-
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
@@ -229,7 +208,6 @@ public class CommCarePreferences extends SessionAwarePreferenceActivity implemen
     }
 
     public static boolean isSavedFormsEnabled() {
-
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
         //If there is a setting for form management it takes precedence
         if (properties.contains(ENABLE_SAVED_FORMS)) {
@@ -332,5 +310,4 @@ public class CommCarePreferences extends SessionAwarePreferenceActivity implemen
                     Localization.get("no.file.browser"), false);
         }
     }
-
 }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -88,7 +88,7 @@ import org.odk.collect.android.listeners.FormSavedListener;
 import org.odk.collect.android.listeners.WidgetChangedListener;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.logic.PropertyManager;
-import org.odk.collect.android.preferences.PreferencesActivity;
+import org.odk.collect.android.preferences.FormEntryPreferences;
 import org.odk.collect.android.tasks.FormLoaderTask;
 import org.odk.collect.android.tasks.SaveToDiskTask;
 import org.odk.collect.android.utilities.Base64Wrapper;
@@ -718,7 +718,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
                 startActivityForResult(i, HIERARCHY_ACTIVITY);
                 return true;
             case MENU_PREFERENCES:
-                Intent pref = new Intent(this, PreferencesActivity.class);
+                Intent pref = new Intent(this, FormEntryPreferences.class);
                 startActivity(pref);
                 return true;
             case android.R.id.home:

--- a/app/src/org/odk/collect/android/preferences/FormEntryPreferences.java
+++ b/app/src/org/odk/collect/android/preferences/FormEntryPreferences.java
@@ -11,7 +11,7 @@ import org.commcare.dalvik.R;
 /**
  * @author yanokwa
  */
-public class PreferencesActivity extends SessionAwarePreferenceActivity
+public class FormEntryPreferences extends SessionAwarePreferenceActivity
         implements OnSharedPreferenceChangeListener {
 
     public static final String KEY_FONT_SIZE = "font_size";

--- a/app/src/org/odk/collect/android/views/ODKView.java
+++ b/app/src/org/odk/collect/android/views/ODKView.java
@@ -23,7 +23,7 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.application.ODKStorage;
 import org.odk.collect.android.listeners.WidgetChangedListener;
-import org.odk.collect.android.preferences.PreferencesActivity;
+import org.odk.collect.android.preferences.FormEntryPreferences;
 import org.odk.collect.android.widgets.IBinaryWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.StringWidget;
@@ -83,7 +83,7 @@ public class ODKView extends ScrollView
              PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
 
         String question_font =
-                settings.getString(PreferencesActivity.KEY_FONT_SIZE, ODKStorage.DEFAULT_FONTSIZE);
+                settings.getString(FormEntryPreferences.KEY_FONT_SIZE, ODKStorage.DEFAULT_FONTSIZE);
 
         mQuestionFontsize = Integer.valueOf(question_font);
         

--- a/app/src/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/app/src/org/odk/collect/android/widgets/QuestionWidget.java
@@ -40,7 +40,7 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.application.ODKStorage;
 import org.odk.collect.android.listeners.WidgetChangedListener;
-import org.odk.collect.android.preferences.PreferencesActivity;
+import org.odk.collect.android.preferences.FormEntryPreferences;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.views.ShrinkingTextView;
 import org.odk.collect.android.views.media.MediaLayout;
@@ -107,7 +107,7 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
         SharedPreferences settings =
                 PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         String question_font =
-                settings.getString(PreferencesActivity.KEY_FONT_SIZE, ODKStorage.DEFAULT_FONTSIZE);
+                settings.getString(FormEntryPreferences.KEY_FONT_SIZE, ODKStorage.DEFAULT_FONTSIZE);
         mQuestionFontsize = Integer.valueOf(question_font);
         mAnswerFontsize = mQuestionFontsize + 2;
 
@@ -433,7 +433,7 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
         // a dialog or inline, underneath the question text
 
         if(!PreferenceManager.getDefaultSharedPreferences(this.getContext().getApplicationContext()).
-                getBoolean(PreferencesActivity.KEY_HELP_MODE_TRAY, false)) {
+                getBoolean(FormEntryPreferences.KEY_HELP_MODE_TRAY, false)) {
 
             AlertDialog mAlertDialog = new AlertDialog.Builder(this.getContext()).create();
             mAlertDialog.setIcon(android.R.drawable.ic_dialog_info);


### PR DESCRIPTION
 - Rename `PreferenceActivity` to `FormEntryPreferences`
 - Update fragments to not use deprecated `onAttach(Activity activity)`.

I was going to  update `CommCarePreferences`, `DeveloperPreferences`, and `PreferencesActivity` to stop extending the deprecated `PreferenceActivity`, and instead use `PreferenceFragment`. Turns out `PreferenceFragment` is only API 11 and greater, so I'll leave this fix for another time.