### PR TITLE
Use default title if refreshing breadcrumb title while updating app

### DIFF
--- a/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/android/framework/BreadcrumbBarFragment.java
@@ -48,6 +48,7 @@ import org.commcare.suite.model.StackFrameStep;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.util.Vector;
 
@@ -361,30 +362,37 @@ public class BreadcrumbBarFragment extends Fragment {
     }
     
     public static String getBestTitle(Activity activity) {
-        String bestTitle = null;
         AndroidSessionWrapper asw;
 
         try {
             asw = CommCareApplication._().getCurrentSessionWrapper();
         } catch (SessionStateUninitException e) {
-            return defaultTitle(bestTitle, activity);
+            return defaultTitle(null, activity);
         }
 
         CommCareSession session = asw.getSession();
 
-        String[] stepTitles = session.getHeaderTitles();
+        String[] stepTitles;
+        try {
+            stepTitles = session.getHeaderTitles();
+        } catch (NoLocalizedTextException e) {
+            // localization resources may not be installed while in the middle
+            // of an update, so default to a generic title
+            return defaultTitle(null, activity);
+        }
 
         Vector<StackFrameStep> v = session.getFrame().getSteps();
 
         //So we need to work our way backwards through each "step" we've taken, since our RelativeLayout
         //displays the Z-Order b insertion (so items added later are always "on top" of items added earlier
-        for(int i = v.size() -1 ; i >= 0; i--){
+        String bestTitle = null;
+        for (int i = v.size() - 1; i >= 0; i--) {
             if (bestTitle != null) {
                 break;
             }
             StackFrameStep step = v.elementAt(i);
 
-            if(!SessionFrame.STATE_DATUM_VAL.equals(step.getType())) {
+            if (!SessionFrame.STATE_DATUM_VAL.equals(step.getType())) {
                 bestTitle = stepTitles[i];
             }
         }


### PR DESCRIPTION
If you rotate the screen while applying an app update then the breadcrumb bar crashes while trying to localize an installed resource because it isn't available. Wrap the offending line in a try/catch that returns a default title when this happens.

Isn't ideal, but is a minimal change and I suspect hunting down a robust solution would take me hours.