### PR TITLE
In entity subnode details, ignore blank rows

### DIFF
--- a/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
@@ -13,7 +13,7 @@ import org.commcare.suite.model.Detail;
 import org.javarosa.core.model.instance.TreeReference;
 
 import java.util.List;
-import java.util.Vector;
+import java.util.ArrayList;
 
 /**
  * Created by jschweers on 8/24/2015.

--- a/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
@@ -32,7 +32,7 @@ public class EntitySubnodeDetailAdapter implements ListAdapter, ModifiableEntity
     public EntitySubnodeDetailAdapter(Context context, Detail detail, List<TreeReference> references, List<Entity<TreeReference>> entities, ListItemViewModifier modifier) {
         this.context = context;
         this.detail = detail;
-        this.references = references;
+        this.modifier = modifier;
         this.initializeData(references, entities);
     }
 
@@ -40,15 +40,15 @@ public class EntitySubnodeDetailAdapter implements ListAdapter, ModifiableEntity
      * Populate entities and references. Will ignore any entities (and their
      * associated references) without any valid fields.
      */
-    private void initializeData(List<TreeReference> references, List<Entity<TreeReference>> entities) {
-        this.references = new Vector<>();
-        this.entities = new Vector<>();
+    private void initializeData(List<TreeReference> referenceList, List<Entity<TreeReference>> entityList) {
+        this.references = new ArrayList<>(referenceList.size());
+        this.entities = new ArrayList<>(entityList.size());
         int entityIndex = 0;
-        for (Entity e : entities) {
+        for (Entity e : entityList) {
             for (int i = 0; i < e.getNumFields(); i++) {
                 if (e.isValidField(i)) {
                     this.entities.add(e);
-                    this.references.add(references.get(entityIndex));
+                    this.references.add(referenceList.get(entityIndex));
                     break;
                 }
             }

--- a/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
@@ -13,6 +13,7 @@ import org.commcare.suite.model.Detail;
 import org.javarosa.core.model.instance.TreeReference;
 
 import java.util.List;
+import java.util.Vector;
 
 /**
  * Created by jschweers on 8/24/2015.
@@ -32,8 +33,24 @@ public class EntitySubnodeDetailAdapter implements ListAdapter, ModifiableEntity
         this.context = context;
         this.detail = detail;
         this.references = references;
-        this.entities = entities;
-        this.modifier = modifier;
+
+        // Only include data for entities that have at least one valid field
+        this.references = new Vector<>();
+        this.entities = new Vector<>();
+        int entityIndex = 0;
+        for (Entity e : entities) {
+            boolean isValid = false;
+            for (int i = 0; i < e.getNumFields(); i++) {
+                if (e.isValidField(i)) {
+                    isValid = true;
+                }
+            }
+            if (isValid) {
+                this.entities.add(e);
+                this.references.add(references.get(entityIndex));
+            }
+            entityIndex++;
+        }
     }
 
 

--- a/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
+++ b/app/src/org/commcare/android/adapters/EntitySubnodeDetailAdapter.java
@@ -33,26 +33,28 @@ public class EntitySubnodeDetailAdapter implements ListAdapter, ModifiableEntity
         this.context = context;
         this.detail = detail;
         this.references = references;
+        this.initializeData(references, entities);
+    }
 
-        // Only include data for entities that have at least one valid field
+    /**
+     * Populate entities and references. Will ignore any entities (and their
+     * associated references) without any valid fields.
+     */
+    private void initializeData(List<TreeReference> references, List<Entity<TreeReference>> entities) {
         this.references = new Vector<>();
         this.entities = new Vector<>();
         int entityIndex = 0;
         for (Entity e : entities) {
-            boolean isValid = false;
             for (int i = 0; i < e.getNumFields(); i++) {
                 if (e.isValidField(i)) {
-                    isValid = true;
+                    this.entities.add(e);
+                    this.references.add(references.get(entityIndex));
+                    break;
                 }
-            }
-            if (isValid) {
-                this.entities.add(e);
-                this.references.add(references.get(entityIndex));
             }
             entityIndex++;
         }
     }
-
 
     @Override
     public boolean areAllItemsEnabled() {


### PR DESCRIPTION
Make data-driven entity detail screens behave like entity selection screens: don't display rows that have no data.