### PR TITLE
Better logging and error message for form save failure

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -176,7 +176,7 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="clear_answer_no" cc:translatable="true">CANCEL</string>
     <string name="completed_data" cc:translatable="true">Complete (%s)</string>
     <string name="data" cc:translatable="true">Saved Forms</string>
-    <string name="data_saved_error" cc:translatable="true">Sorry, form save failed!</string>
+    <string name="data_saved_error" cc:translatable="true">Sorry, form save failed. Please contact technical support to look into the issue.</string>
     <string name="data_saved_ok" cc:translatable="true">Form successfully saved!</string>
     <string name="delete_confirm" cc:translatable="true">Delete %s form(s)?</string>
     <string name="delete_file" cc:translatable="true">Delete Selected</string>

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -253,7 +253,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
             try {
                 updateInstanceDatabase(false, canEditAfterCompleted);
             } catch (SQLException e) {
-                Log.e(TAG, "Error creating database entries for form.");
+                Log.e(TAG, "Error creating database entries for form: " + e);
                 e.printStackTrace();
                 return false;
             }

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -16,6 +16,7 @@ import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.model.xform.XFormSerializingVisitor;
@@ -253,7 +254,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
             try {
                 updateInstanceDatabase(false, canEditAfterCompleted);
             } catch (SQLException e) {
-                Log.e(TAG, "Error creating database entries for form: " + e);
+                Logger.exception("Error creating database entries for form", e);
                 e.printStackTrace();
                 return false;
             }


### PR DESCRIPTION
See http://manage.dimagi.com/default.asp?186674

We should be logging this error anyways since we had no visibility. Unclear if we gain anything from percolating the error to the user level but I think not. 

@phillipm I saw you suggested one of your changes might've impacted this behavior (IE failing on form save instead of later) - this seems better to me (IE better than sending to HQ and failing there) 