### PR TITLE
Fix for overzealous display of group label data

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -144,6 +144,17 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         mGestureDetector = new GestureDetector(this, this);
     }
 
+    /**
+     * Call this method from an implementing activity to request a new event trigger for any time
+     * the available space for the core content view changes significantly, for instance when the
+     * soft keyboard is displayed or hidden.
+     *
+     * This method will also be reliably triggered upon the end of the first layout pass, so it
+     * can be used to do the initial setup for adaptive layouts as well as their updates.
+     *
+     * After this is called, major layout size changes will be triggered in the onMajorLayoutChange
+     * method.
+     */
     protected void requestMajorLayoutUpdates() {
         final View decorView = getWindow().getDecorView();
         decorView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -153,16 +164,15 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             @Override
             public void onGlobalLayout() {
                 Rect r = new Rect();
-                //r will be populated with the coordinates of your view that area still visible.
+                //r will be populated with the coordinates of your view that are visible after the
+                //recent change.
                 decorView.getWindowVisibleDisplayFrame(r);
 
                 int mainContentHeight = r.height();
 
-                //int viewFrameWindowDifference = Math.abs(mainContentHeight - (r.bottom - r.top));
-
                 int previousMeasurementDifference = Math.abs(mainContentHeight - mPreviousDecorViewFrameHeight);
 
-                if (previousMeasurementDifference > 100) { // if more than 100 pixels, its probably a keyboard...
+                if (previousMeasurementDifference > 100) {
                     onMajorLayoutChange(r);
                 }
                 mPreviousDecorViewFrameHeight = mainContentHeight;
@@ -170,6 +180,18 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         });
     }
 
+    /**
+     * This method is called when the root view size available to the activity has changed
+     * significantly. It is the appropriate place to trigger adaptive layout behaviors.
+     *
+     * Note for performance that changes to declarative view properties here will trigger another
+     * layout pass.
+     *
+     * This callback is only triggered if the parent view has called requestMajorLayoutUpdates
+     *
+     * @param newRootViewDimensions The dimensions of the new root screen view that is available
+     *                              to the activity.
+     */
     protected void onMajorLayoutChange(Rect newRootViewDimensions) {
 
    }

--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
+import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
@@ -14,6 +15,7 @@ import android.text.Spannable;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Pair;
+import android.util.TypedValue;
 import android.view.Display;
 import android.view.GestureDetector;
 import android.view.GestureDetector.OnGestureListener;
@@ -22,6 +24,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -140,6 +143,52 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
         mGestureDetector = new GestureDetector(this, this);
     }
+
+    protected void requestMajorLayoutUpdates() {
+        final View decorView = getWindow().getDecorView();
+        decorView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+
+            int mPreviousDecorViewFrameHeight = 0;
+
+            @Override
+            public void onGlobalLayout() {
+                Rect r = new Rect();
+                //r will be populated with the coordinates of your view that area still visible.
+                decorView.getWindowVisibleDisplayFrame(r);
+
+                int mainContentHeight = r.height();
+
+                //int viewFrameWindowDifference = Math.abs(mainContentHeight - (r.bottom - r.top));
+
+                int previousMeasurementDifference = Math.abs(mainContentHeight - mPreviousDecorViewFrameHeight);
+
+                if (previousMeasurementDifference > 100) { // if more than 100 pixels, its probably a keyboard...
+                    onMajorLayoutChange(r);
+                }
+                mPreviousDecorViewFrameHeight = mainContentHeight;
+            }
+        });
+    }
+
+    protected void onMajorLayoutChange(Rect newRootViewDimensions) {
+
+   }
+
+    protected int getActionBarSize() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            int actionBarHeight = getActionBar().getHeight();
+
+            if (actionBarHeight != 0) {
+                return actionBarHeight;
+            }
+            final TypedValue tv = new TypedValue();
+            if (getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+                actionBarHeight = TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
+            }
+            return actionBarHeight;
+        } return 0;
+    }
+
 
     protected void restoreLastQueryString(String key) {
         SharedPreferences settings = getSharedPreferences(CommCarePreferences.ACTIONBAR_PREFS, 0);

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2430,7 +2430,7 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
             }
         }
 
-        if(numberOfGroupLinesAllowed <= 0) {
+        if(numberOfGroupLinesAllowed == 0) {
             this.mGroupForcedInvisible = true;
             updateGroupViewVisibility();
             groupLabel.setMaxLines(0);

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -10,13 +10,16 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.database.Cursor;
+import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.location.LocationManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images;
 import android.support.v4.app.Fragment;
@@ -24,6 +27,7 @@ import android.support.v4.app.FragmentManager;
 import android.text.SpannableStringBuilder;
 import android.util.Log;
 import android.util.Pair;
+import android.util.TypedValue;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.ContextThemeWrapper;
@@ -220,6 +224,8 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
     // database & key session are expiring. Being set causes savingComplete to
     // broadcast a form saving intent.
     private boolean savingFormOnKeySessionExpiration = false;
+    private boolean mGroupForcedInvisible = false;
+    private boolean mGroupNativeVisibility = false;
 
     enum AnimationType {
         LEFT, RIGHT, FADE
@@ -366,6 +372,8 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
         });
 
         mViewPane = (ViewGroup)findViewById(R.id.form_entry_pane);
+
+        requestMajorLayoutUpdates();
 
         mBeenSwiped = false;
         mCurrentView = null;
@@ -1120,8 +1128,8 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
 
         TextView groupLabel = ((TextView)header.findViewById(R.id.form_entry_group_label));
 
-        header.setVisibility(View.GONE);
-        groupLabel.setVisibility(View.GONE);
+        this.mGroupNativeVisibility = false;
+        this.updateGroupViewVisibility();
 
         if (mCurrentView instanceof ODKView) {
             ((ODKView) mCurrentView).setFocus(this);
@@ -1130,8 +1138,8 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
 
             if(groupLabelText != null && !groupLabelText.toString().trim().equals("")) {
                 groupLabel.setText(groupLabelText);
-                header.setVisibility(View.VISIBLE);
-                groupLabel.setVisibility(View.VISIBLE);
+                this.mGroupNativeVisibility = true;
+                updateGroupViewVisibility();
             }
         } else {
             InputMethodManager inputManager =
@@ -2377,4 +2385,87 @@ public class FormEntryActivity extends CommCareActivity<FormEntryActivity>
     private void setFormLoadFailure() {
         hasFormLoadFailed = true;
     }
+
+    @Override
+    protected void onMajorLayoutChange(Rect newRootViewDimensions) {
+        determineNumberOfValidGroupLines(newRootViewDimensions);
+    }
+
+
+    private void determineNumberOfValidGroupLines(Rect newRootViewDimensions) {
+        FrameLayout header = (FrameLayout)findViewById(R.id.form_entry_header);
+        TextView groupLabel = ((TextView)header.findViewById(R.id.form_entry_group_label));
+
+        int contentSize = newRootViewDimensions.height();
+
+        View navBar = this.findViewById(R.id.nav_pane);
+        int headerSize = navBar.getHeight();
+        if(headerSize == 0) {
+            headerSize = this.getResources().getDimensionPixelSize(R.dimen.new_progressbar_minheight);
+        }
+
+        int availableWindow = contentSize - headerSize - getActionBarSize();
+
+        int questionFontSize = getFontSizeInPx();
+
+        //Request a consistent amount of the screen before groups can cut down
+
+        int spaceRequested = questionFontSize * 6;
+
+        int spaceAvailable = availableWindow - spaceRequested;
+
+        int defaultHeaderSpace = this.getResources().getDimensionPixelSize(R.dimen.content_min_margin) * 2;
+
+        float textSize = groupLabel.getTextSize();
+
+        int numberOfGroupLinesAllowed = (int)((spaceAvailable - defaultHeaderSpace) / textSize);
+
+        if(numberOfGroupLinesAllowed < 0) {
+            numberOfGroupLinesAllowed = 0;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            if (groupLabel.getMaxLines() == numberOfGroupLinesAllowed) {
+                return;
+            }
+        }
+
+        if(numberOfGroupLinesAllowed <= 0) {
+            this.mGroupForcedInvisible = true;
+            updateGroupViewVisibility();
+            groupLabel.setMaxLines(0);
+        } else {
+            this.mGroupForcedInvisible = false;
+            updateGroupViewVisibility();
+            groupLabel.setMaxLines(numberOfGroupLinesAllowed);
+        }
+    }
+
+    private void updateGroupViewVisibility() {
+        FrameLayout header = (FrameLayout)findViewById(R.id.form_entry_header);
+        TextView groupLabel = ((TextView)header.findViewById(R.id.form_entry_group_label));
+
+        if(mGroupNativeVisibility && !mGroupForcedInvisible) {
+            header.setVisibility(View.VISIBLE);
+            groupLabel.setVisibility(View.VISIBLE);
+        } else {
+            header.setVisibility(View.GONE);
+            groupLabel.setVisibility(View.GONE);
+
+        }
+    }
+
+    private int getFontSizeInPx() {
+        SharedPreferences settings =
+                PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        String question_font =
+                settings.getString(FormEntryPreferences.KEY_FONT_SIZE, ODKStorage.DEFAULT_FONTSIZE);
+
+        int sizeInPx = Integer.valueOf(question_font);
+
+        return (int)TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, sizeInPx,
+                getResources().getDisplayMetrics());
+
+    }
+
 }


### PR DESCRIPTION
Implemented an adaptive layout technique for shrinking the question group label max size based on the screen dimensions, triggering on any major changes to the screen size (soft keyboard).

Fix for: http://manage.dimagi.com/default.asp?186516