### PR TITLE
Use current case list search query when loading is complete 

### DIFF
--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -610,8 +610,8 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
 
 
     public void afterTextChanged(Editable s) {
-        final String incomingString = incomingEditable.toString();^M
-        final String currentSearchText = getSearchText().toString();^M
+        final String incomingString = incomingEditable.toString();
+        final String currentSearchText = getSearchText().toString();
         if (incomingString.equals(currentSearchText)) {
             filterString = currentSearchText;
             if (adapter != null) {

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -609,7 +609,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
     }
 
 
-    public void afterTextChanged(Editable s) {
+    public void afterTextChanged(Editable incomingEditable) {
         final String incomingString = incomingEditable.toString();
         final String currentSearchText = getSearchText().toString();
         if (incomingString.equals(currentSearchText)) {

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -610,8 +610,10 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
 
 
     public void afterTextChanged(Editable s) {
-        if (getSearchText() == s) {
-            filterString = s.toString();
+        final String incomingString = incomingEditable.toString();^M
+        final String currentSearchText = getSearchText().toString();^M
+        if (incomingString.equals(currentSearchText)) {
+            filterString = currentSearchText;
             if (adapter != null) {
                 adapter.applyFilter(filterString);
             }
@@ -682,6 +684,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
                     @Override
                     public boolean onQueryTextChange(String newText) {
                         lastQueryString = newText;
+                        filterString = newText;
                         if (BuildConfig.DEBUG) {
                             Log.v(TAG, "Setting lastQueryString to (" + newText + ")");
                         }
@@ -896,8 +899,6 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity implement
         if (inAwesomeMode) {
             updateSelectedItem(true);
         }
-
-        rebuildMenus();
 
         this.startTimer();
     }


### PR DESCRIPTION
There was some strange behaviour where [`onQueryTextChange`](https://github.com/dimagi/commcare-odk/blob/bug/case-search-clearing/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java#L685) was getting called multiple times, the last time with an empty string even though the search box wasn't empty. The solution was to not trigger a rebuild of the options menu/action bar.

Fix for this http://manage.dimagi.com/default.asp?186541
Possible that this re-introduces the bug in http://manage.dimagi.com/default.asp?171354 . Clark looked into it and wasn't able to reproduce it, so I think we are good