### PR TITLE
Make alert dialog pop-ups persist across orientation change

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -155,8 +155,6 @@ public class CommCareHomeActivity
 
     private int mDeveloperModeClicks = 0;
 
-    private AndroidCommCarePlatform platform;
-
     private HomeActivityUIController uiController;
     private SessionNavigator sessionNavigator;
 
@@ -227,6 +225,8 @@ public class CommCareHomeActivity
         if(DeveloperPreferences.isGridMenuEnabled()) {
             return true;
         }
+
+        AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         String commonDisplayStyle = platform.getMenuDisplayStyle(menuId);
         return MENU_STYLE_GRID.equals(commonDisplayStyle);
     }
@@ -511,9 +511,7 @@ public class CommCareHomeActivity
                         currentState.setFormRecordId(r.getID());
                     }
 
-                    if (CommCareApplication._().getCurrentApp() != null) {
-                        platform = CommCareApplication._().getCommCarePlatform();
-                    }
+                    AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
                     formEntry(platform.getFormContentUri(r.getFormNamespace()), r);
                     return;
                 }
@@ -892,10 +890,7 @@ public class CommCareHomeActivity
 
         FormRecord record = state.getFormRecord();
 
-        if (CommCareApplication._().getCurrentApp() != null) {
-            platform = CommCareApplication._().getCommCarePlatform();
-        }
-
+        AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         formEntry(platform.getFormContentUri(record.getFormNamespace()), record, CommCareActivity.getTitle(this, null));
     }
 
@@ -1027,10 +1022,6 @@ public class CommCareHomeActivity
     @Override
     protected void onResumeFragments() {
         super.onResumeFragments();
-
-        if (CommCareApplication._().getCurrentApp() != null) {
-            platform = CommCareApplication._().getCommCarePlatform();
-        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             refreshActionBar();
@@ -1209,6 +1200,7 @@ public class CommCareHomeActivity
 
     private void createAskUseOldDialog(final AndroidSessionWrapper state,
                                        final SessionStateDescriptor existing) {
+        final AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         AlertDialogFragment alertDialog = new AlertDialogFragment() {
             @Override
             public DialogInterface.OnClickListener getClickListener() {

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -160,13 +160,6 @@ public class CommCareHomeActivity
     private HomeActivityUIController uiController;
     private SessionNavigator sessionNavigator;
 
-    /**
-     * Save dialog created before fragments have resumed so that it can be
-     * shown at the correct part of the ActivityFragment lifecycle
-     */
-    private AlertDialogFragment dialogToShowOnResume;
-    private static final String ALERT_DIALOG_TAG = "alert-dialog-tag";
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -1035,22 +1028,14 @@ public class CommCareHomeActivity
     protected void onResumeFragments() {
         super.onResumeFragments();
 
-        showPendingDialog();
-
         if (CommCareApplication._().getCurrentApp() != null) {
             platform = CommCareApplication._().getCommCarePlatform();
         }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             refreshActionBar();
         }
         attemptDispatchHomeScreen();
-    }
-
-    private void showPendingDialog() {
-        if (dialogToShowOnResume != null) {
-            dialogToShowOnResume.show(getSupportFragmentManager(), ALERT_DIALOG_TAG);
-            dialogToShowOnResume = null;
-        }
     }
 
     /**

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
@@ -1,7 +1,7 @@
 package org.commcare.dalvik.dialogs;
 
-import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,7 +20,7 @@ public class AlertDialogFactory {
     private final AlertDialog dialog;
     private final View view;
 
-    public AlertDialogFactory(Activity context, String title, String msg) {
+    public AlertDialogFactory(Context context, String title, String msg) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         view = LayoutInflater.from(context).inflate(R.layout.custom_alert_dialog, null);
 
@@ -30,6 +30,7 @@ public class AlertDialogFactory {
         messageView.setText(msg);
 
         this.dialog = builder.create();
+        dialog.setView(view);
         dialog.setCancelable(false); // false by default, can change using makeCancelable()
     }
 
@@ -40,7 +41,7 @@ public class AlertDialogFactory {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                          null, applies a default listener of just dismissing the dialog
      */
-    public static void showBasicAlertDialog(Activity context, String title, String msg,
+    public static void showBasicAlertDialog(Context context, String title, String msg,
                                             DialogInterface.OnClickListener positiveButtonListener) {
         AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
         if (positiveButtonListener == null) {
@@ -64,7 +65,7 @@ public class AlertDialogFactory {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                          null, applies a default listener of just dismissing the dialog
      */
-    public static void showBasicAlertWithIcon(Activity context, String title, String msg, int iconResId,
+    public static void showBasicAlertWithIcon(Context context, String title, String msg, int iconResId,
                                               DialogInterface.OnClickListener positiveButtonListener) {
         AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
         if (positiveButtonListener == null) {
@@ -81,12 +82,11 @@ public class AlertDialogFactory {
     }
 
     public void showDialog() {
-        dialog.setView(this.view);
         dialog.show();
     }
 
     public AlertDialog getDialog() {
-        return this.dialog;
+        return dialog;
     }
 
     public void makeCancelable() {
@@ -138,6 +138,4 @@ public class AlertDialogFactory {
         });
         neutralButton.setVisibility(View.VISIBLE);
     }
-
-
 }

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
@@ -18,6 +18,7 @@ public abstract class AlertDialogFragment extends DialogFragment {
     public static final String NEGATIVE_MESSAGE_KEY = "negative";
     public static final String POSITIVE_MESSAGE_KEY = "positive";
     public static final String NEUTRAL_MESSAGE_KEY = "neutral";
+    public static final String ICON_KEY = "icon";
 
     /**
      * The click listener for the dialog buttons present. Should handle each case
@@ -39,6 +40,10 @@ public abstract class AlertDialogFragment extends DialogFragment {
         String message = args.getString(BODY_MESSAGE_KEY);
         AlertDialogFactory factory =
                 new AlertDialogFactory(getContext(), title, message);
+
+        if (args.containsKey(ICON_KEY)) {
+            factory.setIcon(args.getInt(ICON_KEY));
+        }
 
         DialogInterface.OnClickListener listener = getClickListener();
         if (args.containsKey(NEGATIVE_MESSAGE_KEY)) {

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
@@ -1,0 +1,67 @@
+package org.commcare.dalvik.dialogs;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+/**
+ * Dialog that persists across screen orientation changes.
+ * Wraps AlertDialogFactory interface.
+ *
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public abstract class AlertDialogFragment extends DialogFragment {
+    public static final String TITLE_KEY = "title";
+    public static final String BODY_MESSAGE_KEY = "message";
+    public static final String NEGATIVE_MESSAGE_KEY = "negative";
+    public static final String POSITIVE_MESSAGE_KEY = "positive";
+    public static final String NEUTRAL_MESSAGE_KEY = "neutral";
+
+    /**
+     * The click listener for the dialog buttons present. Should handle each case
+     */
+    public abstract DialogInterface.OnClickListener getClickListener();
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setRetainInstance(true);
+    }
+
+    @Override
+    @NonNull
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        Bundle args = getArguments();
+        String title = args.getString(TITLE_KEY);
+        String message = args.getString(BODY_MESSAGE_KEY);
+        AlertDialogFactory factory =
+                new AlertDialogFactory(getContext(), title, message);
+
+        DialogInterface.OnClickListener listener = getClickListener();
+        if (args.containsKey(NEGATIVE_MESSAGE_KEY)) {
+            factory.setNegativeButton(args.getString(NEGATIVE_MESSAGE_KEY),
+                    listener);
+        }
+        if (args.containsKey(POSITIVE_MESSAGE_KEY)) {
+            factory.setPositiveButton(args.getString(POSITIVE_MESSAGE_KEY),
+                    listener);
+        }
+        if (args.containsKey(NEUTRAL_MESSAGE_KEY)) {
+            factory.setNeutralButton(args.getString(NEUTRAL_MESSAGE_KEY),
+                    listener);
+        }
+
+        return factory.getDialog();
+    }
+
+    @Override
+    public void onDestroyView() {
+        // Ohh, you know, just a 5 year old Android bug ol' G hasn't fixed yet
+        if (getDialog() != null && getRetainInstance())
+            getDialog().setDismissMessage(null);
+        super.onDestroyView();
+    }
+}

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1762,9 +1762,9 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
                 @Override
                 protected void deliverError(FormEntryActivity receiver, Exception e) {
                     if (e != null) {
-                        CommCareActivity.createErrorDialog(receiver, e.getMessage(), EXIT);
+                        createPersistentErrorDialog(receiver, e.getMessage(), EXIT);
                     } else {
-                        CommCareActivity.createErrorDialog(receiver, StringUtils.getStringRobust(receiver, R.string.parse_error), EXIT);
+                        createPersistentErrorDialog(receiver, StringUtils.getStringRobust(receiver, R.string.parse_error), EXIT);
                     }
                 }
             };

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -256,7 +256,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
         } else if (data instanceof SaveToDiskTask) {
             mSaveToDiskTask = (SaveToDiskTask) data;
             mSaveToDiskTask.setFormSavedListener(this);
-        } else if (hasFormLoadBeenTriggered) {
+        } else if (formHasLoaded()) {
             // Screen orientation change
             refreshCurrentView();
         }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1761,6 +1761,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
 
                 @Override
                 protected void deliverError(FormEntryActivity receiver, Exception e) {
+                    receiver.dismissProgressDialog();
                     if (e != null) {
                         createPersistentErrorDialog(receiver, e.getMessage(), EXIT);
                     } else {


### PR DESCRIPTION
Continues the work of https://github.com/dimagi/commcare-odk/pull/735 but applying it to all instances of `AlertDialogFactory`