### PR TITLE
Accept more color formats, and round axis labels

### DIFF
--- a/app/assets/graphing/graph.js
+++ b/app/assets/graphing/graph.js
@@ -53,17 +53,17 @@ document.addEventListener("DOMContentLoaded", function(event) {
     // Add functions for custom tick labels
     if (config.axis.x.tick) {
         config.axis.x.tick.format = function(d) {
-            return xLabels[String(d)] || d;
+            return xLabels[String(d)] || Math.round(d);
         };
     }
     if (config.axis.y.tick) {
         config.axis.y.tick.format = function(d) {
-            return yLabels[String(d)] || d;
+            return yLabels[String(d)] || Math.round(d);
         };
     }
     if (config.axis.y2.tick) {
         config.axis.y2.tick.format = function(d) {
-            return y2Labels[String(d)] || d;
+            return y2Labels[String(d)] || Math.round(d);
         };
     }
     if (type === "bar") {

--- a/app/src/org/commcare/android/view/c3/DataConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/DataConfiguration.java
@@ -269,19 +269,42 @@ public class DataConfiguration extends Configuration {
      * @param s SeriesData from which to pull color
      */
     private void setColor(String yID, SeriesData s) throws JSONException {
-        // TODO: Handle transparency (and test on bubble graphs)
         String color = s.getConfiguration("line-color", "#ff000000");
-
-        double lineOpacity = Color.alpha(Color.parseColor(color)) / (double) 255;
-        mLineOpacities.put(yID, lineOpacity);
+        color = normalizeColor(color);
         mColors.put(yID, "#" + color.substring(3));
+        mLineOpacities.put(yID, getOpacity(color));
 
         String fillBelow = s.getConfiguration("fill-below");
         if (fillBelow != null) {
-            double areaOpacity = Color.alpha(Color.parseColor(fillBelow)) / (double) 255;
-            mAreaOpacities.put(yID, areaOpacity);
-            mAreaColors.put(yID, "#" + color.substring(3));
+            System.out.println("[jls] fill-below => " + fillBelow + " => " + normalizeColor(fillBelow));
+            fillBelow = normalizeColor(fillBelow);
+            mAreaColors.put(yID, "#" + fillBelow.substring(3));
+            mAreaOpacities.put(yID, getOpacity(fillBelow));
         }
+    }
+
+    /**
+     * Convert color string to expected format.
+     * @param color String of format #?(AA)?RRGGBB
+     * @return String of format "#AARRGGBB"
+     */
+    private String normalizeColor(String color) {
+        if (color.length() % 2 == 0) {
+            color = "#" + color;
+        }
+        if (color.length() == 7) {
+            color = "#ff" + color.substring(1);
+        }
+        return color;
+    }
+
+    /**
+     * Calculate opacity of given color.
+     * @param color Color in format "#AARRGGBB"
+     * @return Opacity, which will be between 0 and 1, inclusive
+     */
+    private double getOpacity(String color) {
+        return Color.alpha(Color.parseColor(color)) / (double) 255;
     }
 
     /**


### PR DESCRIPTION
- Accept either 6-digit or 8-digit colors
- Round labels; looks like C3's automatic label calculation doesn't round nicely if you, say, want seven labels ranging from 0 to 1. Might be a problem if someone wants decimal labels, but right now this is an easy bandaid.