### PR TITLE
Restore last case list query

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -4,7 +4,6 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Bundle;
@@ -36,7 +35,6 @@ import org.commcare.android.util.MarkupUtil;
 import org.commcare.android.util.MediaUtil;
 import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.StringUtils;
-import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.AlertDialogFactory;
@@ -136,14 +134,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
 
         mGestureDetector = new GestureDetector(this, this);
-    }
-
-    protected void restoreLastQueryString(String key) {
-        SharedPreferences settings = getSharedPreferences(CommCarePreferences.ACTIONBAR_PREFS, 0);
-        lastQueryString = settings.getString(key, null);
-        if (BuildConfig.DEBUG) {
-            Log.v(TAG, "Recovered lastQueryString: (" + lastQueryString + ")");
-        }
     }
 
     @Override
@@ -421,15 +411,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         stateHolder.cancelTask();
     }
 
-    protected void saveLastQueryString(String key) {
-        SharedPreferences settings = getSharedPreferences(CommCarePreferences.ACTIONBAR_PREFS, 0);
-        SharedPreferences.Editor editor = settings.edit();
-        editor.putString(key, lastQueryString);
-        editor.commit();
+    protected void restoreLastQueryString() {
+        lastQueryString = CommCareApplication._().getCurrentSession().getCurrentFrameStepExtra(KEY_LAST_QUERY_STRING);
+    }
 
-        if (BuildConfig.DEBUG) {
-            Log.v(TAG, "Saving lastQueryString: (" + lastQueryString + ") in file: " + CommCarePreferences.ACTIONBAR_PREFS);
-        }
+    protected void saveLastQueryString() {
+        CommCareApplication._().getCurrentSession().addExtraToCurrentFrameStep(KEY_LAST_QUERY_STRING, lastQueryString);
     }
 
     //Graphical stuff below, needs to get modularized

--- a/app/src/org/commcare/android/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/android/models/AndroidSessionWrapper.java
@@ -48,13 +48,11 @@ public class AndroidSessionWrapper {
     private static final String TAG = AndroidSessionWrapper.class.getSimpleName();
     //The state descriptor will need these 
     protected CommCareSession session;
-    private CommCarePlatform platform;
     protected int formRecordId = -1;
     protected int sessionStateRecordId = -1;
 
     public AndroidSessionWrapper(CommCarePlatform platform) {
         session = new CommCareSession(platform);
-        this.platform = platform;
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -49,7 +49,6 @@ import org.commcare.android.models.Entity;
 import org.commcare.android.models.NodeEntityFactory;
 import org.commcare.android.tasks.EntityLoaderListener;
 import org.commcare.android.tasks.EntityLoaderTask;
-import org.commcare.android.util.AndroidUtil;
 import org.commcare.android.util.AndroidInstanceInitializer;
 import org.commcare.android.util.DetailCalloutListener;
 import org.commcare.android.util.SerializationUtil;
@@ -281,7 +280,8 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity
         }
         //cts: disabling for non-demo purposes
         //tts = new TextToSpeech(this, this);
-        restoreLastQueryString(TAG + "-" + KEY_LAST_QUERY_STRING);
+
+        restoreLastQueryString();
 
         if (!isUsingActionBar()) {
             searchbox.setText(lastQueryString);
@@ -488,7 +488,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity
     protected void onStop() {
         super.onStop();
         stopTimer();
-        saveLastQueryString(TAG + "-" + KEY_LAST_QUERY_STRING);
+        saveLastQueryString();
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -223,7 +223,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         this.registerForContextMenu(listView);
         refreshView();
 
-        restoreLastQueryString(TAG + "-" + KEY_LAST_QUERY_STRING);
+        restoreLastQueryString();
 
         if (!isUsingActionBar()) {
             if (BuildConfig.DEBUG) {
@@ -271,7 +271,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     protected void onStop() {
         super.onStop();
 
-        saveLastQueryString(TAG + "-" + KEY_LAST_QUERY_STRING);
+        saveLastQueryString();
     }
 
     public void onBarcodeFetch(int resultCode, Intent intent) {


### PR DESCRIPTION
Store the last query for a case list in the current sessions top frame. Hence, if you continue forward in a session, when you back out to the same case list, the query is restored from the session's stack. If you back out past the case list selection view and then forward into it again, the query won't be restored; implementing the desired behavior. 

fixes: http://manage.dimagi.com/default.asp?183986
cross request: https://github.com/dimagi/commcare/pull/191