### PR TITLE
Reset update stats once update is stale

### DIFF
--- a/app/src/org/commcare/android/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/android/resource/AndroidResourceManager.java
@@ -33,13 +33,12 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException;
 public class AndroidResourceManager extends ResourceManager {
     private final static String TAG = AndroidResourceManager.class.getSimpleName();
     public final static String TEMP_UPGRADE_TABLE_KEY = "TEMP_UPGRADE_RESOURCE_TABLE";
-    private final UpdateStats updateStats;
-    private final CommCareApp app;
-    private String profileRef;
-    private final ResourceTable tempUpgradeTable;
-
     // 60 minutes
     private final static long MAX_UPDATE_RETRY_DELAY_IN_MS = 1000 * 60 * 60;
+    private final CommCareApp app;
+    private final UpdateStats updateStats;
+    private final ResourceTable tempUpgradeTable;
+    private String profileRef;
 
     public AndroidResourceManager(AndroidCommCarePlatform platform) {
         super(platform, platform.getGlobalResourceTable(),
@@ -118,6 +117,7 @@ public class AndroidResourceManager extends ResourceManager {
             Log.i(TAG, "Clearing upgrade table because resource downloads " +
                     "failed too many times or started too long ago");
             upgradeTable.destroy();
+            updateStats.resetStats(app);
         }
 
         Resource upgradeProfile =

--- a/app/src/org/commcare/android/resource/analytics/UpdateStats.java
+++ b/app/src/org/commcare/android/resource/analytics/UpdateStats.java
@@ -26,14 +26,14 @@ import java.util.Hashtable;
  */
 public class UpdateStats implements InstallStatsLogger, Serializable {
     private static final String TAG = UpdateStats.class.getSimpleName();
-    private final Hashtable<String, InstallAttempts<String>> resourceInstallStats;
-    private final long startInstallTime;
-    private int restartCount = 0;
-    private final static String TOP_LEVEL_STATS_KEY = "top-level-update-exceptions";
+    private static final String TOP_LEVEL_STATS_KEY = "top-level-update-exceptions";
     private static final String UPGRADE_STATS_KEY = "upgrade_table_stats";
-
     private static final long TWO_WEEKS_IN_MS = 1000 * 60 * 60 * 24 * 24;
     private static final int ATTEMPTS_UNTIL_UPDATE_STALE = 5;
+
+    private final Hashtable<String, InstallAttempts<String>> resourceInstallStats;
+    private long startInstallTime;
+    private int restartCount = 0;
 
     private UpdateStats() {
         startInstallTime = new Date().getTime();
@@ -73,6 +73,13 @@ public class UpdateStats implements InstallStatsLogger, Serializable {
         Object o = ois.readObject();
         ois.close();
         return o;
+    }
+
+    public void resetStats(CommCareApp app) {
+        clearPersistedStats(app);
+        startInstallTime = new Date().getTime();
+        resourceInstallStats.clear();
+        restartCount = 0;
     }
 
     /**


### PR DESCRIPTION
When updates fail a certain number of times they are considered stale and the update table is cleared. When this happens, we should also clear the update stats so that the table doesn't continue to be considered stale. 