### PR TITLE
Ui progress dialog cutoff on tab 2/3 devices

### DIFF
--- a/app/res/layout/progress_dialog_determinate.xml
+++ b/app/res/layout/progress_dialog_determinate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/progress_fragment_determinate"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -13,7 +13,6 @@
         android:id="@+id/main_content_holder"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/progress_dialog_title"
         android:layout_marginBottom="@dimen/standard_spacer_large"
         android:layout_marginLeft="@dimen/standard_spacer_large"
         android:layout_marginRight="@dimen/standard_spacer_large" >
@@ -53,4 +52,4 @@
         layout="@layout/progress_dialog_cancel_button" />
 
 
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
Fixed progress dialog text cutoff occurring on Tab 2 & 3 devices:
![image](https://cloud.githubusercontent.com/assets/94817/10799935/d1b94b08-7d85-11e5-96a5-3d13ec02dbe1.png)


http://manage.dimagi.com/default.asp?184613