### PR TITLE
Save form as complete if auto-advance question reaches End-of-form

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1032,9 +1032,8 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
                         }
                         break group_skip;
                     case FormEntryController.EVENT_END_OF_FORM:
-                        Logger.log(AndroidLogger.SOFT_ASSERT,
-                                "Trying to show an end of form event");
-                        saveFormToDisk(EXIT, null, false);
+                        // auto-advance questions might advance past the last form quesion
+                        triggerUserFormComplete();
                         break group_skip;
                     case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
                         createRepeatDialog();


### PR DESCRIPTION
Auto-advance questions at the end of form were resulting in the form being saved as incomplete. Instead auto-advancing past the end of form should be the same as pressing the 'next arrow' button 

Should consider hotfixing this.

http://manage.dimagi.com/default.asp?186847