### PR TITLE
Turn case-list query storing/retrieving into no-ops

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -4,7 +4,6 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.os.Build;
@@ -40,7 +39,6 @@ import org.commcare.android.util.MarkupUtil;
 import org.commcare.android.util.MediaUtil;
 import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.StringUtils;
-import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.AlertDialogFactory;
@@ -213,11 +211,17 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
 
     protected void restoreLastQueryString(String key) {
+        // XXX PLM: disabling this for 2.24.1, fix soon! (Nov 6th 2015)
+        // TODO PLM: fix case list query caching such that queries are saved
+        // to current place in session
+        lastQueryString = "";
+        /*
         SharedPreferences settings = getSharedPreferences(CommCarePreferences.ACTIONBAR_PREFS, 0);
         lastQueryString = settings.getString(key, null);
         if (BuildConfig.DEBUG) {
             Log.v(TAG, "Recovered lastQueryString: (" + lastQueryString + ")");
         }
+        */
     }
 
     @Override
@@ -497,6 +501,10 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     }
 
     protected void saveLastQueryString(String key) {
+        // XXX PLM: disabling this for 2.24.1, fix soon! (Nov 6th 2015)
+        // TODO PLM: fix case list query caching such that queries are saved
+        // to current place in session
+        /*
         SharedPreferences settings = getSharedPreferences(CommCarePreferences.ACTIONBAR_PREFS, 0);
         SharedPreferences.Editor editor = settings.edit();
         editor.putString(key, lastQueryString);
@@ -505,6 +513,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         if (BuildConfig.DEBUG) {
             Log.v(TAG, "Saving lastQueryString: (" + lastQueryString + ") in file: " + CommCarePreferences.ACTIONBAR_PREFS);
         }
+        */
     }
 
     //Graphical stuff below, needs to get modularized


### PR DESCRIPTION
temporarily disabling case list search caching for 2.24.1 until we can come up with a robust solution.

http://manage.dimagi.com/default.asp?183986