### PR TITLE
Make alert dialogs persist on rotation V.2

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -173,7 +173,7 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="clearanswer_confirm" cc:translatable="true">Remove the response to \"%s\"?</string>
     <string name="clear_answer" cc:translatable="true">Remove response</string>
     <string name="clear_answer_ask" cc:translatable="true">Remove This Response?</string>
-    <string name="clear_answer_no" cc:translatable="true">Cancel</string>
+    <string name="clear_answer_no" cc:translatable="true">CANCEL</string>
     <string name="completed_data" cc:translatable="true">Complete (%s)</string>
     <string name="data" cc:translatable="true">Saved Forms</string>
     <string name="data_saved_error" cc:translatable="true">Sorry, form save failed!</string>
@@ -182,7 +182,7 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="delete_file" cc:translatable="true">Delete Selected</string>
     <string name="delete_no" cc:translatable="true">Do Not Delete</string>
     <string name="delete_yes" cc:translatable="true">Delete Forms</string>
-    <string name="discard_answer" cc:translatable="true">Remove response</string>
+    <string name="discard_answer" cc:translatable="true">REMOVE RESPONSE</string>
     <string name="download" cc:translatable="true">Get Selected</string>
     <string name="download_forms_result" cc:translatable="true">Download Result</string>
     <string name="downloading_data" cc:translatable="true">Connecting to Server</string>

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -249,14 +249,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     @Override
     @TargetApi(11)
     protected void onResumeFragments() {
-        showPendingDialog();
-    }
-
-    private void showPendingDialog() {
-        if (dialogToShowOnResume != null) {
-            dialogToShowOnResume.show(getSupportFragmentManager(), KEY_ALERT_DIALOG_FRAG);
-            dialogToShowOnResume = null;
-        }
+        showPendingAlertDialog();
     }
 
     protected View getBannerHost() {

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -247,8 +247,9 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     }
 
     @Override
-    @TargetApi(11)
     protected void onResumeFragments() {
+        super.onResumeFragments();
+
         showPendingAlertDialog();
     }
 
@@ -525,7 +526,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
      * @param activity   Activity to which to attach the dialog.
      * @param shouldExit If true, cancel activity when user exits dialog.
      */
-    public static void createErrorDialog(final Activity activity, String errorMsg,
+    public static void createErrorDialog(final CommCareActivity activity, String errorMsg,
                                          final boolean shouldExit) {
         String title = StringUtils.getStringRobust(activity, org.commcare.dalvik.R.string.error_occured);
         AlertDialogFactory factory = new AlertDialogFactory(activity, title, errorMsg);
@@ -545,11 +546,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         };
         CharSequence buttonDisplayText = StringUtils.getStringSpannableRobust(activity, org.commcare.dalvik.R.string.ok);
         factory.setPositiveButton(buttonDisplayText, buttonListener);
-        if (activity instanceof CommCareActivity) {
-            ((CommCareActivity)activity).showAlertDialog(factory);
-        } else {
-            factory.showDialog();
-        }
+
+        activity.showAlertDialog(factory);
     }
 
     // region - All methods for implementation of DialogController

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -618,7 +618,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     @Override
     public void showPendingAlertDialog() {
-        if (dialogToShowOnResume != null) {
+        if (dialogToShowOnResume != null && getCurrentAlertDialog() == null) {
             dialogToShowOnResume.show(getSupportFragmentManager(), KEY_ALERT_DIALOG_FRAG);
             dialogToShowOnResume = null;
         }
@@ -626,6 +626,10 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     @Override
     public void showAlertDialog(AlertDialogFactory f) {
+        if (getCurrentAlertDialog() != null) {
+            // Means we already have an alert dialog on screen
+            return;
+        }
         AlertDialogFragment dialog = AlertDialogFragment.fromFactory(f);
         if (activityPaused) {
             dialogToShowOnResume = dialog;

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -67,7 +67,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         implements CommCareTaskConnector<R>, DialogController, OnGestureListener {
     private static final String TAG = CommCareActivity.class.getSimpleName();
 
-    private static final String KEY_PROGRESS_DIALOG_FRAG = "dialog_fragment";
+    private static final String KEY_PROGRESS_DIALOG_FRAG = "progress-dialog-fragment";
     private static final String KEY_ALERT_DIALOG_FRAG = "alert-dialog-fragment";
 
     private boolean mBannerOverriden = false;
@@ -228,12 +228,9 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         return false;
     }
 
-    @Override
-    @TargetApi(11)
-    protected void onResumeFragments() {
-        super.onResumeFragments();
 
-        showPendingAlertDialog();
+    protected void onResume() {
+        super.onResume();
 
         activityPaused = false;
 
@@ -247,6 +244,19 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
 
         AudioController.INSTANCE.playPreviousAudio();
+    }
+
+    @Override
+    @TargetApi(11)
+    protected void onResumeFragments() {
+        showPendingDialog();
+    }
+
+    private void showPendingDialog() {
+        if (dialogToShowOnResume != null) {
+            dialogToShowOnResume.show(getSupportFragmentManager(), KEY_ALERT_DIALOG_FRAG);
+            dialogToShowOnResume = null;
+        }
     }
 
     protected View getBannerHost() {

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -41,6 +41,7 @@ import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.AlertDialogFactory;
+import org.commcare.dalvik.dialogs.AlertDialogFragment;
 import org.commcare.dalvik.dialogs.CustomProgressDialog;
 import org.commcare.dalvik.dialogs.DialogController;
 import org.commcare.dalvik.preferences.CommCarePreferences;
@@ -66,7 +67,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         implements CommCareTaskConnector<R>, DialogController, OnGestureListener {
     private static final String TAG = CommCareActivity.class.getSimpleName();
 
-    private final static String KEY_DIALOG_FRAG = "dialog_fragment";
+    private static final String KEY_PROGRESS_DIALOG_FRAG = "dialog_fragment";
+    private static final String KEY_ALERT_DIALOG_FRAG = "alert-dialog-fragment";
 
     private boolean mBannerOverriden = false;
 
@@ -80,6 +82,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
      * should be dismissed because the task has completed or been canceled.
      */
     private boolean shouldDismissDialog = true;
+
+    protected AlertDialogFragment dialogToShowOnResume;
 
     private GestureDetector mGestureDetector;
 
@@ -226,8 +230,10 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     @Override
     @TargetApi(11)
-    protected void onResume() {
-        super.onResume();
+    protected void onResumeFragments() {
+        super.onResumeFragments();
+
+        showPendingAlertDialog();
 
         activityPaused = false;
 
@@ -292,6 +298,10 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     protected void onPause() {
         super.onPause();
 
+        if (getCurrentAlertDialog() != null) {
+            dialogToShowOnResume = getCurrentAlertDialog();
+        }
+
         activityPaused = true;
         AudioController.INSTANCE.systemInducedPause();
     }
@@ -302,7 +312,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
         //If we've left an old dialog showing during the task transition and it was from the same task
         //as the one that is starting, don't dismiss it
-        CustomProgressDialog currDialog = getCurrentDialog();
+        CustomProgressDialog currDialog = getCurrentProgressDialog();
         if (currDialog != null && currDialog.getTaskId() == task.getTaskId()) {
             shouldDismissDialog = false;
         }
@@ -369,12 +379,14 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public void stopTaskTransition() {
         inTaskTransition = false;
         attemptDismissDialog();
-        //reset shouldDismissDialog to true after this transition cycle is over
+        // Re-set shouldDismissDialog to true after this transition cycle is over
         shouldDismissDialog = true;
     }
 
-    //if shouldDismiss flag has not been set to false in the course of a task transition,
-    //then dismiss the dialog
+    /**
+     * If shouldDismiss flag has not been set to false in the course of a task transition, then
+     * dismiss the dialog
+     */
     void attemptDismissDialog() {
         if (shouldDismissDialog) {
             dismissProgressDialog();
@@ -399,7 +411,9 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                 }
             }
         };
-        AlertDialogFactory.showBasicAlertWithIcon(this, title, message, android.R.drawable.ic_dialog_info, listener);
+        AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactoryWithIcon(this, title,
+                message, android.R.drawable.ic_dialog_info, listener);
+        showAlertDialog(f);
     }
 
     @Override
@@ -528,14 +542,18 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         };
         CharSequence buttonDisplayText = StringUtils.getStringSpannableRobust(activity, org.commcare.dalvik.R.string.ok);
         factory.setPositiveButton(buttonDisplayText, buttonListener);
-        factory.showDialog();
+        if (activity instanceof CommCareActivity) {
+            ((CommCareActivity)activity).showAlertDialog(factory);
+        } else {
+            factory.showDialog();
+        }
     }
 
     // region - All methods for implementation of DialogController
 
     @Override
     public void updateProgress(String updateText, int taskId) {
-        CustomProgressDialog mProgressDialog = getCurrentDialog();
+        CustomProgressDialog mProgressDialog = getCurrentProgressDialog();
         if (mProgressDialog != null) {
             if (mProgressDialog.getTaskId() == taskId) {
                 mProgressDialog.updateMessage(updateText);
@@ -549,7 +567,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     @Override
     public void updateProgressBar(int progress, int max, int taskId) {
-        CustomProgressDialog mProgressDialog = getCurrentDialog();
+        CustomProgressDialog mProgressDialog = getCurrentProgressDialog();
         if (mProgressDialog != null) {
             if (mProgressDialog.getTaskId() == taskId) {
                 mProgressDialog.updateProgressBar(progress, max);
@@ -565,21 +583,21 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public void showProgressDialog(int taskId) {
         CustomProgressDialog dialog = generateProgressDialog(taskId);
         if (dialog != null) {
-            dialog.show(getSupportFragmentManager(), KEY_DIALOG_FRAG);
+            dialog.show(getSupportFragmentManager(), KEY_PROGRESS_DIALOG_FRAG);
         }
     }
 
     @Override
-    public CustomProgressDialog getCurrentDialog() {
+    public CustomProgressDialog getCurrentProgressDialog() {
         return (CustomProgressDialog) getSupportFragmentManager().
-                findFragmentByTag(KEY_DIALOG_FRAG);
+                findFragmentByTag(KEY_PROGRESS_DIALOG_FRAG);
     }
 
     @Override
     public void dismissProgressDialog() {
-        CustomProgressDialog mProgressDialog = getCurrentDialog();
-        if (mProgressDialog != null && mProgressDialog.isAdded()) {
-            mProgressDialog.dismissAllowingStateLoss();
+        CustomProgressDialog progressDialog = getCurrentProgressDialog();
+        if (progressDialog != null && progressDialog.isAdded()) {
+            progressDialog.dismissAllowingStateLoss();
         }
     }
 
@@ -587,6 +605,30 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public CustomProgressDialog generateProgressDialog(int taskId) {
         //dummy method for compilation, implementation handled in those subclasses that need it
         return null;
+    }
+
+    @Override
+    public AlertDialogFragment getCurrentAlertDialog() {
+        return (AlertDialogFragment) getSupportFragmentManager().
+                findFragmentByTag(KEY_ALERT_DIALOG_FRAG);
+    }
+
+    @Override
+    public void showPendingAlertDialog() {
+        if (dialogToShowOnResume != null) {
+            dialogToShowOnResume.show(getSupportFragmentManager(), KEY_ALERT_DIALOG_FRAG);
+            dialogToShowOnResume = null;
+        }
+    }
+
+    @Override
+    public void showAlertDialog(AlertDialogFactory f) {
+        AlertDialogFragment dialog = AlertDialogFragment.fromFactory(f);
+        if (activityPaused) {
+            dialogToShowOnResume = dialog;
+        } else {
+            dialog.show(getSupportFragmentManager(), KEY_ALERT_DIALOG_FRAG);
+        }
     }
 
     // endregion

--- a/app/src/org/commcare/android/util/TemplatePrinterUtils.java
+++ b/app/src/org/commcare/android/util/TemplatePrinterUtils.java
@@ -144,14 +144,14 @@ public abstract class TemplatePrinterUtils {
      */
     public static void showAlertDialog(final Activity activity, String title, String msg,
                                        final boolean finishActivity) {
-        AlertDialogFactory.showBasicAlertDialog(activity, title, msg, new DialogInterface.OnClickListener() {
+        AlertDialogFactory.getBasicAlertFactory(activity, title, msg, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
                 if (finishActivity) {
                     activity.finish();
                 }
             }
-        });
+        }).showDialog();
     }
 
 }

--- a/app/src/org/commcare/dalvik/activities/AppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/AppManagerActivity.java
@@ -127,14 +127,14 @@ public class AppManagerActivity extends Activity implements OnItemClickListener 
                 if (resultCode == RESULT_CANCELED) {
                     String title = getString(R.string.media_not_verified);
                     String msg  = getString(R.string.skipped_verification_warning);
-                    AlertDialogFactory.showBasicAlertDialog(this, title, msg, new DialogInterface.OnClickListener() {
+                    AlertDialogFactory.getBasicAlertFactory(this, title, msg, new DialogInterface.OnClickListener() {
 
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             dialog.dismiss();
                         }
 
-                    });
+                    }).showDialog();
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }

--- a/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
@@ -199,7 +199,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
                 dialog.dismiss();
                 if (id == AlertDialog.BUTTON_POSITIVE) {
                     acknowledgedRisk = true;
-                    dialog.cancel();
+                    dialog.dismiss();
                 } else {
                     exitDump();
                 }

--- a/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareFormDumpActivity.java
@@ -20,7 +20,6 @@ import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.models.notifications.NotificationMessageFactory;
 import org.commcare.android.models.notifications.NotificationMessageFactory.StockMessages;
 import org.commcare.android.tasks.DumpTask;
-import org.commcare.android.tasks.ExceptionReportTask;
 import org.commcare.android.tasks.SendTask;
 import org.commcare.android.util.FileUtil;
 import org.commcare.dalvik.R;
@@ -208,7 +207,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
         };
         factory.setPositiveButton("OK", listener);
         factory.setNegativeButton("NO", listener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
     
     public void updateCounters() {

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -812,6 +812,7 @@ public class CommCareHomeActivity
         createErrorDialog(text.evaluate(ec), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int i) {
+                dialog.dismiss();
                 asw.getSession().stepBack();
                 CommCareHomeActivity.this.sessionNavigator.startNextSessionStep();
             }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -1025,8 +1025,9 @@ public class CommCareHomeActivity
     }
 
     @Override
-    protected void onResumeFragments() {
-        super.onResumeFragments();
+    protected void onResume() {
+        super.onResume();
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             refreshActionBar();
         }

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -154,8 +154,6 @@ public class CommCareHomeActivity
 
     private int mDeveloperModeClicks = 0;
 
-    private AndroidCommCarePlatform platform;
-
     private HomeActivityUIController uiController;
     private SessionNavigator sessionNavigator;
 
@@ -226,6 +224,7 @@ public class CommCareHomeActivity
         if(DeveloperPreferences.isGridMenuEnabled()) {
             return true;
         }
+        AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         String commonDisplayStyle = platform.getMenuDisplayStyle(menuId);
         return MENU_STYLE_GRID.equals(commonDisplayStyle);
     }
@@ -510,9 +509,7 @@ public class CommCareHomeActivity
                         currentState.setFormRecordId(r.getID());
                     }
 
-                    if (CommCareApplication._().getCurrentApp() != null) {
-                        platform = CommCareApplication._().getCommCarePlatform();
-                    }
+                    AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
                     formEntry(platform.getFormContentUri(r.getFormNamespace()), r);
                     return;
                 }
@@ -740,8 +737,10 @@ public class CommCareHomeActivity
     }
 
     private void createErrorDialog(String errorMsg, AlertDialog.OnClickListener errorListener) {
-        AlertDialogFactory.showBasicAlertWithIcon(this, Localization.get("app.handled.error.title"),
-                errorMsg, android.R.drawable.ic_dialog_info, errorListener);
+        AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactoryWithIcon(this,
+                Localization.get("app.handled.error.title"), errorMsg,
+                android.R.drawable.ic_dialog_info, errorListener);
+        showAlertDialog(f);
     }
 
     @Override
@@ -896,11 +895,7 @@ public class CommCareHomeActivity
         }
 
         FormRecord record = state.getFormRecord();
-
-        if (CommCareApplication._().getCurrentApp() != null) {
-            platform = CommCareApplication._().getCommCarePlatform();
-        }
-
+        AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         formEntry(platform.getFormContentUri(record.getFormNamespace()), record, CommCareActivity.getTitle(this, null));
     }
 
@@ -1030,11 +1025,8 @@ public class CommCareHomeActivity
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
-        if (CommCareApplication._().getCurrentApp() != null) {
-            platform = CommCareApplication._().getCommCarePlatform();
-        }
+    protected void onResumeFragments() {
+        super.onResumeFragments();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             refreshActionBar();
         }
@@ -1218,6 +1210,7 @@ public class CommCareHomeActivity
 
 
     private void createAskUseOldDialog(final AndroidSessionWrapper state, final SessionStateDescriptor existing) {
+        final AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         String title = Localization.get("app.workflow.incomplete.continue.title");
         String msg = Localization.get("app.workflow.incomplete.continue");
         AlertDialogFactory factory = new AlertDialogFactory(this, title, msg);
@@ -1247,7 +1240,7 @@ public class CommCareHomeActivity
         factory.setPositiveButton(Localization.get("option.yes"), listener);
         factory.setNegativeButton(Localization.get("app.workflow.incomplete.continue.option.delete"), listener);
         factory.setNeutralButton(Localization.get("option.no"), listener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 
     private void displayMessage(String message) {

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -374,7 +374,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             CommCareApp app = getCommCareApp();
             ccApp = app;
 
-            CustomProgressDialog lastDialog = getCurrentDialog();
+            CustomProgressDialog lastDialog = getCurrentProgressDialog();
             // used to tell the ResourceEngineTask whether or not it should
             // sleep before it starts, set based on whether we are currently
             // in keep trying mode.
@@ -666,7 +666,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         CustomProgressDialog dialog = CustomProgressDialog.newInstance(title, message, taskId);
         dialog.setCancelable(false);
         String checkboxText = Localization.get("install.keep.trying");
-        CustomProgressDialog lastDialog = getCurrentDialog();
+        CustomProgressDialog lastDialog = getCurrentProgressDialog();
         boolean isChecked = (lastDialog != null) && lastDialog.isChecked();
         dialog.addCheckbox(checkboxText, isChecked);
         dialog.addProgressBar();

--- a/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
@@ -257,6 +257,7 @@ public class CommCareWiFiDirectActivity extends SessionAwareCommCareActivity<Com
                         beSender();
                         break;
                 }
+                dialog.dismiss();
             }
         };
         factory.setNeutralButton(localize("wifi.direct.receive.forms"), listener);

--- a/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
@@ -262,7 +262,7 @@ public class CommCareWiFiDirectActivity extends SessionAwareCommCareActivity<Com
         factory.setNeutralButton(localize("wifi.direct.receive.forms"), listener);
         factory.setNegativeButton(localize("wifi.direct.transfer.forms"), listener);
         factory.setPositiveButton(localize("wifi.direct.submit.forms"), listener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 
     public void beSender(){

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -375,8 +375,9 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
 
             finish();
         } else {
-            AlertDialogFactory.showBasicAlertDialog(this, "Form Missing",
+            AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactory(this, "Form Missing",
                     Localization.get("form.record.gone.message"), null);
+            showAlertDialog(f);
         }
     }
 
@@ -444,7 +445,9 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
             title = Localization.get("app.workflow.forms.scan.title.invalid");
         }
         int resId = result.first ? R.drawable.checkmark : R.drawable.redx;
-        AlertDialogFactory.showBasicAlertWithIcon(this, title, result.second, resId, null);
+        AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactoryWithIcon(this, title,
+                result.second, resId, null);
+        showAlertDialog(f);
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
@@ -142,7 +142,7 @@ public class SingleAppManagerActivity extends Activity {
                 if (resultCode == RESULT_CANCELED) {
                     String title = getString(R.string.media_not_verified);
                     String msg = getString(R.string.skipped_verification_warning_2);
-                    AlertDialogFactory.showBasicAlertDialog(this, title, msg, null);
+                    AlertDialogFactory.getBasicAlertFactory(this, title, msg, null).showDialog();
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }

--- a/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
@@ -46,7 +46,10 @@ public class UnrecoverableErrorActivity extends Activity {
                Intent intent = new Intent(UnrecoverableErrorActivity.this, CommCareHomeActivity.class);
 
                 //Make sure that the new stack starts with a home activity, and clear everything between.
-               intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET | Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+               intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET |
+                       Intent.FLAG_ACTIVITY_CLEAR_TOP |
+                       Intent.FLAG_ACTIVITY_SINGLE_TOP |
+                       Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
                UnrecoverableErrorActivity.this.startActivity(intent);
                UnrecoverableErrorActivity.this.moveTaskToBack(true);
 

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
@@ -1,7 +1,7 @@
 package org.commcare.dalvik.dialogs;
 
-import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,7 +20,7 @@ public class AlertDialogFactory {
     private final AlertDialog dialog;
     private final View view;
 
-    public AlertDialogFactory(Activity context, String title, String msg) {
+    public AlertDialogFactory(Context context, String title, String msg) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         view = LayoutInflater.from(context).inflate(R.layout.custom_alert_dialog, null);
 
@@ -40,7 +40,7 @@ public class AlertDialogFactory {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                          null, applies a default listener of just dismissing the dialog
      */
-    public static void showBasicAlertDialog(Activity context, String title, String msg,
+    public static AlertDialogFactory getBasicAlertFactory(Context context, String title, String msg,
                                             DialogInterface.OnClickListener positiveButtonListener) {
         AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
         if (positiveButtonListener == null) {
@@ -52,7 +52,7 @@ public class AlertDialogFactory {
             };
         }
         factory.setPositiveButton(Localization.get("dialog.ok"), positiveButtonListener);
-        factory.showDialog();
+        return factory;
     }
 
     /**
@@ -64,7 +64,7 @@ public class AlertDialogFactory {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                          null, applies a default listener of just dismissing the dialog
      */
-    public static void showBasicAlertWithIcon(Activity context, String title, String msg, int iconResId,
+    public static AlertDialogFactory getBasicAlertFactoryWithIcon(Context context, String title, String msg, int iconResId,
                                               DialogInterface.OnClickListener positiveButtonListener) {
         AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
         if (positiveButtonListener == null) {
@@ -77,16 +77,21 @@ public class AlertDialogFactory {
         }
         factory.setPositiveButton(Localization.get("dialog.ok"), positiveButtonListener);
         factory.setIcon(iconResId);
-        factory.showDialog();
-    }
-
-    public void showDialog() {
-        dialog.setView(this.view);
-        dialog.show();
+        return factory;
     }
 
     public AlertDialog getDialog() {
+        finalizeView();
         return this.dialog;
+    }
+
+    public void showDialog() {
+        finalizeView();
+        dialog.show();
+    }
+
+    public void finalizeView() {
+        dialog.setView(this.view);
     }
 
     public void makeCancelable() {

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
@@ -1,0 +1,47 @@
+package org.commcare.dalvik.dialogs;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+/**
+ * Dialog that persists across screen orientation changes, wraps AlertDialogFactory
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ * @author Aliza Stone (astone@dimagi.com)
+ */
+public class AlertDialogFragment extends DialogFragment {
+
+    private AlertDialogFactory factory;
+
+    public static AlertDialogFragment fromFactory(AlertDialogFactory f) {
+        AlertDialogFragment frag = new AlertDialogFragment();
+        frag.setFactory(f);
+        return frag;
+    }
+
+    public void setFactory(AlertDialogFactory f) {
+        this.factory = f;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+    }
+
+    @Override
+    @NonNull
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        return factory.getDialog();
+    }
+
+    @Override
+    public void onDestroyView() {
+        // Ohh, you know, just a 5 year old Android bug ol' G hasn't fixed yet
+        if (getDialog() != null && getRetainInstance())
+            getDialog().setDismissMessage(null);
+        super.onDestroyView();
+    }
+}

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
@@ -21,7 +21,7 @@ public class AlertDialogFragment extends DialogFragment {
         return frag;
     }
 
-    public void setFactory(AlertDialogFactory f) {
+    private void setFactory(AlertDialogFactory f) {
         this.factory = f;
     }
 

--- a/app/src/org/commcare/dalvik/dialogs/DialogController.java
+++ b/app/src/org/commcare/dalvik/dialogs/DialogController.java
@@ -13,7 +13,7 @@ public interface DialogController {
 
     /** Return the dialog that is currently showing, or null
      * if none exists */
-    CustomProgressDialog getCurrentDialog();
+    CustomProgressDialog getCurrentProgressDialog();
 
     /** Update the current dialog's message to the new text */
     void updateProgress(String updateText, int taskId);
@@ -26,4 +26,12 @@ public interface DialogController {
      *  in the activity hierarchy, in one of CommCareActivity's subclasses,
      *  while the other methods can be handled entirely by CommCareActivity */
     CustomProgressDialog generateProgressDialog(int taskId);
+
+
+    void showAlertDialog(AlertDialogFactory factory);
+
+    AlertDialogFragment getCurrentAlertDialog();
+
+    void showPendingAlertDialog();
+
 }

--- a/app/src/org/commcare/dalvik/dialogs/DialogController.java
+++ b/app/src/org/commcare/dalvik/dialogs/DialogController.java
@@ -27,11 +27,20 @@ public interface DialogController {
      *  while the other methods can be handled entirely by CommCareActivity */
     CustomProgressDialog generateProgressDialog(int taskId);
 
-
+    /**
+     * Show the alert dialog provided by the given AlertDialogFactory
+     */
     void showAlertDialog(AlertDialogFactory factory);
 
+    /**
+     * @return the alert dialog that is currently on screen (possibly null)
+     */
     AlertDialogFragment getCurrentAlertDialog();
 
+    /**
+     * If a dialog was showing when a previous instance of this activity was destroyed, this
+     * will re-pop up that dialog when the activity is re-launched
+     */
     void showPendingAlertDialog();
 
 }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1577,7 +1577,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
         };
         factory.setPositiveButton(StringUtils.getStringSpannableRobust(this, R.string.discard_answer), quitListener);
         factory.setNegativeButton(StringUtils.getStringSpannableRobust(this, R.string.clear_answer_no), quitListener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 
     /**

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1573,6 +1573,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
                     case DialogInterface.BUTTON_NEGATIVE:
                         break;
                 }
+                dialog.dismiss();
             }
         };
         factory.setPositiveButton(StringUtils.getStringSpannableRobust(this, R.string.discard_answer), quitListener);

--- a/app/src/org/odk/collect/android/activities/components/FormNavigationUI.java
+++ b/app/src/org/odk/collect/android/activities/components/FormNavigationUI.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android.activities.components;
 
-import android.app.Activity;
 import android.graphics.Rect;
 import android.util.Log;
 import android.util.Pair;
@@ -27,9 +26,9 @@ import java.util.ArrayList;
 public class FormNavigationUI {
     private final FormController mFormController;
     private final View mCurrentView;
-    private final Activity activity;
+    private final CommCareActivity activity;
 
-    public FormNavigationUI(Activity activity, View currentView, FormController formController) {
+    public FormNavigationUI(CommCareActivity activity, View currentView, FormController formController) {
         this.activity = activity;
         this.mCurrentView = currentView;
         this.mFormController = formController;

--- a/app/src/org/odk/collect/android/utilities/GeoUtils.java
+++ b/app/src/org/odk/collect/android/utilities/GeoUtils.java
@@ -5,6 +5,7 @@ import android.content.DialogInterface;
 import android.location.Location;
 import android.location.LocationManager;
 
+import org.commcare.android.framework.CommCareActivity;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.dialogs.AlertDialogFactory;
 import org.javarosa.core.model.data.GeoPointData;
@@ -79,7 +80,11 @@ public class GeoUtils {
             factory.makeCancelable();
             factory.setOnCancelListener(onCancel);
         }
-        factory.showDialog();
+        if (activity instanceof CommCareActivity) {
+            ((CommCareActivity)activity).showAlertDialog(factory);
+        } else {
+            factory.showDialog();
+        }
     }
 
     /**

--- a/app/src/org/odk/collect/android/utilities/GeoUtils.java
+++ b/app/src/org/odk/collect/android/utilities/GeoUtils.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.utilities;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.location.Location;
 import android.location.LocationManager;
@@ -54,37 +55,48 @@ public class GeoUtils {
                 
         return set;
     }
-    
+
     /**
      * Display a non-cancel-able dialog asking user if they want to turn on their GPS.
+     *
      * @param onChange Listener to call when dialog button is pressed.
      */
-    public static void showNoGpsDialog(Activity activity, DialogInterface.OnClickListener onChange) {
-        showNoGpsDialog(activity, onChange, null);
+    public static void showNoGpsDialog(CommCareActivity activity,
+                                       DialogInterface.OnClickListener onChange) {
+        AlertDialogFactory factory = setupAlertFactory(activity, onChange, null);
+        activity.showAlertDialog(factory);
     }
 
     /**
      * Display a (possibly cancelable) dialog asking user if they want to turn on their GPS.
+     *
      * @param onChange Listener to call when dialog button is pressed.
      * @param onCancel Listener to call when dialog is canceled.
      */
     public static void showNoGpsDialog(Activity activity,
                                        DialogInterface.OnClickListener onChange,
                                        DialogInterface.OnCancelListener onCancel) {
-        AlertDialogFactory factory = new AlertDialogFactory(activity,
-                activity.getString(R.string.no_gps_title),
-                activity.getString(R.string.no_gps_message));
-        factory.setPositiveButton(activity.getString(R.string.change_settings), onChange);
-        factory.setNegativeButton(activity.getString(R.string.cancel), onChange);
+        AlertDialogFactory factory = setupAlertFactory(activity, onChange, onCancel);
+
+        // NOTE PLM: this dialog will not persist through orientation changes.
+        factory.showDialog();
+    }
+
+    private static AlertDialogFactory setupAlertFactory(Context context,
+                                                        DialogInterface.OnClickListener onChange,
+                                                        DialogInterface.OnCancelListener onCancel) {
+        AlertDialogFactory factory =
+                new AlertDialogFactory(context,
+                        context.getString(R.string.no_gps_title),
+                        context.getString(R.string.no_gps_message));
+        factory.setPositiveButton(context.getString(R.string.change_settings), onChange);
+        factory.setNegativeButton(context.getString(R.string.cancel), onChange);
+
         if (onCancel != null) {
             factory.makeCancelable();
             factory.setOnCancelListener(onCancel);
         }
-        if (activity instanceof CommCareActivity) {
-            ((CommCareActivity)activity).showAlertDialog(factory);
-        } else {
-            factory.showDialog();
-        }
+        return factory;
     }
 
     /**


### PR DESCRIPTION
This PR makes it so that all alert dialogs spawned by any CommCareActivity will persist on orientation change. Alert Dialogs spawned by non-CC activities will still disappear on rotation, but this seems ok for now-- none of those instances are things that will break the app in any way or cause confusion. 

This is a partial (but not complete) solution to http://manage.dimagi.com/default.asp?184630. @phillipm is going to make a PR to address the rest of that ticket.