### PR TITLE
Make alert dialogs cancelable

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -529,22 +529,34 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public static void createErrorDialog(final CommCareActivity activity, String errorMsg,
                                          final boolean shouldExit) {
         String title = StringUtils.getStringRobust(activity, org.commcare.dalvik.R.string.error_occured);
+
         AlertDialogFactory factory = new AlertDialogFactory(activity, title, errorMsg);
         factory.setIcon(android.R.drawable.ic_dialog_info);
-        DialogInterface.OnClickListener buttonListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int i) {
-                switch (i) {
-                    case DialogInterface.BUTTON_POSITIVE:
+
+        DialogInterface.OnCancelListener cancelListener =
+                new DialogInterface.OnCancelListener() {
+                    @Override
+                    public void onCancel(DialogInterface dialog) {
                         if (shouldExit) {
                             activity.setResult(RESULT_CANCELED);
                             activity.finish();
                         }
-                        break;
-                }
-            }
-        };
-        CharSequence buttonDisplayText = StringUtils.getStringSpannableRobust(activity, org.commcare.dalvik.R.string.ok);
+                    }
+                };
+        factory.setOnCancelListener(cancelListener);
+
+        CharSequence buttonDisplayText =
+                StringUtils.getStringSpannableRobust(activity, org.commcare.dalvik.R.string.ok);
+        DialogInterface.OnClickListener buttonListener =
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int i) {
+                        if (shouldExit) {
+                            activity.setResult(RESULT_CANCELED);
+                            activity.finish();
+                        }
+                    }
+                };
         factory.setPositiveButton(buttonDisplayText, buttonListener);
 
         activity.showAlertDialog(factory);

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFactory.java
@@ -19,6 +19,8 @@ public class AlertDialogFactory {
 
     private final AlertDialog dialog;
     private final View view;
+    private DialogInterface.OnCancelListener cancelListener;
+    private boolean isCancelable = false;
 
     public AlertDialogFactory(Context context, String title, String msg) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
@@ -95,11 +97,20 @@ public class AlertDialogFactory {
     }
 
     public void makeCancelable() {
+        isCancelable = true;
         dialog.setCancelable(true);
     }
 
     public void setOnCancelListener(DialogInterface.OnCancelListener cancelListener) {
+        makeCancelable();
+        this.cancelListener = cancelListener;
         dialog.setOnCancelListener(cancelListener);
+    }
+
+    public void performCancel(DialogInterface dialog) {
+        if (cancelListener != null) {
+            cancelListener.onCancel(dialog);
+        }
     }
 
     public void setIcon(int resId) {
@@ -144,5 +155,7 @@ public class AlertDialogFactory {
         neutralButton.setVisibility(View.VISIBLE);
     }
 
-
+    public boolean isCancelable() {
+        return isCancelable;
+    }
 }

--- a/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/dalvik/dialogs/AlertDialogFragment.java
@@ -1,6 +1,7 @@
 package org.commcare.dalvik.dialogs;
 
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
@@ -18,6 +19,7 @@ public class AlertDialogFragment extends DialogFragment {
     public static AlertDialogFragment fromFactory(AlertDialogFactory f) {
         AlertDialogFragment frag = new AlertDialogFragment();
         frag.setFactory(f);
+        frag.setCancelable(f.isCancelable());
         return frag;
     }
 
@@ -29,6 +31,11 @@ public class AlertDialogFragment extends DialogFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
+    }
+
+    @Override
+    public void onCancel(DialogInterface dialog) {
+        factory.performCancel(dialog);
     }
 
     @Override

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1772,6 +1772,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
                 @Override
                 protected void deliverError(FormEntryActivity receiver, Exception e) {
                     receiver.setFormLoadFailure();
+                    receiver.dismissProgressDialog();
                     if (e != null) {
                         CommCareActivity.createErrorDialog(receiver, e.getMessage(), EXIT);
                     } else {
@@ -1837,11 +1838,13 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
      * Call when the user provides input that they want to quit the form
      */
     private void triggerUserQuitInput() {
-        //If we're just reviewing a read only form, don't worry about saving
-        //or what not, just quit
-        if(mFormController.isFormReadOnly()) {
-            //It's possible we just want to "finish" here, but
-            //I don't really wanna break any c compatibility
+        if(!formHasLoaded()) {
+            finish();
+        } else if (mFormController.isFormReadOnly()) {
+            // If we're just reviewing a read only form, don't worry about saving
+            // or what not, just quit
+            // It's possible we just want to "finish" here, but
+            // I don't really wanna break any c compatibility
             finishReturnInstance(false);
         } else {
             createQuitDialog();

--- a/app/src/org/odk/collect/android/utilities/GeoUtils.java
+++ b/app/src/org/odk/collect/android/utilities/GeoUtils.java
@@ -93,7 +93,6 @@ public class GeoUtils {
         factory.setNegativeButton(context.getString(R.string.cancel), onChange);
 
         if (onCancel != null) {
-            factory.makeCancelable();
             factory.setOnCancelListener(onCancel);
         }
         return factory;


### PR DESCRIPTION
Pressing back on an alert dialog that has a cancel listener wasn't doing anything.

This fixes that is very unfortunate way.