### PR TITLE
call dialog.dismiss() for no gps dialog

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -1236,9 +1236,6 @@ public class CommCareHomeActivity
                         // create a new form record and begin form entry
                         state.commitStub();
                         formEntry(platform.getFormContentUri(state.getSession().getForm()), state.getFormRecord());
-                        break;
-                    default:
-                        break;
                 }
                 dialog.dismiss();
             }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -324,6 +324,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
                         Intent intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
                         startActivity(intent);
                     }
+                    dialog.dismiss();
                 }
             };
             GeoUtils.showNoGpsDialog(this, onChangeListener);

--- a/app/src/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/app/src/org/odk/collect/android/activities/GeoPointActivity.java
@@ -110,6 +110,7 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
                             GeoPointActivity.this.finish();
                             break;
                     }
+                    dialog.dismiss();
                 }
             };
             

--- a/app/src/org/odk/collect/android/utilities/GeoUtils.java
+++ b/app/src/org/odk/collect/android/utilities/GeoUtils.java
@@ -90,7 +90,7 @@ public class GeoUtils {
                         context.getString(R.string.no_gps_title),
                         context.getString(R.string.no_gps_message));
         factory.setPositiveButton(context.getString(R.string.change_settings), onChange);
-        factory.setNegativeButton(context.getString(R.string.cancel), onChange);
+        factory.setNegativeButton(context.getString(R.string.cancel_location), onChange);
 
         if (onCancel != null) {
             factory.setOnCancelListener(onCancel);


### PR DESCRIPTION
dialog.dismiss() wasn't getting called where it should be for the onClickListener in one of the dialogs, making it impossible to close. I also did a quick pass over all of the new dialogs to make sure there weren't any others left with the same problem.

Also makes text capitalization for the no gps dialog consistent, and removes a noop from 1 file.