### PR TITLE
Don't retry auto update after logout

### DIFF
--- a/app/src/org/commcare/android/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/android/resource/AndroidResourceManager.java
@@ -10,6 +10,7 @@ import org.commcare.android.resource.installers.LocalStorageUnavailableException
 import org.commcare.android.tasks.UpdateTask;
 import org.commcare.android.util.AndroidCommCarePlatform;
 import org.commcare.android.util.AndroidResourceInstallerFactory;
+import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.resources.ResourceManager;
@@ -248,16 +249,33 @@ public class AndroidResourceManager extends ResourceManager {
             public void run() {
                 String ref = ResourceInstallUtils.getDefaultProfileRef();
                 try {
-                    UpdateTask updateTask = UpdateTask.getNewInstance();
-                    updateTask.startPinnedNotification(ctx);
-                    updateTask.setAsAutoUpdate();
-                    updateTask.execute(ref);
+                    if (canUpdateRetryRun()) {
+                        UpdateTask updateTask = UpdateTask.getNewInstance();
+                        updateTask.startPinnedNotification(ctx);
+                        updateTask.setAsAutoUpdate();
+                        updateTask.execute(ref);
+                    }
                 } catch (IllegalStateException e) {
                     // The user may have started the update process in the meantime
                     Log.w(TAG, "Trying trigger an auto-update retry when it is already running");
                 }
             }
         }, exponentionalRetryDelay(numberOfRestarts));
+    }
+
+    /**
+     * @return Logged into an app that has begun the auto-update process
+     */
+    private static boolean canUpdateRetryRun() {
+        try {
+            CommCareApp currentApp = CommCareApplication._().getCurrentApp();
+            // NOTE PLM: Doesn't distinguish between two apps currently in the
+            // auto-update process.
+            return CommCareApplication._().getSession().isActive() &&
+                    ResourceInstallUtils.shouldAutoUpdateResume(currentApp);
+        } catch (SessionUnavailableException e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Auto-update failures will schedule retries attempts, which launch the update task. The task shouldn't launch if the user is no longer logged in, or is logged into an app that doesn't have a pending retry scheduled.

Also move app setup for a test class into the single test that uses it to prevent strange task timing test failures. 