### PR TITLE
Set FormRecord class field properly

### DIFF
--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -102,7 +102,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
         this.uuid = uuid;
         this.lastModified = lastModified;
         if (lastModified == null) {
-            lastModified = new Date();
+            this.lastModified = new Date();
         }
     }
 


### PR DESCRIPTION
The value of lastModified was not actually getting set in the constructor if the if value passed in was null. Not sure what the implications of this are or if it could have been causing any bugs -- if it could be, should  probably just put in 2.24.