### PR TITLE
use dp for font sizes in dialogs

### DIFF
--- a/app/res/layout/custom_alert_dialog.xml
+++ b/app/res/layout/custom_alert_dialog.xml
@@ -33,7 +33,7 @@
                     android:id="@+id/dialog_message"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:textSize="@dimen/font_size_large"/>
+                    android:textSize="@dimen/font_size_dp_large"/>
 
             </RelativeLayout>
 
@@ -56,7 +56,7 @@
                 android:layout_marginRight="@dimen/standard_spacer"
 
                 android:background="@android:color/transparent"
-                android:textSize="@dimen/font_size_medium"
+                android:textSize="@dimen/font_size_dp_medium"
                 android:textColor="@color/dialog_button_color"
                 android:visibility="gone">
             </Button>
@@ -70,7 +70,7 @@
                 android:layout_toLeftOf="@id/positive_button"
 
                 android:background="@android:color/transparent"
-                android:textSize="@dimen/font_size_medium"
+                android:textSize="@dimen/font_size_dp_medium"
                 android:textColor="@color/dialog_button_color"
                 android:visibility="gone">
             </Button>
@@ -87,7 +87,7 @@
                 android:layout_marginLeft="@dimen/standard_spacer"
 
                 android:background="@android:color/transparent"
-                android:textSize="@dimen/font_size_medium"
+                android:textSize="@dimen/font_size_dp_medium"
                 android:textColor="@color/dialog_button_color"
                 android:visibility="gone">
             </Button>

--- a/app/res/layout/dialog_title.xml
+++ b/app/res/layout/dialog_title.xml
@@ -20,6 +20,6 @@
         android:id="@+id/dialog_title_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="@dimen/font_size_xlarger" />
+        android:textSize="@dimen/font_size_dp_xlarger" />
 
 </LinearLayout>

--- a/app/res/layout/progress_dialog_cancel_button.xml
+++ b/app/res/layout/progress_dialog_cancel_button.xml
@@ -9,6 +9,6 @@
     android:padding="@dimen/standard_spacer"
     android:background="@android:color/transparent"
     android:text="STOP"
-    android:textSize="@dimen/font_size_medium"
+    android:textSize="@dimen/font_size_dp_medium"
     android:visibility="gone" >
 </Button>

--- a/app/res/layout/progress_dialog_determinate.xml
+++ b/app/res/layout/progress_dialog_determinate.xml
@@ -22,7 +22,7 @@
             android:id="@+id/progress_dialog_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/font_size_large"
+            android:textSize="@dimen/font_size_dp_large"
             android:paddingBottom="@dimen/standard_spacer_double" />
 
         <ProgressBar
@@ -42,7 +42,7 @@
             android:layout_below="@id/progress_bar_horizontal"
             android:focusable="true"
             android:visibility="gone"
-            android:textSize="@dimen/font_size_large"
+            android:textSize="@dimen/font_size_dp_large"
             android:layout_marginTop="@dimen/standard_spacer_double" >
         </CheckBox>
 

--- a/app/res/layout/progress_dialog_indeterminate.xml
+++ b/app/res/layout/progress_dialog_indeterminate.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:layout_toRightOf="@id/progress_bar"
             android:layout_centerVertical="true"
-            android:textSize="@dimen/font_size_large" />
+            android:textSize="@dimen/font_size_dp_large" />
 
     </RelativeLayout>
 

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -40,6 +40,13 @@
     <dimen name="font_size_xlarger">23sp</dimen>
     <dimen name="font_size_xlargest">28sp</dimen>
 
+    <dimen name="font_size_dp_small">12dp</dimen>
+    <dimen name="font_size_dp_medium">15dp</dimen>
+    <dimen name="font_size_dp_large">18dp</dimen>
+    <dimen name="font_size_dp_xlarge">21dp</dimen>
+    <dimen name="font_size_dp_xlarger">23dp</dimen>
+    <dimen name="font_size_dp_xlargest">28dp</dimen>
+
     <dimen name="cell_padding_vertical">8dp</dimen>
     <dimen name="cell_padding_horizontal">8dp</dimen>
     <dimen name="row_padding_vertical">8dp</dimen>


### PR DESCRIPTION
So Kriti found a major bug with the new dialogs-- Even though using 'sp' font sizes is the standard recommendation, for some reason in the new dialogs, it was making the font sizes completely wonky on some tablets. This PR changes all the font sizes in all the new dialogs to the same size, but 'dp'. I confirmed that it fixes the appearance on the problematic tablets, and doesn't change the prior appearance on other devices.