### PR TITLE
Prevent swipe when repeat dialog is up

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1983,6 +1983,7 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
         }
         return super.onKeyDown(keyCode, event);
     }
+
     private boolean shouldIgnoreSwipeAction() {
         return isAnimatingSwipe || isDialogShowing;
     }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -203,7 +203,6 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
     private boolean hasFormLoadFailed = false;
 
     // used to limit forward/backward swipes to one per question
-    private boolean shouldIgnoreSwipeAction;
     private boolean isAnimatingSwipe;
     private boolean isDialogShowing;
 
@@ -371,7 +370,9 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
 
         mViewPane = (ViewGroup)findViewById(R.id.form_entry_pane);
 
+        // re-set defaults in case the app got in a bad state.
         isAnimatingSwipe = false;
+        isDialogShowing = false;
         mCurrentView = null;
         mInAnimation = null;
         mOutAnimation = null;


### PR DESCRIPTION
If you try to quickly swipe twice when the next question launches a repeat dialog, then clicking any entry in the dialog crashes the app. This is happening because the second swipe is being processed even when the dialog is present

http://manage.dimagi.com/default.asp?186334

Fixes this ACRA crash: 
```
java.lang.RuntimeException: Invalid reference while copying itemset answer: Destination already exists!
```
https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/dc4a2588a05c7cff3cc4279bd7562f9d