### PR TITLE
Don't allow keyboard suggestions

### DIFF
--- a/app/src/org/odk/collect/android/widgets/StringWidget.java
+++ b/app/src/org/odk/collect/android/widgets/StringWidget.java
@@ -116,6 +116,8 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
         if(secret) {
             mAnswer.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
             mAnswer.setTransformationMethod(PasswordTransformationMethod.getInstance());
+        } else{
+            mAnswer.setInputType(InputType.TYPE_TEXT_VARIATION_FILTER);
         }
     }
 


### PR DESCRIPTION
One fix for the lack of form entry space in the new UI

In classic Android fashion the supposed flag for this doesn't work and you have to use this "textFilter" flag:

http://stackoverflow.com/questions/4281838/how-to-disable-displaying-suggestions-on-the-soft-keyboard