### PR TITLE
Fix crash when rotating form entry view w/ date/time pickers

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1712,11 +1712,11 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
                         })
                     .setTitle(StringUtils.getStringRobust(this, R.string.change_language))
                     .setNegativeButton(StringUtils.getStringSpannableRobust(this, R.string.do_not_change),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int whichButton) {
-                            }
-                        }).create();
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int whichButton) {
+                                }
+                            }).create();
         dialog.show();
     }
 
@@ -1768,32 +1768,41 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
         }
 
         registerFormEntryReceiver();
-
-        //csims@dimagi.com - 22/08/2012 - For release only, fix immediately.
-        //There is a _horribly obnoxious_ bug in TimePickers that messes up how they work
-        //on screen rotation. We need to re-do any setAnswers that we perform on them after
-        //onResume.
-        try {
-            if(mCurrentView instanceof ODKView) {
-                ODKView ov = ((ODKView) mCurrentView);
-                if(ov.getWidgets() != null) {
-                    for(QuestionWidget qw : ov.getWidgets()) {
-                        if(qw instanceof DateTimeWidget) {
-                            ((DateTimeWidget)qw).setAnswer();
-                        } else if(qw instanceof TimeWidget) {
-                            ((TimeWidget)qw).setAnswer();
-                        }
-                    }
-                }
-            }
-        } catch(Exception e) {
-            //if this fails, we _really_ don't want to mess anything up. this is a last minute
-            //fix
-        }
+        restoreTimePickerData();
 
         if (mFormController != null) {
             // clear pending callout post onActivityResult processing
             mFormController.setPendingCalloutFormIndex(null);
+        }
+    }
+
+    private void restoreTimePickerData() {
+        // On honeycomb and above this is handled by calling:
+        //   TimePicker.setSaveFromParentEnabled(false);
+        //   TimePicker.setSaveEnabled(true);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            //csims@dimagi.com - 22/08/2012 - For release only, fix immediately.
+            //There is a _horribly obnoxious_ bug in TimePickers that messes up how they work
+            //on screen rotation. We need to re-do any setAnswers that we perform on them after
+            //onResume.
+            try {
+                if (mCurrentView instanceof ODKView) {
+                    ODKView ov = ((ODKView)mCurrentView);
+                    if (ov.getWidgets() != null) {
+                        for (QuestionWidget qw : ov.getWidgets()) {
+                            if (qw instanceof DateTimeWidget) {
+                                ((DateTimeWidget)qw).setAnswer();
+                            } else if (qw instanceof TimeWidget) {
+                                ((TimeWidget)qw).setAnswer();
+                            }
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                //if this fails, we _really_ don't want to mess anything up. this is a last minute
+                //fix
+            }
         }
     }
 

--- a/app/src/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/app/src/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.os.Build;
 import android.view.Gravity;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.DatePicker;
@@ -56,6 +57,10 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         mTimePicker.setEnabled(!prompt.isReadOnly());
         mTimePicker.setPadding(0, 20, 0, 0);
         mTimePicker.setOnTimeChangedListener(this);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            mTimePicker.setSaveFromParentEnabled(false);
+            mTimePicker.setSaveEnabled(true);
+        }
 
         String clockType =
             android.provider.Settings.System.getString(context.getContentResolver(),

--- a/app/src/org/odk/collect/android/widgets/TimeWidget.java
+++ b/app/src/org/odk/collect/android/widgets/TimeWidget.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.inputmethod.InputMethodManager;
@@ -31,9 +32,13 @@ public class TimeWidget extends QuestionWidget implements OnTimeChangedListener 
         mTimePicker = new TimePicker(getContext());
         mTimePicker.setFocusable(!prompt.isReadOnly());
         mTimePicker.setEnabled(!prompt.isReadOnly());
-
         mTimePicker.setOnTimeChangedListener(this);
-        
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            mTimePicker.setSaveFromParentEnabled(false);
+            mTimePicker.setSaveEnabled(true);
+        }
+
         String clockType =
             android.provider.Settings.System.getString(context.getContentResolver(),
                 android.provider.Settings.System.TIME_12_24);


### PR DESCRIPTION
If you rotate the a device while in a form that has TimePicker or DateTimePicker widgets then it crashes with `java.lang.IndexOutOfBoundsException: setSpan (2 ... 2) ends beyond length 0`

I was only able to trigger this crash on the [registration form of the mLabour app](https://www.commcarehq.org/a/mlabour/apps/view/6bbf69cec278cff14d152ae8d1a30fe8/modules-1/forms-0/). I tried to rotate on other forms that had TimePickers without success. 

This fix probably only works for devices running Android 3 and up, but that is okay with me, since it seems hard to encounter.

https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/1c3ed844920b9be36e634e2a31ec3933