### PR TITLE
prevent null pointer exception if getCurrentWidget() returns null

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -542,6 +542,8 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
     public QuestionWidget getPendingWidget() {
         FormIndex pendingIndex = mFormController.getPendingCalloutFormIndex();
         if (pendingIndex == null) {
+            Logger.log(AndroidLogger.SOFT_ASSERT,
+                    "getPendingWidget called when pending callout form index was null");
             return null;
         }
         for (QuestionWidget q : ((ODKView)mCurrentView).getWidgets()) {
@@ -549,6 +551,8 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
                 return q;
             }
         }
+        Logger.log(AndroidLogger.SOFT_ASSERT,
+                "getPendingWidget couldn't find question widget with a form index that matches the pending callout.");
         return null;
     }
 

--- a/app/src/org/odk/collect/android/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/odk/collect/android/activities/components/ImageCaptureProcessing.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class ImageCaptureProcessing {
+
     /**
      * Performs any necessary relocating and scaling of an image coming from either a
      * SignatureWidget or ImageWidget (capture or choose)
@@ -29,9 +30,11 @@ public class ImageCaptureProcessing {
         // TODO PLM: this scale flag should be decoupled such that getPendingWidget doesn't need to be called
         if (shouldScale) {
             ImageWidget currentWidget = (ImageWidget)formEntryActivity.getPendingWidget();
-            int maxDimen = currentWidget.getMaxDimen();
-            if (maxDimen != -1) {
-                savedScaledImage = FileUtils.scaleAndSaveImage(originalImage, finalFilePath, maxDimen);
+            if (currentWidget != null) {
+                int maxDimen = currentWidget.getMaxDimen();
+                if (maxDimen != -1) {
+                    savedScaledImage = FileUtils.scaleAndSaveImage(originalImage, finalFilePath, maxDimen);
+                }
             }
         }
 


### PR DESCRIPTION
This is a short-term patch for this bug on ACRA: https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/a75355af7f8fba060f693b6f8eb90128.

It looks like getCurrentWidget() is sometimes returning null, which isn't good, but is gonna be really hard to track down the cause of. For now, this will at least prevent the app from crashing when it does. In theory this means it's possible that we will skip performing scaling of an image capture when we should be, but since it's a very minimally used feature right now, the chances of that are unlikely. More concerned about what's wrong with the implementation of getCurrentWidget(), since it definitely shouldn't be returning null in the place the stack trace is indicating -- if anyone has intuitions, let me know.