### PR TITLE
Standard aspect ratio for graphs

### DIFF
--- a/app/src/org/commcare/android/view/EntityDetailView.java
+++ b/app/src/org/commcare/android/view/EntityDetailView.java
@@ -258,7 +258,11 @@ public class EntityDetailView extends FrameLayout {
                 GraphView g = new GraphView(context, labelText);
                 try {
                     graphView = g.getView((GraphData)field);
-                    graphLayout.setRatio((float)g.getRatio(), (float)1);
+                    // Graphs are drawn with aspect ratio 2:1, which is mostly arbitrary
+                    // and happened to look nice for partographs. Expect to revisit
+                    // this eventually (make all graphs square? user-configured aspect ratio?).
+                    graphLayout.setRatio(2, 1);
+
                 } catch (InvalidStateException ise) {
                     graphView = new TextView(context);
                     int padding = (int)context.getResources().getDimension(R.dimen.spacer_small);

--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -139,21 +139,4 @@ public class GraphView {
     public static LinearLayout.LayoutParams getLayoutParams() {
         return new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
     }
-
-    /**
-     * Get graph's desired aspect ratio.
-     *
-     * @return Ratio, expressed as a double: width / height.
-     */
-    public double getRatio() {
-        // Most graphs are drawn with aspect ratio 2:1, which is mostly arbitrary
-        // and happened to look nice for partographs. Vertically-oriented graphs,
-        // however, get squished unless they're drawn as a square. Expect to revisit 
-        // this eventually (make all graphs square? user-configured aspect ratio?).
-        // TODO: did migrating to C3 fix the squishing issue?
-        if (Graph.TYPE_BAR.equals(mData.getType())) {
-            return 1;
-        }
-        return 2;
-    }
 }


### PR DESCRIPTION
AChartEngine displayed bar graphs squished unless they were square, so the old graphing code based aspect ratio on graph type. Drop this hackiness, use the same aspect ratio everywhere.

![screenshot_2015-11-21-21-16-21](https://cloud.githubusercontent.com/assets/1486591/11321724/efcc6cae-9097-11e5-82d5-fbddaa4c70fb.png)
