### PR TITLE
Add missing $ in manifest

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -122,7 +122,7 @@
             android:authorities="${applicationId}.case"
             android:enabled="true"
             android:exported="true"
-            android:readPermission="{applicationId}.provider.cases.read" />
+            android:readPermission="${applicationId}.provider.cases.read" />
         <provider
             android:name=".provider.FixtureDataContentProvider"
             android:authorities="${applicationId}.fixture"


### PR DESCRIPTION
Fix variable expansion failure due to missing `$` in manifest file

`Permission Denial: reading org.commcare.dalvik.provider.CaseDataContentProvider uri content://org.commcare.dalvik.case/casedb/case from pid=24687, uid=10244 requires {applicationId}.provider.cases.read, or grantUriPermission(`