### PR TITLE
Fix annotations

### DIFF
--- a/app/assets/graphing/graph.css
+++ b/app/assets/graphing/graph.css
@@ -2,6 +2,10 @@ path {
     stroke-linecap: round;
 }
 
+text {
+    fill: #000 !important;
+}
+
 /* Thicken graph lines */
 .c3-lines path {
     stroke-width: 3;
@@ -16,13 +20,7 @@ path {
     opacity: 1 !important;
 }
 
-/* Annotations text color */
-g.c3-texts-annotationsY text {
-    fill: #000 !important;
-}
-
-/* Hide system-genereated series */
-g.c3-chart-line.c3-target.c3-target-annotationsY,
+/* Hide system-generated series */
 g.c3-chart-line.c3-target.c3-target-boundsY,
 g.c3-chart-line.c3-target.c3-target-boundsY2 {
     display: none;

--- a/app/assets/graphing/graph.js
+++ b/app/assets/graphing/graph.js
@@ -45,8 +45,14 @@ document.addEventListener("DOMContentLoaded", function(event) {
         };
     }
 
-    // Hide any system-generated series
-
+    // Hide any system-generated series from legend
+    var systemSeries = ['boundsY', 'boundsY2'];
+    for (var yID in config.data.xs) {
+        if (!pointStyles[yID]) {
+            systemSeries.push(yID);
+        }
+    }
+    config.legend.hide = systemSeries;
 
     // Configure data labels, which we use only to display annotations
     config.data.labels = {

--- a/app/assets/graphing/graph.js
+++ b/app/assets/graphing/graph.js
@@ -44,20 +44,20 @@ document.addEventListener("DOMContentLoaded", function(event) {
         };
     }
 
+    // Hide any system-generated series
+
+
     // Configure data labels, which we use only to display annotations
     config.data.labels = {
         format: function(value, id, index) {
-            if (id === 'annotationsY') {
-                return annotations[index];
-            }
-            return '';
+            return annotations[id] || '';
         },
     };
 
     // Post-processing
     config.onrendered = function() {
         // For annotations series, nudge text so it appears on top of data point
-        d3.selectAll("g.c3-texts-annotationsY text").attr("dy", 10);
+        d3.selectAll("g.c3-texts text").attr("dy", 10);
 
         // TODO: support point-style: s.getConfiguration("point-style", "circle").toLowerCase()
     };

--- a/app/src/org/commcare/android/view/c3/DataConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/DataConfiguration.java
@@ -101,29 +101,35 @@ public class DataConfiguration extends Configuration {
      * Add annotations, by creating a fake series with data labels turned on.
      */
     private void addAnnotations() throws JSONException, InvalidStateException {
-        String xID = "annotationsX";
-        String yID = "annotationsY";
+        JSONObject text = new JSONObject();
 
-        mXs.put(yID, xID);
-        mTypes.put(yID, "line");
-        mAxes.put(yID, "y");
-
-        JSONArray xValues = new JSONArray();
-        xValues.put(xID);
-        JSONArray yValues = new JSONArray();
-        yValues.put(yID);
-        JSONArray text = new JSONArray();
-
-        // TODO: This is broken. Need to add one series per text, because C3 re-orders the data.
+        int index = 0;
         for (AnnotationData a : mData.getAnnotations()) {
-            String description = "annotation '" + text + "' at (" + a.getX() + ", " + a.getY() + ")";
+            String xID = "annotationsX" + index;
+            String yID = "annotationsY" + index;
+            String description = "annotation '" + a.getAnnotation() + "' at (" + a.getX() + ", " + a.getY() + ")";
+            text.put(yID, a.getAnnotation());
+
+            // Add x value
+            JSONArray xValues = new JSONArray();
+            xValues.put(xID);
             xValues.put(parseXValue(a.getX(), description));
+            mColumns.put(xValues);
+
+            // Add y value
+            JSONArray yValues = new JSONArray();
+            yValues.put(yID);
             yValues.put(parseYValue(a.getY(), description));
-            text.put(a.getAnnotation());
+            mColumns.put(yValues);
+
+            // Configure series
+            mXs.put(yID, xID);
+            mTypes.put(yID, "line");
+            mAxes.put(yID, "y");
+
+            index++;
         }
 
-        mColumns.put(xValues);
-        mColumns.put(yValues);
         mVariables.put("annotations", text.toString());
     }
 

--- a/app/src/org/commcare/android/view/c3/LegendConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/LegendConfiguration.java
@@ -18,11 +18,5 @@ public class LegendConfiguration extends Configuration {
         if (!showLegend) {
             mConfiguration.put("show", false);
         }
-
-        // Keep system-generated series out of the legend
-        JSONArray systemIDs = new JSONArray();
-        systemIDs.put("boundsY");
-        systemIDs.put("boundsY2");
-        mConfiguration.put("hide", systemIDs);
     }
 }

--- a/app/src/org/commcare/android/view/c3/LegendConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/LegendConfiguration.java
@@ -21,7 +21,6 @@ public class LegendConfiguration extends Configuration {
 
         // Keep system-generated series out of the legend
         JSONArray systemIDs = new JSONArray();
-        systemIDs.put("annotationsY");
         systemIDs.put("boundsY");
         systemIDs.put("boundsY2");
         mConfiguration.put("hide", systemIDs);


### PR DESCRIPTION
C3 re-orders the data in the annotations series, so the `index` passed into `data.labels.format` isn't necessarily the same index that I'm expecting. Deal with this by creating a separate series for each annotation, rather than one series for all annotations.