### PR TITLE
Remove soft asserts when home screen buttons are null

### DIFF
--- a/app/src/org/commcare/dalvik/activities/HomeActivityUIController.java
+++ b/app/src/org/commcare/dalvik/activities/HomeActivityUIController.java
@@ -139,10 +139,7 @@ public class HomeActivityUIController {
         startButton = adapter.getButton(R.layout.home_start_button);
         if (startButton != null) {
             startButton.setText(Localization.get("home.start"));
-        } else {
-            Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "startButton was null in setupStartButton()");
-        }
+        } 
         adapter.setOnClickListenerForButton(R.layout.home_start_button, getStartButtonListener());
     }
 
@@ -150,10 +147,7 @@ public class HomeActivityUIController {
         viewIncompleteFormsButton = adapter.getButton(R.layout.home_incompleteforms_button);
         if (viewIncompleteFormsButton != null) {
             setIncompleteFormsText();
-        } else {
-            Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "incompleteFormsButton was null in setupIncompleteFormsButton()");
-        }
+        } 
         adapter.setOnClickListenerForButton(R.layout.home_incompleteforms_button, getIncompleteButtonListener());
     }
 
@@ -163,10 +157,7 @@ public class HomeActivityUIController {
             logoutButton.setText(Localization.get("home.logout"));
             logoutButton.setNotificationText(activity.getActivityTitle());
             adapter.notifyDataSetChanged();
-        } else {
-            Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "logoutButton was null in setupLogoutButton()");
-        }
+        } 
         adapter.setOnClickListenerForButton(R.layout.home_disconnect_button, getLogoutButtonListener());
     }
 
@@ -182,10 +173,7 @@ public class HomeActivityUIController {
         syncButton = adapter.getButton(R.layout.home_sync_button);
         if (syncButton != null) {
             setSyncButtonText(null);
-        } else {
-            Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "syncButton was null in setupSyncButton()");
-        }
+        } 
         adapter.setOnClickListenerForButton(R.layout.home_sync_button, getSyncButtonListener());
     }
 
@@ -290,17 +278,11 @@ public class HomeActivityUIController {
     private void refreshHomeAndLogoutButtons() {
         if (startButton != null) {
             startButton.setText(Localization.get(homeMessageKey));
-        } else {
-            Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "startButton was null in refreshHomeAndLogoutButtons()");
-        }
+        } 
         if (logoutButton != null) {
             logoutButton.setText(Localization.get(logoutMessageKey));
             logoutButton.setNotificationText(activity.getActivityTitle());
-        } else {
-            Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "logoutButton was null in refreshHomeAndLogoutButtons()");
-        }
+        } 
     }
 
     /**
@@ -322,10 +304,7 @@ public class HomeActivityUIController {
     private void refreshSyncButton() {
         if (syncButton != null) {
             setSyncButtonText(syncKey);
-        } else {
-            Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "syncButton was null in refreshSyncButton()");
-        }
+        } 
     }
 
     private void refreshSavedFormsButton() {


### PR DESCRIPTION
We should fix this at some point. Removing the soft assert logging because it is polluting the device logs