### PR TITLE
Consolidate duplicate code in UpdateTask & PurgeStaleArchivedFormsTask

### DIFF
--- a/app/src/org/commcare/android/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/android/resource/AndroidResourceManager.java
@@ -247,20 +247,24 @@ public class AndroidResourceManager extends ResourceManager {
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                String ref = ResourceInstallUtils.getDefaultProfileRef();
-                try {
-                    if (canUpdateRetryRun()) {
-                        UpdateTask updateTask = UpdateTask.getNewInstance();
-                        updateTask.startPinnedNotification(ctx);
-                        updateTask.setAsAutoUpdate();
-                        updateTask.execute(ref);
-                    }
-                } catch (IllegalStateException e) {
-                    // The user may have started the update process in the meantime
-                    Log.w(TAG, "Trying trigger an auto-update retry when it is already running");
-                }
+                launchRetryTask(ctx);
             }
         }, exponentionalRetryDelay(numberOfRestarts));
+    }
+
+    protected void launchRetryTask(Context ctx) {
+        String ref = ResourceInstallUtils.getDefaultProfileRef();
+        try {
+            if (canUpdateRetryRun()) {
+                UpdateTask updateTask = UpdateTask.getNewInstance();
+                updateTask.startPinnedNotification(ctx);
+                updateTask.setAsAutoUpdate();
+                updateTask.execute(ref);
+            }
+        } catch (IllegalStateException e) {
+            // The user may have started the update process in the meantime
+            Log.w(TAG, "Trying trigger an auto-update retry when it is already running");
+        }
     }
 
     /**

--- a/app/src/org/commcare/android/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/android/resource/ResourceInstallUtils.java
@@ -98,7 +98,7 @@ public class ResourceInstallUtils {
         updateProfileRef(currentApp.getAppPreferences(), authRef, profileRef);
     }
 
-    private static void updateProfileRef(SharedPreferences prefs,
+    public static void updateProfileRef(SharedPreferences prefs,
                                          String authRef, String profileRef) {
         SharedPreferences.Editor edit = prefs.edit();
         if (authRef != null) {

--- a/app/src/org/commcare/android/tasks/SingletonTask.java
+++ b/app/src/org/commcare/android/tasks/SingletonTask.java
@@ -1,0 +1,85 @@
+package org.commcare.android.tasks;
+
+import org.commcare.android.tasks.templates.ManagedAsyncTask;
+
+/**
+ * Base implementation for a singleton task that reports progress and results
+ * through a TaskListener.  Handles clearing pointer to static task via
+ * extender's implementation of clearTaskInstance.
+ */
+public abstract class SingletonTask<Params, Progress, Result>
+        extends ManagedAsyncTask<Params, Progress, Result> {
+
+    protected static String TAG;
+    private TaskListener<Progress, Result> taskListener = null;
+
+    /**
+     * Clears pointer to the singleton class instance in a thread-safe manner
+     */
+    protected abstract void clearTaskInstance();
+
+    @Override
+    protected void onProgressUpdate(Progress... values) {
+        super.onProgressUpdate(values);
+
+        if (taskListener != null) {
+            taskListener.handleTaskUpdate(values);
+        }
+    }
+
+    @Override
+    protected void onPostExecute(Result result) {
+        super.onPostExecute(result);
+
+        if (taskListener != null) {
+            taskListener.handleTaskCompletion(result);
+        }
+
+        clearTaskInstance();
+    }
+
+    @Override
+    protected void onCancelled(Result result) {
+        if (android.os.Build.VERSION.SDK_INT >= 11) {
+            super.onCancelled(result);
+        } else {
+            super.onCancelled();
+        }
+
+        if (taskListener != null) {
+            taskListener.handleTaskCancellation(result);
+        }
+
+        clearTaskInstance();
+    }
+
+    /**
+     * Start reporting progress with a listener process.
+     *
+     * @throws TaskListenerRegistrationException If this task was already
+     *                                           registered with a listener
+     */
+    public void registerTaskListener(TaskListener<Progress, Result> listener)
+            throws TaskListenerRegistrationException {
+        if (taskListener != null) {
+            throw new TaskListenerRegistrationException("This " + TAG +
+                    " was already registered with a TaskListener");
+        }
+        taskListener = listener;
+    }
+
+    /**
+     * Stop reporting progress with a listener process
+     *
+     * @throws TaskListenerRegistrationException If this task wasn't registered
+     *                                           with the unregistering listener.
+     */
+    public void unregisterTaskListener(TaskListener<Progress, Result> listener)
+            throws TaskListenerRegistrationException {
+        if (listener != taskListener) {
+            throw new TaskListenerRegistrationException("The provided listener wasn't " +
+                    "registered with this " + TAG);
+        }
+        taskListener = null;
+    }
+}

--- a/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
+++ b/app/src/org/commcare/android/tasks/templates/ManagedAsyncTask.java
@@ -12,14 +12,15 @@ import java.util.ArrayList;
  * @author Phillip Mates (pmates@dimagi.com)
  */
 
-public abstract class ManagedAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
+public abstract class ManagedAsyncTask<Params, Progress, Result>
+        extends AsyncTask<Params, Progress, Result> {
 
     /**
      * List of running tasks. Tasks add/remove themselves automatically upon
      * start, cancellation, and completion.
      */
     private static final ArrayList<ManagedAsyncTask<?, ?, ?>> livingTasks =
-            new ArrayList<ManagedAsyncTask<?, ?, ?>>();
+            new ArrayList<>();
 
     /**
      * Call cancel on all tasks and then wipe the living task list.
@@ -49,7 +50,7 @@ public abstract class ManagedAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
      * On execution completion remove task from managed task list.
      */
     @Override
-    protected void onPostExecute(C result) {
+    protected void onPostExecute(Result result) {
         super.onPostExecute(result);
 
         synchronized (livingTasks) {

--- a/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
@@ -15,7 +15,6 @@ import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.suite.model.Profile;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,11 +50,6 @@ public class AppUpdateTest {
 
         Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
         Assert.assertTrue(p.getVersion() == 6);
-    }
-
-    @After
-    public void tearDown() {
-        UpdateTask.clearTaskInstance();
     }
 
     private String buildResourceRef(String app, String resource) {
@@ -180,6 +174,7 @@ public class AppUpdateTest {
 
         Assert.assertEquals(expectedInstallStatus,
                 InstallStagedUpdateTask.installStagedUpdate());
+        updateTask.clearTaskInstance();
     }
 
     private TaskListener<Integer, AppInstallStatus> taskListenerFactory(final AppInstallStatus expectedResult) {

--- a/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.fail;
@@ -49,8 +50,13 @@ public class AutoUpdateTest {
         CommCareApp app = CommCareApplication._().getCurrentApp();
         Assert.assertFalse(ResourceInstallUtils.shouldAutoUpdateResume(app));
 
+        String profileOfInvalidApp = buildResourceRef("invalid_update", "profile.ccpr");
+        // necessary because retry auto-update task reads from the app's default profile
+        setAppsDefaultProfile(profileOfInvalidApp);
+
         // try to update to an app with syntax errors
         UpdateTask updateTask = UpdateTask.getNewInstance();
+        updateTask.startPinnedNotification(RuntimeEnvironment.application);
         updateTask.setAsAutoUpdate();
         try {
             TaskListener<Integer, AppInstallStatus> listener =
@@ -59,7 +65,7 @@ public class AutoUpdateTest {
         } catch (TaskListenerRegistrationException e) {
             fail("failed to register listener for update task");
         }
-        updateTask.execute(buildResourceRef("invalid_update", "profile.ccpr"));
+        updateTask.execute(profileOfInvalidApp);
 
         Robolectric.flushBackgroundThreadScheduler();
         Robolectric.flushForegroundThreadScheduler();
@@ -69,6 +75,11 @@ public class AutoUpdateTest {
 
         updateTask.clearTaskInstance();
         CommCareApplication._().closeUserSession();
+    }
+
+    private void setAppsDefaultProfile(String ref) {
+        CommCareApp app = CommCareApplication._().getCurrentApp();
+        ResourceInstallUtils.updateProfileRef(app.getAppPreferences(), ref, null);
     }
 
     private void installBaseApp() {

--- a/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
@@ -67,7 +67,7 @@ public class AutoUpdateTest {
         // auto-update should now want to resume
         Assert.assertTrue(ResourceInstallUtils.shouldAutoUpdateResume(app));
 
-        UpdateTask.clearTaskInstance();
+        updateTask.clearTaskInstance();
         CommCareApplication._().closeUserSession();
     }
 


### PR DESCRIPTION
Both UpdateTask and PurgeStaleArchivedFormsTask are examples of singleton tasks that report to some sort of TaskListener. Hence, they share a lot of reporting and tear-down code. This PR consolidates that duplicate code into `SingletonTask`.