### PR TITLE
Move cancel button back to being right-aligned

### DIFF
--- a/app/res/layout/progress_dialog_determinate.xml
+++ b/app/res/layout/progress_dialog_determinate.xml
@@ -47,9 +47,14 @@
 
     </RelativeLayout>
 
-    <include
-        android:id="@+id/dialog_cancel_button"
-        layout="@layout/progress_dialog_cancel_button" />
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
+        <include
+            android:id="@+id/dialog_cancel_button"
+            layout="@layout/progress_dialog_cancel_button" />
+
+    </RelativeLayout>
 
 </LinearLayout>


### PR DESCRIPTION
A fix for a different dialog bug changed this layout from a RelativeLayout to LinearLayout, which messed up the alignment of the cancel button. Moving it back to right-aligned