### PR TITLE
Clear session on app swipe close

### DIFF
--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -906,6 +906,7 @@ public class CommCareApplication extends Application {
         // class name because we want a specific service implementation that
         // we know will be running in our own process (and thus won't be
         // supporting component replacement by other applications).
+        startService(new Intent(this, CommCareSessionService.class));
         bindService(new Intent(this, CommCareSessionService.class), mConnection, Context.BIND_AUTO_CREATE);
         mIsBinding = true;
     }
@@ -1050,6 +1051,7 @@ public class CommCareApplication extends Application {
                 mIsBound = false;
                 // Detach our existing connection.
                 unbindService(mConnection);
+                stopService(new Intent(this, CommCareSessionService.class));
             }
         }
     }

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -44,7 +44,6 @@ import org.commcare.android.database.global.DatabaseGlobalOpenHelper;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.database.user.CommCareUserOpenHelper;
 import org.commcare.android.database.user.models.FormRecord;
-import org.javarosa.core.model.User;
 import org.commcare.android.db.legacy.LegacyInstallUtils;
 import org.commcare.android.framework.SessionActivityRegistration;
 import org.commcare.android.javarosa.AndroidLogEntry;
@@ -85,6 +84,7 @@ import org.commcare.dalvik.services.CommCareSessionService;
 import org.commcare.session.CommCareSession;
 import org.commcare.suite.model.Profile;
 import org.commcare.util.externalizable.AndroidClassHasher;
+import org.javarosa.core.model.User;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.core.services.Logger;
@@ -113,29 +113,28 @@ import javax.crypto.SecretKey;
  */
 @ReportsCrashes(
         formUri = "https://your/cloudant/report",
-        formUriBasicAuthLogin="your_username",
-        formUriBasicAuthPassword="your_password",
+        formUriBasicAuthLogin = "your_username",
+        formUriBasicAuthPassword = "your_password",
         reportType = org.acra.sender.HttpSender.Type.JSON,
         httpMethod = org.acra.sender.HttpSender.Method.PUT)
 public class CommCareApplication extends Application {
     private static final String TAG = CommCareApplication.class.getSimpleName();
 
-    public static final int STATE_UNINSTALLED = 0;
+    private static final int STATE_UNINSTALLED = 0;
     public static final int STATE_UPGRADE = 1;
-    public static final int STATE_READY = 2;
+    private static final int STATE_READY = 2;
     public static final int STATE_CORRUPTED = 4;
     public static final int STATE_DELETE_REQUESTED = 8;
     public static final int STATE_MIGRATION_FAILED = 16;
     public static final int STATE_MIGRATION_QUESTIONABLE = 32;
 
-    public static final String ACTION_PURGE_NOTIFICATIONS = "CommCareApplication_purge";
+    private static final String ACTION_PURGE_NOTIFICATIONS = "CommCareApplication_purge";
 
     private int dbState;
 
     private static CommCareApplication app;
 
     private CommCareApp currentApp;
-    private CommCareApp appBeingInstalled;
 
     // stores current state of application: the session, form
     private AndroidSessionWrapper sessionWrapper;
@@ -210,7 +209,7 @@ public class CommCareApplication extends Application {
         //we aren't going to dump our logs from the Pre-init logger until after this transition occurs.
         try {
             LegacyInstallUtils.checkForLegacyInstall(this, this.getGlobalStorage(ApplicationRecord.class));
-        } catch(SessionUnavailableException sfe) {
+        } catch (SessionUnavailableException sfe) {
             throw new RuntimeException(sfe);
         } finally {
             //No matter what happens, set up our new logger, we want those logs!
@@ -250,10 +249,10 @@ public class CommCareApplication extends Application {
     }
 
     public void startUserSession(byte[] symetricKey, UserKeyRecord record) {
-        synchronized(serviceLock) {
+        synchronized (serviceLock) {
             // if we already have a connection established to
             // CommCareSessionService, close it and open a new one
-            if(this.mIsBound) {
+            if (this.mIsBound) {
                 releaseUserResourcesAndServices();
             }
             bindUserSessionService(symetricKey, record);
@@ -265,7 +264,7 @@ public class CommCareApplication extends Application {
      * manual user log-outs.
      */
     public void closeUserSession() {
-        synchronized(serviceLock) {
+        synchronized (serviceLock) {
             // Cancel any running tasks before closing down the user databse.
             ManagedAsyncTask.cancelTasks();
 
@@ -279,7 +278,7 @@ public class CommCareApplication extends Application {
      * for session-expiration related user logouts.
      */
     public void expireUserSession() {
-        synchronized(serviceLock) {
+        synchronized (serviceLock) {
             closeUserSession();
 
             SessionActivityRegistration.registerSessionExpiration();
@@ -303,7 +302,7 @@ public class CommCareApplication extends Application {
     }
 
     private void attachCallListener() {
-        TelephonyManager tManager = (TelephonyManager) this.getSystemService(TELEPHONY_SERVICE);
+        TelephonyManager tManager = (TelephonyManager)this.getSystemService(TELEPHONY_SERVICE);
 
         listener = new CallInPhoneListener(this, this.getCommCarePlatform());
         listener.startCache();
@@ -357,7 +356,7 @@ public class CommCareApplication extends Application {
     }
 
     public String getPhoneId() {
-        TelephonyManager manager = (TelephonyManager) this.getSystemService(TELEPHONY_SERVICE);
+        TelephonyManager manager = (TelephonyManager)this.getSystemService(TELEPHONY_SERVICE);
         String imei = manager.getDeviceId();
         if (imei == null) {
             imei = Secure.getString(getContentResolver(), Secure.ANDROID_ID);
@@ -402,8 +401,7 @@ public class CommCareApplication extends Application {
             if (record.getStatus() == ApplicationRecord.STATUS_DELETE_REQUESTED) {
                 try {
                     uninstall(record);
-                }
-                catch (RuntimeException e) {
+                } catch (RuntimeException e) {
                     Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Unable to uninstall an app " +
                             "during startup that was previously left partially-deleted");
                 }
@@ -505,7 +503,7 @@ public class CommCareApplication extends Application {
     }
 
     /**
-     * @return  all ApplicationRecords that are installed AND are not archived AND have MM verified
+     * @return all ApplicationRecords that are installed AND are not archived AND have MM verified
      */
     public ArrayList<ApplicationRecord> getUsableAppRecords() {
         ArrayList<ApplicationRecord> ready = new ArrayList<>();
@@ -673,7 +671,7 @@ public class CommCareApplication extends Application {
     }
 
     public <T extends Persistable> SqlStorage<T> getGlobalStorage(String table, Class<T> c) {
-        return new SqlStorage<T>(table, c, new AndroidDbHelper(this.getApplicationContext()) {
+        return new SqlStorage<>(table, c, new AndroidDbHelper(this.getApplicationContext()) {
             @Override
             public SQLiteDatabase getHandle() {
                 synchronized (globalDbHandleLock) {
@@ -699,7 +697,7 @@ public class CommCareApplication extends Application {
     }
 
     public <T extends Persistable> SqlStorage<T> getUserStorage(String storage, Class<T> c) {
-        return new SqlStorage<T>(storage, c, new AndroidDbHelper(this.getApplicationContext()) {
+        return new SqlStorage<>(storage, c, new AndroidDbHelper(this.getApplicationContext()) {
             @Override
             public SQLiteDatabase getHandle() throws SessionUnavailableException {
                 SQLiteDatabase database = getUserDbHandle();
@@ -712,7 +710,7 @@ public class CommCareApplication extends Application {
     }
 
     public <T extends Persistable> SqlStorage<T> getRawStorage(String storage, Class<T> c, final SQLiteDatabase handle) {
-        return new SqlStorage<T>(storage, c, new AndroidDbHelper(this.getApplicationContext()) {
+        return new SqlStorage<>(storage, c, new AndroidDbHelper(this.getApplicationContext()) {
             @Override
             public SQLiteDatabase getHandle() {
                 return handle;
@@ -756,7 +754,7 @@ public class CommCareApplication extends Application {
             return;
         }
 
-        final Set<String> dbIdsToRemove = new HashSet<String>();
+        final Set<String> dbIdsToRemove = new HashSet<>();
 
         this.getAppStorage(UserKeyRecord.class).removeAll(new EntityFilter<UserKeyRecord>() {
 
@@ -850,7 +848,7 @@ public class CommCareApplication extends Application {
                 synchronized (serviceLock) {
                     mCurrentServiceBindTimeout = MAX_BIND_TIMEOUT;
 
-                    mBoundService = ((CommCareSessionService.LocalBinder) service).getService();
+                    mBoundService = ((CommCareSessionService.LocalBinder)service).getService();
 
                     //Don't let anyone touch this until it's logged in
                     // Open user database
@@ -927,11 +925,11 @@ public class CommCareApplication extends Application {
             return;
         }
 
-        DataSubmissionListener dataListener = null;
+        DataSubmissionListener dataListener;
 
         try {
             dataListener =
-                CommCareApplication.this.getSession().startDataSubmissionListener(R.string.submission_logs_title);
+                    CommCareApplication.this.getSession().startDataSubmissionListener(R.string.submission_logs_title);
         } catch (SessionUnavailableException sue) {
             // abort since it looks like the session expired
             return;
@@ -971,7 +969,7 @@ public class CommCareApplication extends Application {
             updateTask.startPinnedNotification(this);
             updateTask.setAsAutoUpdate();
             updateTask.execute(ref);
-        } catch(IllegalStateException e) {
+        } catch (IllegalStateException e) {
             Log.w(TAG, "Trying trigger auto-update when it is already running. " +
                     "Should only happen if the user triggered a manual update before this fired.");
         }
@@ -1102,7 +1100,7 @@ public class CommCareApplication extends Application {
 
     private final int MESSAGE_NOTIFICATION = org.commcare.dalvik.R.string.notification_message_title;
 
-    private final ArrayList<NotificationMessage> pendingMessages = new ArrayList<NotificationMessage>();
+    private final ArrayList<NotificationMessage> pendingMessages = new ArrayList<>();
 
     public void reportNotificationMessage(NotificationMessage message) {
         reportNotificationMessage(message, false);
@@ -1132,7 +1130,7 @@ public class CommCareApplication extends Application {
     }
 
     public void updateMessageNotification() {
-        NotificationManager mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        NotificationManager mNM = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
         synchronized (pendingMessages) {
             if (pendingMessages.size() == 0) {
                 mNM.cancel(MESSAGE_NOTIFICATION);
@@ -1165,7 +1163,7 @@ public class CommCareApplication extends Application {
     public ArrayList<NotificationMessage> purgeNotifications() {
         synchronized (pendingMessages) {
             this.sendBroadcast(new Intent(ACTION_PURGE_NOTIFICATIONS));
-            ArrayList<NotificationMessage> cloned = (ArrayList<NotificationMessage>) pendingMessages.clone();
+            ArrayList<NotificationMessage> cloned = (ArrayList<NotificationMessage>)pendingMessages.clone();
             clearNotifications(null);
             return cloned;
         }
@@ -1173,8 +1171,8 @@ public class CommCareApplication extends Application {
 
     public void clearNotifications(String category) {
         synchronized (pendingMessages) {
-            NotificationManager mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-            Vector<NotificationMessage> toRemove = new Vector<NotificationMessage>();
+            NotificationManager mNM = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
+            Vector<NotificationMessage> toRemove = new Vector<>();
             for (NotificationMessage message : pendingMessages) {
                 if (category == null || category.equals(message.getCategory())) {
                     toRemove.add(message);
@@ -1296,7 +1294,7 @@ public class CommCareApplication extends Application {
          * @param activity Is the context used to pop-up the toast message.
          */
         public PopupHandler(CommCareApplication activity) {
-            mActivity = new WeakReference<CommCareApplication>(activity);
+            mActivity = new WeakReference<>(activity);
         }
 
         /**
@@ -1310,10 +1308,10 @@ public class CommCareApplication extends Application {
 
             CommCareApplication activity = mActivity.get();
 
-            if (activity != null) {
+            if (activity != null && message != null) {
                 Toast.makeText(activity,
                         Localization.get("notification.for.details.wrapper",
-                            new String[]{message.getTitle()}),
+                                new String[]{message.getTitle()}),
                         Toast.LENGTH_LONG).show();
             }
         }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -49,9 +49,8 @@ import javax.crypto.spec.SecretKeySpec;
  * a CommCare login session
  *
  * @author ctsims
- *
  */
-public class CommCareSessionService extends Service  {
+public class CommCareSessionService extends Service {
 
     private NotificationManager mNM;
 
@@ -125,9 +124,9 @@ public class CommCareSessionService extends Service  {
         pool = new CipherPool() {
             @Override
             public Cipher generateNewCipher() {
-                synchronized(lock) {
+                synchronized (lock) {
                     try {
-                        synchronized(key) {
+                        synchronized (key) {
                             SecretKeySpec spec = new SecretKeySpec(key, "AES");
                             Cipher decrypter = Cipher.getInstance("AES");
                             decrypter.init(Cipher.DECRYPT_MODE, spec);
@@ -197,7 +196,7 @@ public class CommCareSessionService extends Service  {
                 .setContentIntent(contentIntent)
                 .build();
 
-        if(user != null) {
+        if (user != null) {
             //Send the notification.
             this.startForeground(NOTIFICATION, notification);
         }
@@ -227,7 +226,7 @@ public class CommCareSessionService extends Service  {
     //Start CommCare Specific Functionality
 
     public SQLiteDatabase getUserDbHandle() {
-        synchronized(lock){
+        synchronized (lock) {
             return userDatabase;
         }
     }
@@ -236,10 +235,10 @@ public class CommCareSessionService extends Service  {
      * (Re-)open user database
      */
     public void prepareStorage(byte[] symetricKey, UserKeyRecord record) {
-        synchronized(lock){
+        synchronized (lock) {
             this.key = symetricKey;
             pool.init();
-            if(userDatabase != null && userDatabase.isOpen()) {
+            if (userDatabase != null && userDatabase.isOpen()) {
                 userDatabase.close();
             }
             userDatabase = new CommCareUserOpenHelper(CommCareApplication._(), record.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(key));
@@ -253,8 +252,8 @@ public class CommCareSessionService extends Service  {
      * @param user attach this user to the session
      */
     public void startSession(User user) {
-        synchronized(lock){
-            if(user != null) {
+        synchronized (lock) {
+            if (user != null) {
                 Logger.log(AndroidLogger.TYPE_USER, "login|" + user.getUsername() + "|" + user.getUniqueId());
 
                 //Let anyone who is listening know!
@@ -305,7 +304,7 @@ public class CommCareSessionService extends Service  {
             }
         } else if (isActive() && logoutStartedAt == -1 &&
                 (currentTime > sessionExpireDate.getTime() ||
-                 (sessionExpireDate.getTime() - currentTime  > sessionLength))) {
+                        (sessionExpireDate.getTime() - currentTime > sessionLength))) {
             // If we haven't started closing the session and we're either past
             // the session expire time, or the session expires more than its
             // period in the future, we need to log the user out. The second
@@ -337,7 +336,7 @@ public class CommCareSessionService extends Service  {
         logoutStartedAt = new Date().getTime();
 
         // save form progress, if any
-        synchronized(lock) {
+        synchronized (lock) {
             if (formSaver != null) {
                 formSaver.formSaveCallback();
             } else {
@@ -351,7 +350,7 @@ public class CommCareSessionService extends Service  {
      * save any forms being editted when key expiration begins.
      *
      * @param callbackObj object with a method for saving the current form
-     * being edited
+     *                    being edited
      */
     public void registerFormSaveCallback(FormSaveCallback callbackObj) {
         this.formSaver = callbackObj;
@@ -362,7 +361,7 @@ public class CommCareSessionService extends Service  {
      * a form open that might need to be saved if the session expires.
      */
     public void unregisterFormSaveCallback() {
-        synchronized(lock) {
+        synchronized (lock) {
             this.formSaver = null;
         }
     }
@@ -371,7 +370,7 @@ public class CommCareSessionService extends Service  {
      * Closes the key pool and user database.
      */
     public void closeServiceResources() {
-        synchronized(lock){
+        synchronized (lock) {
             if (!isActive()) {
                 // Since both the FormSaveCallback callback and the maintenance
                 // timer might call this, only run if it hasn't been called
@@ -412,7 +411,7 @@ public class CommCareSessionService extends Service  {
      * database.
      */
     public boolean isActive() {
-        synchronized(lock){
+        synchronized (lock) {
             return (key != null);
         }
     }
@@ -422,7 +421,7 @@ public class CommCareSessionService extends Service  {
     }
 
     public User getLoggedInUser() throws SessionUnavailableException {
-        if(user == null) {
+        if (user == null) {
             throw new SessionUnavailableException();
         }
         return user;
@@ -464,7 +463,7 @@ public class CommCareSessionService extends Service  {
                 contentView.setImageViewResource(R.id.image, R.drawable.notification);
                 contentView.setTextViewText(R.id.submitTitle, getString(notificationId));
                 contentView.setTextViewText(R.id.progressText, text);
-                contentView.setTextViewText(R.id.submissionDetails,"0b transmitted");
+                contentView.setTextViewText(R.id.submissionDetails, "0b transmitted");
 
 
                 // Set the info for the views that show in the notification panel.
@@ -472,7 +471,7 @@ public class CommCareSessionService extends Service  {
 
                 submissionNotification.contentView = contentView;
 
-                if(user != null) {
+                if (user != null) {
                     //Send the notification.
                     mNM.notify(notificationId, submissionNotification);
                 }
@@ -492,28 +491,29 @@ public class CommCareSessionService extends Service  {
             public void notifyProgress(int itemNumber, long progress) {
                 int progressPercent = (int)Math.floor((progress * 1.0 / currentSize) * 100);
 
-                if(progressPercent - lastUpdate > 5) {
+                if (progressPercent - lastUpdate > 5) {
 
                     String progressDetails;
-                    if(progress < 1024) {
+                    if (progress < 1024) {
                         progressDetails = progress + "b transmitted";
                     } else if (progress < 1024 * 1024) {
-                        progressDetails =  String.format("%1$,.1f", (progress / 1024.0))+ "kb transmitted";
+                        progressDetails = String.format("%1$,.1f", (progress / 1024.0)) + "kb transmitted";
                     } else {
-                        progressDetails = String.format("%1$,.1f", (progress / (1024.0 * 1024.0)))+ "mb transmitted";
+                        progressDetails = String.format("%1$,.1f", (progress / (1024.0 * 1024.0))) + "mb transmitted";
                     }
 
                     int pending = ProcessAndSendTask.pending();
-                    if(pending > 1) {
-                        submissionNotification.contentView.setTextViewText(R.id.submissionsPending, pending -1 + " Pending");
+                    if (pending > 1) {
+                        submissionNotification.contentView.setTextViewText(R.id.submissionsPending, pending - 1 + " Pending");
                     }
 
-                    submissionNotification.contentView.setTextViewText(R.id.submissionDetails,progressDetails);
+                    submissionNotification.contentView.setTextViewText(R.id.submissionDetails, progressDetails);
                     submissionNotification.contentView.setProgressBar(R.id.submissionProgress, 100, progressPercent, false);
                     mNM.notify(notificationId, submissionNotification);
                     lastUpdate = progressPercent;
                 }
             }
+
             @Override
             public void endSubmissionProcess() {
                 mNM.cancel(notificationId);
@@ -528,7 +528,7 @@ public class CommCareSessionService extends Service  {
             }
 
             private String getTickerText(int total) {
-                return "CommCare submitting " + total +" forms";
+                return "CommCare submitting " + total + " forms";
             }
 
             // END - Submission Listening Hooks
@@ -540,7 +540,7 @@ public class CommCareSessionService extends Service  {
      * Read the login session duration from app preferences and set the session
      * length accordingly.
      */
-    private void setSessionLength(){
+    private void setSessionLength() {
         sessionLength = CommCarePreferences.getLoginDuration() * 1000;
     }
 }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -9,6 +9,7 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.DateFormat;
+import android.util.Log;
 import android.widget.RemoteViews;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -21,6 +22,7 @@ import org.commcare.android.database.user.UserSandboxUtils;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.tasks.DataSubmissionListener;
 import org.commcare.android.tasks.ProcessAndSendTask;
+import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.activities.CommCareHomeActivity;
@@ -118,6 +120,16 @@ public class CommCareSessionService extends Service {
         mNM = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
         setSessionLength();
         createCipherPool();
+    }
+
+    @Override
+    public void onTaskRemoved(Intent rootIntent) {
+        try {
+            CommCareApplication._().getCurrentSessionWrapper().reset();
+        } catch (SessionStateUninitException e) {
+            Log.e(AndroidLogger.SOFT_ASSERT,
+                    "Trying to wipe uninitialized session in session service tear-down");
+        }
     }
 
     public void createCipherPool() {

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -86,9 +86,9 @@ public class CommCareSessionService extends Service  {
     private SQLiteDatabase userDatabase;
 
     // unique id for logged in notification
-    private final int NOTIFICATION = org.commcare.dalvik.R.string.notificationtitle;
+    private final static int NOTIFICATION = org.commcare.dalvik.R.string.notificationtitle;
 
-    private final int SUBMISSION_NOTIFICATION = org.commcare.dalvik.R.string.submission_notification_title;
+    private final static int SUBMISSION_NOTIFICATION = org.commcare.dalvik.R.string.submission_notification_title;
 
     // How long to wait until we force the session to finish logging out. Set
     // at 90 seconds to make sure huge forms on slow phones actually get saved
@@ -388,12 +388,7 @@ public class CommCareSessionService extends Service  {
 
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, msg);
 
-            if (user != null) {
-                if (user.getUsername() != null) {
-                    msg = "Logging out user " + user.getUsername();
-                }
-                user = null;
-            }
+            user = null;
 
             if (userDatabase != null) {
                 if (userDatabase.isOpen()) {


### PR DESCRIPTION
If you swipe close the android app and then re-open it the current commcare session is still around (used to show up in oldui breadcrumb bar, on new ui you have to inspect the object using the debugger). The user isn't restored to that session's current state, but rather taken to the home screen.

This PR catches the swipe close action via `onTaskRemoved` and resets the session. 

Fixes http://manage.dimagi.com/default.asp?168706
Contains commits from https://github.com/dimagi/commcare-odk/pull/796