### PR TITLE
Make progress bar full after update

### DIFF
--- a/app/src/org/commcare/dalvik/activities/UpdateUIState.java
+++ b/app/src/org/commcare/dalvik/activities/UpdateUIState.java
@@ -190,7 +190,7 @@ class UpdateUIState {
         checkUpdateButton.setEnabled(true);
         stopUpdateButton.setEnabled(false);
         installUpdateButton.setEnabled(false);
-
+        updateProgressBar(100, 100);
         progressBar.setEnabled(false);
         updateProgressText(upgradeFinishedText);
 


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?185293

We seem to use this call updateProgressBar(100, 100) throughout this class to accomplish this. Guessing that's because filling the bar dynamically would require adding a lot of callbacks in the ResourceManager upgrade method. @phillipm 