### PR TITLE
Ensure AndroidInstanceInitializer uses the android version of data instance classes

### DIFF
--- a/app/src/org/commcare/android/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/android/cases/AndroidCaseInstanceTreeElement.java
@@ -3,7 +3,6 @@ package org.commcare.android.cases;
 import android.util.Log;
 
 import org.commcare.android.database.SqlStorage;
-import org.commcare.android.database.SqlStorageIterator;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.android.database.user.models.CaseIndexTable;
 import org.commcare.cases.instance.CaseChildElement;
@@ -24,7 +23,6 @@ import java.util.Vector;
  */
 public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement implements CacheHost {
     private static final String TAG = AndroidCaseInstanceTreeElement.class.getSimpleName();
-    SqlStorageIterator<ACase> iter;
     CaseIndexTable mCaseIndexTable;
 
     protected Hashtable<Integer, Integer> multiplicityIdMapping = new Hashtable<Integer, Integer>();
@@ -38,7 +36,7 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         mCaseIndexTable = caseIndexTable;
     }
 
-
+    @Override
     protected synchronized void getCases() {
         if (cases != null) {
             return;
@@ -153,7 +151,6 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         return ids;
     }
 
-
     public String getCacheIndex(TreeReference ref) {
         //NOTE: there's no evaluation here as to whether the ref is suitable
         //we only follow one pattern for now and it's evaluated below. 
@@ -172,7 +169,6 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         }
         return null;
     }
-
 
     @Override
     public boolean isReferencePatternCachable(TreeReference ref) {

--- a/app/src/org/commcare/android/util/AndroidInstanceInitializer.java
+++ b/app/src/org/commcare/android/util/AndroidInstanceInitializer.java
@@ -1,16 +1,17 @@
-/**
- * 
- */
 package org.commcare.android.util;
 
+import org.commcare.android.cases.AndroidCaseInstanceTreeElement;
 import org.commcare.android.database.AndroidSandbox;
+import org.commcare.android.database.SqlStorage;
+import org.commcare.android.database.user.models.ACase;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.session.CommCareSession;
+import org.javarosa.core.model.instance.AbstractTreeElement;
+import org.javarosa.core.model.instance.ExternalDataInstance;
 
 /**
  * @author ctsims
- *
  */
 public class AndroidInstanceInitializer extends CommCareInstanceInitializer {
 
@@ -19,12 +20,25 @@ public class AndroidInstanceInitializer extends CommCareInstanceInitializer {
     }
 
     @Override
-    public String getVersionString(){
+    protected AbstractTreeElement setupCaseData(ExternalDataInstance instance) {
+        if (casebase == null) {
+            SqlStorage<ACase> storage = (SqlStorage<ACase>)mSandbox.getCaseStorage();
+            casebase = new AndroidCaseInstanceTreeElement(instance.getBase(), storage, false);
+        } else {
+            //re-use the existing model if it exists.
+            casebase.rebase(instance.getBase());
+        }
+        instance.setCacheHost((AndroidCaseInstanceTreeElement)casebase);
+        return casebase;
+    }
+
+    @Override
+    public String getVersionString() {
         return CommCareApplication._().getCurrentVersionString();
     }
 
     @Override
-    public String getDeviceId(){
+    public String getDeviceId() {
         return CommCareApplication._().getPhoneId();
     }
 }


### PR DESCRIPTION
If this is the correct pattern for making the android instance initializer use android version of data instance classes, then I will implement it for ledgers, fixtures, and sessions.

fixes http://manage.dimagi.com/default.asp?186528
cross-requested with https://github.com/dimagi/commcare/pull/192

NOTE: we need to remove `org.commcare.android.util.CommCareInstanceInitializer` because it isn't used any more.