### PR TITLE
Make "Continue Form" alert dialog pop-ups persist across orientation change

### DIFF
--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
@@ -1,7 +1,7 @@
 package org.commcare.dalvik.dialogs;
 
-import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,7 +20,7 @@ public class AlertDialogFactory {
     private final AlertDialog dialog;
     private final View view;
 
-    public AlertDialogFactory(Activity context, String title, String msg) {
+    public AlertDialogFactory(Context context, String title, String msg) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         view = LayoutInflater.from(context).inflate(R.layout.custom_alert_dialog, null);
 
@@ -30,6 +30,7 @@ public class AlertDialogFactory {
         messageView.setText(msg);
 
         this.dialog = builder.create();
+        dialog.setView(view);
         dialog.setCancelable(false); // false by default, can change using makeCancelable()
     }
 
@@ -40,7 +41,7 @@ public class AlertDialogFactory {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                          null, applies a default listener of just dismissing the dialog
      */
-    public static void showBasicAlertDialog(Activity context, String title, String msg,
+    public static void showBasicAlertDialog(Context context, String title, String msg,
                                             DialogInterface.OnClickListener positiveButtonListener) {
         AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
         if (positiveButtonListener == null) {
@@ -64,7 +65,7 @@ public class AlertDialogFactory {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                          null, applies a default listener of just dismissing the dialog
      */
-    public static void showBasicAlertWithIcon(Activity context, String title, String msg, int iconResId,
+    public static void showBasicAlertWithIcon(Context context, String title, String msg, int iconResId,
                                               DialogInterface.OnClickListener positiveButtonListener) {
         AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
         if (positiveButtonListener == null) {
@@ -81,12 +82,11 @@ public class AlertDialogFactory {
     }
 
     public void showDialog() {
-        dialog.setView(this.view);
         dialog.show();
     }
 
     public AlertDialog getDialog() {
-        return this.dialog;
+        return dialog;
     }
 
     public void makeCancelable() {
@@ -138,6 +138,4 @@ public class AlertDialogFactory {
         });
         neutralButton.setVisibility(View.VISIBLE);
     }
-
-
 }

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
@@ -1,0 +1,67 @@
+package org.commcare.dalvik.dialogs;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+/**
+ * Dialog that persists across screen orientation changes.
+ * Wraps AlertDialogFactory interface.
+ *
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public abstract class AlertDialogFragment extends DialogFragment {
+    public static final String TITLE_KEY = "title";
+    public static final String BODY_MESSAGE_KEY = "message";
+    public static final String NEGATIVE_MESSAGE_KEY = "negative";
+    public static final String POSITIVE_MESSAGE_KEY = "positive";
+    public static final String NEUTRAL_MESSAGE_KEY = "neutral";
+
+    /**
+     * The click listener for the dialog buttons present. Should handle each case
+     */
+    public abstract DialogInterface.OnClickListener getClickListener();
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setRetainInstance(true);
+    }
+
+    @Override
+    @NonNull
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        Bundle args = getArguments();
+        String title = args.getString(TITLE_KEY);
+        String message = args.getString(BODY_MESSAGE_KEY);
+        AlertDialogFactory factory =
+                new AlertDialogFactory(getContext(), title, message);
+
+        DialogInterface.OnClickListener listener = getClickListener();
+        if (args.containsKey(NEGATIVE_MESSAGE_KEY)) {
+            factory.setNegativeButton(args.getString(NEGATIVE_MESSAGE_KEY),
+                    listener);
+        }
+        if (args.containsKey(POSITIVE_MESSAGE_KEY)) {
+            factory.setPositiveButton(args.getString(POSITIVE_MESSAGE_KEY),
+                    listener);
+        }
+        if (args.containsKey(NEUTRAL_MESSAGE_KEY)) {
+            factory.setNeutralButton(args.getString(NEUTRAL_MESSAGE_KEY),
+                    listener);
+        }
+
+        return factory.getDialog();
+    }
+
+    @Override
+    public void onDestroyView() {
+        // Ohh, you know, just a 5 year old Android bug ol' G hasn't fixed yet
+        if (getDialog() != null && getRetainInstance())
+            getDialog().setDismissMessage(null);
+        super.onDestroyView();
+    }
+}


### PR DESCRIPTION
The "Continue Form" alert dialog shouldn't disappear when the screen orientation changes.

![image](https://cloud.githubusercontent.com/assets/94817/10704651/5b93ba40-79a6-11e5-935f-a4cdfff91cb4.png)


http://manage.dimagi.com/default.asp?184706#BugEvent.1033877