### PR TITLE
full screen graphs

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -264,6 +264,9 @@
             android:windowSoftInputMode="stateUnchanged|adjustResize" >
         </activity>
         <activity
+            android:name=".activities.GraphActivity">
+        </activity>
+        <activity
             android:name=".activities.EntityDetailActivity"
             android:windowSoftInputMode="adjustResize" >
         </activity>

--- a/app/assets/graphing/graph.css
+++ b/app/assets/graphing/graph.css
@@ -6,8 +6,23 @@ path {
     stroke-linecap: round;
 }
 
-text {
+text, #tooltip {
     fill: #000 !important;
+}
+
+/* Tooltip */
+#tooltip {
+    background-color: white;
+    border: 1px solid black;
+}
+
+#tooltip table td {
+    padding: 5px;
+}
+
+#tooltip table td:not(:first-child) {
+    text-align: right;
+    background-color: line;
 }
 
 /* Thicken graph lines */

--- a/app/src/org/commcare/android/view/EntityDetailView.java
+++ b/app/src/org/commcare/android/view/EntityDetailView.java
@@ -254,10 +254,12 @@ public class EntityDetailView extends FrameLayout {
             } else {
                 graphViewsCache.put(index, new Hashtable<Integer, View>());
             }
+            String graphHTML = "";
             if (graphView == null) {
-                GraphView g = new GraphView(context, labelText);
+                GraphView g = new GraphView(context, labelText, false);
                 try {
-                    graphView = g.getView((GraphData)field);
+                    graphHTML = g.getHTML((GraphData) field);
+                    graphView = g.getView(graphHTML);
                     graphLayout.setRatio((float)g.getRatio(), (float)1);
                 } catch (InvalidStateException ise) {
                     graphView = new TextView(context);
@@ -270,12 +272,14 @@ public class EntityDetailView extends FrameLayout {
             }
 
             // Fetch full-screen graph intent from cache, or create it
-            // TODO: implement full-screen view
-            /*Intent graphIntent = graphIntentsCache.get(index);
+            Intent graphIntent = graphIntentsCache.get(index);
             if (graphIntent == null && !graphsWithErrors.contains(index)) {
-                GraphView g = new GraphView(context, labelText);
+                GraphView g = new GraphView(context, labelText, true);
                 try {
-                    graphIntent = g.getIntent((GraphData)field);
+                    if (graphHTML.equals("")) {
+                        graphHTML = g.getHTML((GraphData) field);
+                    }
+                    graphIntent = g.getIntent(graphHTML);
                     graphIntentsCache.put(index, graphIntent);
                 } catch (InvalidStateException ise) {
                     // This shouldn't happen, since any error should have been caught during getView above
@@ -304,7 +308,7 @@ public class EntityDetailView extends FrameLayout {
                         return detector.onTouchEvent(event);
                     }
                 });
-            }*/
+            }
 
             graphLayout.removeAllViews();
             graphLayout.addView(graphView, GraphView.getLayoutParams());

--- a/app/src/org/commcare/android/view/EntityView.java
+++ b/app/src/org/commcare/android/view/EntityView.java
@@ -179,9 +179,8 @@ public class EntityView extends LinearLayout {
             } else if (FORM_IMAGE.equals(form)) {
                 setupImageLayout(view, (String) field);
             } else if (FORM_GRAPH.equals(form) && field instanceof GraphData) {
-                // TODO
                 int orientation = getResources().getConfiguration().orientation;
-                GraphView g = new GraphView(context, "");
+                GraphView g = new GraphView(context, "", false);
                 View rendered = null;
                 if (renderedGraphsCache.get(i) != null) {
                     rendered = renderedGraphsCache.get(i).get(orientation);
@@ -190,7 +189,7 @@ public class EntityView extends LinearLayout {
                 }
                 if (rendered == null) {
                     try {
-                        rendered = g.getView((GraphData) field);
+                        rendered = g.getView(g.getHTML((GraphData) field));
                     } catch (InvalidStateException ise) {
                         rendered = new TextView(context);
                         ((TextView) rendered).setText(ise.getMessage());

--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -126,12 +126,11 @@ public class GraphView {
 
         String titleHTML = "<div id='chart-title'>" + mTitle + "</div>";
         String chartHTML = "<div id='chart'></div>";
-        String spinnerHTML = "<div id='spinner'><img src='file:///android_asset/graphing/spinner.gif' /></div>";
         html +=
                 "</script>" +
                         "<script type='text/javascript' src='file:///android_asset/graphing/graph.js'></script>" +
                         "</head>" +
-                        "<body>" + titleHTML + spinnerHTML + chartHTML + "</body>" +
+                        "<body>" + titleHTML + chartHTML + "</body>" +
                         "</html>";
 
         return html;

--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -15,6 +15,7 @@ import org.commcare.android.view.c3.DataConfiguration;
 import org.commcare.android.view.c3.GridConfiguration;
 import org.commcare.android.view.c3.LegendConfiguration;
 import org.commcare.dalvik.BuildConfig;
+import org.commcare.dalvik.activities.GraphActivity;
 import org.commcare.suite.model.graph.Graph;
 import org.commcare.suite.model.graph.GraphData;
 import org.javarosa.core.util.OrderedHashtable;
@@ -28,19 +29,25 @@ import java.util.Enumeration;
  * @author jschweers
  */
 public class GraphView {
+    public static final String HTML = "html";
+    public static final String TITLE = "title";
+
     private final Context mContext;
     private final String mTitle;
+    private final boolean mIsFullScreen;
     private GraphData mData;
 
-    public GraphView(Context context, String title) {
+    public GraphView(Context context, String title, boolean isFullScreen) {
         mContext = context;
         mTitle = title;
+        mIsFullScreen = isFullScreen;
     }
 
-    // TODO
-    // display mTitle as title, not on graph itself
-    public Intent getIntent(GraphData data) throws InvalidStateException {
-        return null;
+    public Intent getIntent(String html) throws InvalidStateException {
+        Intent intent = new Intent(mContext, GraphActivity.class);
+        intent.putExtra(HTML, html);
+        intent.putExtra(TITLE, mTitle);
+        return intent;
     }
 
     /*
@@ -48,15 +55,34 @@ public class GraphView {
      * any changes to graph's configuration, title, etc.
      */
     @TargetApi(Build.VERSION_CODES.KITKAT)
-    public View getView(GraphData graphData) throws InvalidStateException {
-        mData = graphData;
-
+    public View getView(String html) throws InvalidStateException {
         if (BuildConfig.DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true);
         }
         WebView webView = new WebView(mContext);
-        configureSettings(webView);
 
+        WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+
+        webView.setClickable(true);
+        settings.setBuiltInZoomControls(mIsFullScreen);
+        settings.setSupportZoom(mIsFullScreen);
+        settings.setDisplayZoomControls(mIsFullScreen);
+
+        // Improve performance
+        settings.setCacheMode(WebSettings.LOAD_NO_CACHE);
+
+        webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "utf-8", null);
+        return webView;
+    }
+
+    /**
+     * Get the HTML that will comprise this graph.
+     * @param graphData The data to render.
+     * @return Full HTML page, including head, body, and all script and style tags
+     */
+    public String getHTML(GraphData graphData) throws InvalidStateException {
+        mData = graphData;
         OrderedHashtable<String, String> variables = new OrderedHashtable<>();
         JSONObject config = new JSONObject();
         try {
@@ -85,7 +111,7 @@ public class GraphView {
 
         String html =
                 "<html>" +
-                    "<head>" +
+                        "<head>" +
                         "<link rel='stylesheet' type='text/css' href='file:///android_asset/graphing/c3.min.css'></link>" +
                         "<link rel='stylesheet' type='text/css' href='file:///android_asset/graphing/graph.css'></link>" +
                         "<script type='text/javascript' src='file:///android_asset/graphing/d3.min.js'></script>" +
@@ -99,27 +125,16 @@ public class GraphView {
         }
 
         String titleHTML = "<div id='chart-title'>" + mTitle + "</div>";
+        String chartHTML = "<div id='chart'></div>";
+        String spinnerHTML = "<div id='spinner'><img src='file:///android_asset/graphing/spinner.gif' /></div>";
         html +=
-                        "</script>" +
+                "</script>" +
                         "<script type='text/javascript' src='file:///android_asset/graphing/graph.js'></script>" +
-                    "</head>" +
-                    "<body>" + titleHTML + "<div id='chart'></div></body>" +
-                "</html>";
-        webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "utf-8", null);
-        return webView;
-    }
+                        "</head>" +
+                        "<body>" + titleHTML + spinnerHTML + chartHTML + "</body>" +
+                        "</html>";
 
-    private void configureSettings(WebView view) {
-        WebSettings settings = view.getSettings();
-
-        settings.setJavaScriptEnabled(true);
-
-        // Improve performance
-        settings.setCacheMode(WebSettings.LOAD_NO_CACHE);
-
-        // Panning and zooming are allowed only in full-screen graphs (created by getIntent)
-        // TODO: Support if this is full-screen view
-        settings.setSupportZoom(false);
+        return html;
     }
 
     /**
@@ -147,10 +162,10 @@ public class GraphView {
      */
     public double getRatio() {
         // Most graphs are drawn with aspect ratio 2:1, which is mostly arbitrary
-        // and happened to look nice for partographs. Vertically-oriented graphs,
-        // however, get squished unless they're drawn as a square. Expect to revisit 
+        // and happened to look nice for partographs. Bar charts, however, are drawn square.
+        // This decision was made for legacy reasons that are no longer relevant, but there's
+        // also no particular reason to cange it right now. Expect to revisit
         // this eventually (make all graphs square? user-configured aspect ratio?).
-        // TODO: did migrating to C3 fix the squishing issue?
         if (Graph.TYPE_BAR.equals(mData.getType())) {
             return 1;
         }

--- a/app/src/org/commcare/android/view/c3/DataConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/DataConfiguration.java
@@ -34,6 +34,7 @@ public class DataConfiguration extends Configuration {
 
     // Hash of y-values id => name for legend
     private final JSONObject mNames = new JSONObject();
+    private final JSONObject mXNames = new JSONObject();
 
     // Hash of y-values id => 'y' or 'y2' depending on whether this data
     // should be plotted against the primary or secondary y axis
@@ -44,6 +45,9 @@ public class DataConfiguration extends Configuration {
 
     // Hash of y-values id => series color
     private final JSONObject mColors = new JSONObject();
+
+    // Array of series that should appear in legend & tooltip
+    private final JSONObject mIsData = new JSONObject();
 
     // Hash of y-values id => point-style string ("circle", "none", "cross", etc.)
     // Doubles as a record of all user-defined series
@@ -76,6 +80,7 @@ public class DataConfiguration extends Configuration {
             setColumns(xID, yID, s);
             setName(yID, s);
             setColor(yID, s);
+            setIsData(yID, s);
             setPointStyle(yID, s);
             setType(yID, s);
             setYAxis(yID, s);
@@ -87,6 +92,8 @@ public class DataConfiguration extends Configuration {
         mVariables.put("radii", mRadii.toString());
         mVariables.put("maxRadii", mMaxRadii.toString());
         mVariables.put("pointStyles", mPointStyles.toString());
+        mVariables.put("isData", mIsData.toString());
+        mVariables.put("xNames", mXNames.toString());
 
         // Data-based tweaking of user's configuration and adding system series
         normalizeBoundaries();
@@ -315,6 +322,18 @@ public class DataConfiguration extends Configuration {
     }
 
     /**
+     * Set whether or not point should appear in legend and tooltip.
+     * @param yID ID of y-values array that is or isn't data
+     * @param s SeriesData from which to pull flag
+     */
+    private void setIsData(String yID, SeriesData s) throws JSONException {
+        boolean isData = Boolean.valueOf(s.getConfiguration("is-data", "true"));
+        if (isData) {
+            mIsData.put(yID, 1);
+        }
+    }
+
+    /**
      * Set series name to display in legend.
      * @param yID ID of y-values array that name applies to
      * @param s SeriesData from which to pull name
@@ -324,6 +343,7 @@ public class DataConfiguration extends Configuration {
         if (name != null) {
             mNames.put(yID, name);
         }
+        mXNames.put(yID, s.getConfiguration("xName", mData.getConfiguration("x-title", "x")));
     }
 
     /**
@@ -358,7 +378,6 @@ public class DataConfiguration extends Configuration {
         } else if (mData.getType().equals(Graph.TYPE_BAR)) {
             type = "bar";
         } else if (s.getConfiguration("fill-below") != null) {
-            // TODO: allow customizing fill's color
             type = "area";
         }
         mTypes.put(yID, type);

--- a/app/src/org/commcare/android/view/c3/DataConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/DataConfiguration.java
@@ -343,7 +343,7 @@ public class DataConfiguration extends Configuration {
         if (name != null) {
             mNames.put(yID, name);
         }
-        mXNames.put(yID, s.getConfiguration("xName", mData.getConfiguration("x-title", "x")));
+        mXNames.put(yID, s.getConfiguration("x-name", mData.getConfiguration("x-title", "x")));
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/GraphActivity.java
+++ b/app/src/org/commcare/dalvik/activities/GraphActivity.java
@@ -1,0 +1,45 @@
+package org.commcare.dalvik.activities;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.webkit.WebView;
+import android.widget.LinearLayout;
+
+import org.commcare.android.framework.CommCareActivity;
+import org.commcare.android.util.InvalidStateException;
+import org.commcare.android.view.GraphView;
+import org.commcare.suite.model.graph.GraphData;
+
+/**
+ * Created by jschweers on 11/20/2015.
+ */
+public class GraphActivity extends CommCareActivity {
+    private GraphView mView;
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Bundle extras = getIntent().getExtras();
+        String title = extras.getString(GraphView.TITLE);
+        if (title == null) {
+            requestWindowFeature(Window.FEATURE_NO_TITLE);
+        } else if (title.length() > 0) {
+            setTitle(title);
+        }
+
+        String html = extras.getString(GraphView.HTML);
+        mView = new GraphView(this, title, true);
+        try {
+            WebView view = (WebView) mView.getView(html);
+            setContentView(view);
+        } catch (InvalidStateException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/org/commcare/dalvik/activities/GraphActivity.java
+++ b/app/src/org/commcare/dalvik/activities/GraphActivity.java
@@ -42,6 +42,7 @@ public class GraphActivity extends CommCareActivity {
             setContentView(view);
         } catch (InvalidStateException e) {
             e.printStackTrace();
+            finish();
         }
     }
 }

--- a/app/src/org/commcare/dalvik/activities/GraphActivity.java
+++ b/app/src/org/commcare/dalvik/activities/GraphActivity.java
@@ -15,6 +15,8 @@ import org.commcare.android.view.GraphView;
 import org.commcare.suite.model.graph.GraphData;
 
 /**
+ * Full-screen view of a graph.
+ *
  * Created by jschweers on 11/20/2015.
  */
 public class GraphActivity extends CommCareActivity {


### PR DESCRIPTION
Support double-tap to see the graph full screen.

In full-screen mode, you can zoom and can touch a point to get a tooltip. This PR adds to series configuration `is-data` (default true) so users can specify that a given series should *not* be included in the tooltip (or the legend) (for example, the fake "series" used to create parto's red and yellow areas, or thresholds in general).

It's a bit finicky; the touch to tooltip isn't always responsive (it's a hover event in C3, so Android is translating the touch event to a mouseover). I'm using the built-in WebView zoom because C3's zoom capabilities are "experimental" (do not work well), but unfortunately that means that you're zooming in on the entire view, not just zooming in on the data while the axes stay put & re-scale themselves.

![screenshot_2015-11-20-19-09-47](https://cloud.githubusercontent.com/assets/1486591/11315131/402ac94e-8fbb-11e5-885e-3e287b503a5c.png)
![screenshot_2015-11-20-19-09-55](https://cloud.githubusercontent.com/assets/1486591/11315132/402b7628-8fbb-11e5-9794-46566b684663.png)
