### PR TITLE
IncompleteFormListAdapter bug fixes

### DIFF
--- a/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
@@ -109,6 +109,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
     public void notifyPriorityLoaded(FormRecord record, boolean isLoaded) {
         if (isLoaded && satisfiesQuery(record)) {
             current.add(record);
+            notifyDataSetChanged();
         }
     }
 
@@ -117,7 +118,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
      */
     @Override
     public void notifyLoaded() {
-        this.notifyDataSetChanged();
+        notifyDataSetChanged();
     }
 
     /**
@@ -178,6 +179,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
 
         searchCache.clear();
         current.clear();
+        notifyDataSetChanged();
 
         // load specific data about the 'records' into the searchCache, such as
         // record title, form name, modified date
@@ -198,6 +200,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
     @Override
     public void notifyDataSetChanged() {
         super.notifyDataSetChanged();
+
         for (DataSetObserver observer : observers) {
             observer.onChanged();
         }
@@ -308,15 +311,15 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
 
         if ("".equals(query)) {
             current.addAll(records);
-            return;
-        }
-
-        // collect all forms that have text data that contains pieces.
-        for (FormRecord r : records) {
-            if (satisfiesQuery(r)) {
-                current.add(r);
+        } else {
+            // collect all forms that have text data that contains pieces.
+            for (FormRecord r : records) {
+                if (satisfiesQuery(r)) {
+                    current.add(r);
+                }
             }
         }
+        notifyDataSetChanged();
     }
 
     /**

--- a/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/android/adapters/IncompleteFormListAdapter.java
@@ -282,7 +282,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
 
     @Override
     public boolean isEmpty() {
-        return getCount() > 0;
+        return getCount() == 0;
     }
 
     public void setFormFilter(FormRecordFilter filter) {

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -413,6 +413,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
                             adapter.notifyDataSetInvalidated();
                         }
                     });
+                    return true;
                 case RESTORE_RECORD:
                     FormRecord record = (FormRecord)adapter.getItem(info.position);
                     try {


### PR DESCRIPTION
I think this is a fix for [this ticket](http://manage.dimagi.com/default.asp?183564) ([crash report here](https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/2470c26b3312af4adf1fce1ecd49f46d)), though I wasn't able to reproduce it, so I'm unsure.

First commit contains functional changes, which are to call `notifyDataSetChanged()` when the underlying adapter data is changed in any way.

Also fixes bug where deleting an incomplete/saved form entry actually duplicated the entry.