### PR TITLE
Don't crash when trying to remove attached videos on form discarding 

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1444,21 +1444,21 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
             String where =
                 Images.Media.DATA + " like '" + instanceFolder + "%'";
 
-            String[] projection = {
-                Images.ImageColumns._ID
-            };
 
             // images
             Cursor imageCursor = null;
             try {
+                String[] projection = {
+                        Images.ImageColumns._ID
+                };
                 imageCursor = getContentResolver().query(
                             android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                             projection, where, null, null);
-                if (imageCursor.getCount() > 0) {
+                if (imageCursor != null && imageCursor.getCount() > 0) {
                     imageCursor.moveToFirst();
-                    String id =
-                        imageCursor.getString(imageCursor
-                                .getColumnIndex(Images.ImageColumns._ID));
+                    int columnIndex =
+                            imageCursor.getColumnIndex(Images.ImageColumns._ID);
+                    String id = imageCursor.getString(columnIndex);
 
                     Log.i(
                             TAG,
@@ -1482,14 +1482,17 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
             // audio
             Cursor audioCursor = null;
             try {
+                String[] projection = {
+                        MediaStore.Audio.AudioColumns._ID
+                };
                 audioCursor = getContentResolver().query(
                     MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                     projection, where, null, null);
-                if (audioCursor.getCount() > 0) {
+                if (audioCursor != null && audioCursor.getCount() > 0) {
                     audioCursor.moveToFirst();
-                    String id =
-                        audioCursor.getString(imageCursor
-                                .getColumnIndex(Images.ImageColumns._ID));
+                    int columnIndex =
+                            audioCursor.getColumnIndex(MediaStore.Audio.AudioColumns._ID);
+                    String id = audioCursor.getString(columnIndex);
 
                     Log.i(
                             TAG,
@@ -1513,14 +1516,17 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
             // video
             Cursor videoCursor = null;
             try {
+                String[] projection = {
+                        MediaStore.Video.VideoColumns._ID
+                };
                 videoCursor = getContentResolver().query(
                     MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
                     projection, where, null, null);
-                if (videoCursor.getCount() > 0) {
+                if (videoCursor != null && videoCursor.getCount() > 0) {
                     videoCursor.moveToFirst();
-                    String id =
-                        videoCursor.getString(imageCursor
-                                .getColumnIndex(Images.ImageColumns._ID));
+                    int columnIndex =
+                            videoCursor.getColumnIndex(MediaStore.Video.VideoColumns._ID);
+                    String id = videoCursor.getString(columnIndex);
 
                     Log.i(
                             TAG,


### PR DESCRIPTION
Deleting form media was using incorrect cursors and columns. This resulted in CommCare crashing, leaving media files around on the phone.

https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/f0d93cc3076bcc0c57c569debab9646a