### PR TITLE
Case list icon resize

### DIFF
--- a/app/res/layout/entity_item_image.xml
+++ b/app/res/layout/entity_item_image.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" style="@style/EntityItemTextView" android:textAppearance="@style/EntityItemText">
+    android:layout_height="match_parent" style="@style/EntityItemTextView"
+    android:textAppearance="@style/EntityItemText"
+    android:scaleType="centerCrop">
     
 
 </ImageView>

--- a/app/src/org/commcare/android/view/EntityView.java
+++ b/app/src/org/commcare/android/view/EntityView.java
@@ -282,6 +282,7 @@ public class EntityView extends LinearLayout {
             try {
                 if (onMeasureCalled) {
                     int columnWidthInPixels = layout.getLayoutParams().width;
+                    System.out.println("columnWidthInPixels "  + columnWidthInPixels);
                     b = FileUtils.getScaledBitmap(
                             ReferenceManager._().DeriveReference(source).getStream(),
                             columnWidthInPixels, true);

--- a/app/src/org/commcare/android/view/EntityView.java
+++ b/app/src/org/commcare/android/view/EntityView.java
@@ -282,7 +282,6 @@ public class EntityView extends LinearLayout {
             try {
                 if (onMeasureCalled) {
                     int columnWidthInPixels = layout.getLayoutParams().width;
-                    System.out.println("columnWidthInPixels "  + columnWidthInPixels);
                     b = FileUtils.getScaledBitmap(
                             ReferenceManager._().DeriveReference(source).getStream(),
                             columnWidthInPixels, true);


### PR DESCRIPTION
So adding this property will scale the image to take up the entire space available to the image (the red in the second picture) without messing with the aspect ratio. I *think* this is more often to be what we want, especially if HQ will continue adding the "13%" default space to icons since this will end up being tiny on small screens.

Long term, I think better HQ case tile support is the correct-er solution here

@orangejenny 

![bigger](https://cloud.githubusercontent.com/assets/2293064/10592231/c42f6b4c-7688-11e5-8665-557b4c5d3d52.png)

<img width="494" alt="screen shot 2015-10-19 at 5 37 27 pm" src="https://cloud.githubusercontent.com/assets/2293064/10592218/ae61e132-7688-11e5-89b4-9170bb8cc370.png">