### PR TITLE
Modify fragements after they have resumed

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -26,8 +26,8 @@ import org.commcare.android.framework.ManagedUi;
 import org.commcare.android.logic.GlobalConstants;
 import org.commcare.android.models.notifications.NotificationMessage;
 import org.commcare.android.models.notifications.NotificationMessageFactory;
-import org.commcare.android.resource.installers.SingleAppInstallation;
 import org.commcare.android.resource.AppInstallStatus;
+import org.commcare.android.resource.installers.SingleAppInstallation;
 import org.commcare.android.tasks.ResourceEngineListener;
 import org.commcare.android.tasks.ResourceEngineTask;
 import org.commcare.android.tasks.RetrieveParseVerifyMessageListener;
@@ -209,8 +209,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     protected void onResume() {
         super.onResume();
 
-        uiStateScreenTransition();
-
         // If clicking the regular app icon brought us to CommCareSetupActivity
         // (because that's where we were last time the app was up), but there are now
         // 1 or more available apps, we want to redirect to CCHomeActivity
@@ -223,6 +221,13 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         if (isSingleAppBuild()) {
             SingleAppInstallation.installSingleApp(this, DIALOG_INSTALL_PROGRESS);
         }
+    }
+
+    @Override
+    protected void onResumeFragments() {
+        super.onResumeFragments();
+
+        uiStateScreenTransition();
     }
 
     @Override


### PR DESCRIPTION
Attempt to fix the following error, which I thought was handled in https://github.com/dimagi/commcare-odk/pull/740

```
java.lang.RuntimeException: Unable to resume activity {org.commcare.dalvik/org.commcare.dalvik.activities.CommCareSetupActivity}: java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState : at org.commcare.dalvik.activities.CommCareSetupActivity.uiStateScreenTransition(CommCareSetupActivity.java:273)
```
https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/4e3e4f36dedf8bc5a84ae6d47e2a0eac