### PR TITLE
Save form load error and reshow dialog on orientation change

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -154,8 +154,6 @@ public class CommCareHomeActivity
 
     private int mDeveloperModeClicks = 0;
 
-    private AndroidCommCarePlatform platform;
-
     private HomeActivityUIController uiController;
     private SessionNavigator sessionNavigator;
 
@@ -226,6 +224,8 @@ public class CommCareHomeActivity
         if(DeveloperPreferences.isGridMenuEnabled()) {
             return true;
         }
+
+        AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         String commonDisplayStyle = platform.getMenuDisplayStyle(menuId);
         return MENU_STYLE_GRID.equals(commonDisplayStyle);
     }
@@ -510,9 +510,7 @@ public class CommCareHomeActivity
                         currentState.setFormRecordId(r.getID());
                     }
 
-                    if (CommCareApplication._().getCurrentApp() != null) {
-                        platform = CommCareApplication._().getCommCarePlatform();
-                    }
+                    AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
                     formEntry(platform.getFormContentUri(r.getFormNamespace()), r);
                     return;
                 }
@@ -897,10 +895,7 @@ public class CommCareHomeActivity
 
         FormRecord record = state.getFormRecord();
 
-        if (CommCareApplication._().getCurrentApp() != null) {
-            platform = CommCareApplication._().getCommCarePlatform();
-        }
-
+        AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         formEntry(platform.getFormContentUri(record.getFormNamespace()), record, CommCareActivity.getTitle(this, null));
     }
 
@@ -1032,9 +1027,7 @@ public class CommCareHomeActivity
     @Override
     protected void onResume() {
         super.onResume();
-        if (CommCareApplication._().getCurrentApp() != null) {
-            platform = CommCareApplication._().getCommCarePlatform();
-        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             refreshActionBar();
         }
@@ -1221,6 +1214,8 @@ public class CommCareHomeActivity
         String title = Localization.get("app.workflow.incomplete.continue.title");
         String msg = Localization.get("app.workflow.incomplete.continue");
         AlertDialogFactory factory = new AlertDialogFactory(this, title, msg);
+
+        final AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {


### PR DESCRIPTION
Prevent app from crashing when form load error dialog is shown and the app is rotated.

Fixed a bug where the `CommCareHomeActivity.platform` field wasn't being setup correctly between orientation changes. The solution was to not have a `platform` class field, but rather lookup the platform every time we need it. Not sure why `platform` was a class field in the first place, so worth double checking I didn't break anything/make anything slower. @ctsims, thoughts?

http://manage.dimagi.com/default.asp?184630