### PR TITLE
Don't try to get session before cc app is installed

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -365,7 +365,6 @@ public class CommCareHomeActivity
         if(resultCode == RESULT_RESTART) {
             sessionNavigator.startNextSessionStep();
         } else {
-            AndroidSessionWrapper currentState = CommCareApplication._().getCurrentSessionWrapper();
             // if handling new return code (want to return to home screen) but a return at the end of your statement
             switch(requestCode) {
             case INIT_APP:
@@ -503,6 +502,8 @@ public class CommCareHomeActivity
                     //Retrieve and load the appropriate ssd
                     SqlStorage<SessionStateDescriptor> ssdStorage = CommCareApplication._().getUserStorage(SessionStateDescriptor.class);
                     Vector<Integer> ssds = ssdStorage.getIDsForValue(SessionStateDescriptor.META_FORM_RECORD_ID, r.getID());
+                    AndroidSessionWrapper currentState =
+                            CommCareApplication._().getCurrentSessionWrapper();
                     if(ssds.size() == 1) {
                         currentState.loadFromStateDescription(ssdStorage.read(ssds.firstElement()));
                     } else {
@@ -516,6 +517,8 @@ public class CommCareHomeActivity
                 break;
             case GET_COMMAND:
                 //TODO: We might need to load this from serialized state?
+                AndroidSessionWrapper currentState =
+                        CommCareApplication._().getCurrentSessionWrapper();
                 if (resultCode == RESULT_CANCELED) {
                     if (currentState.getSession().getCommand() == null) {
                         //Needed a command, and didn't already have one. Stepping back from
@@ -534,7 +537,8 @@ public class CommCareHomeActivity
                 break;
             case GET_CASE:
                 //TODO: We might need to load this from serialized state?
-                CommCareSession currentSession = currentState.getSession();
+                CommCareSession currentSession =
+                        CommCareApplication._().getCurrentSessionWrapper().getSession();
                 if (resultCode == RESULT_CANCELED) {
                     currentSession.stepBack();
                 } else if (resultCode == RESULT_OK) {

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -340,8 +340,6 @@ public class CommCareApplication extends Application {
 
     public AndroidSessionWrapper getCurrentSessionWrapper() {
         if (sessionWrapper == null) {
-            // TODO PLM: should be able to init this so it is never null.
-            // Need to find the correct place after the currentApp is set.
             throw new SessionStateUninitException("CommCare user session isn't available");
         }
         return sessionWrapper;


### PR DESCRIPTION
Pressing back on the install screen caused a crash because the onResultActivity code path was trying to load the commcare session before an app was installed.

http://manage.dimagi.com/default.asp?185291