### PR TITLE
Force all bar labels to show

### DIFF
--- a/app/assets/graphing/graph.js
+++ b/app/assets/graphing/graph.js
@@ -66,11 +66,6 @@ document.addEventListener("DOMContentLoaded", function(event) {
             return y2Labels[String(d)] || d;
         };
     }
-    if (type === "bar") {
-        config.axis.x.tick.format = function(d) {
-            return barLabels[d];
-        };
-    }
 
     // Hide any system-generated series from legend
     var hideSeries = [];

--- a/app/src/org/commcare/android/view/c3/DataConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/DataConfiguration.java
@@ -254,12 +254,19 @@ public class DataConfiguration extends Configuration {
     /**
      * For bar charts, set up bar labels and force the x axis min and max so bars are spaced nicely
      */
-    private void normalizeBoundaries() {
+    private void normalizeBoundaries() throws JSONException {
         if (mData.getType().equals(Graph.TYPE_BAR)) {
             mData.setConfiguration("x-min", "0.5");
             mData.setConfiguration("x-max", String.valueOf(mBarCount + 0.5));
             mBarLabels.put("");
             mVariables.put("barLabels", mBarLabels.toString());
+
+            // Force all labels to show; C3 will hide some labels if it thinks there are too many.
+            JSONObject xLabels = new JSONObject();
+            for (int i = 0; i < mBarLabels.length(); i++) {
+                xLabels.put(String.valueOf(i), (String) mBarLabels.get(i));
+            }
+            mData.setConfiguration("x-labels", xLabels.toString());
         }
     }
 


### PR DESCRIPTION
C3 will hide alternate labels if it thinks the axis is too crowded...good for visual breathing room, bad for being able to read bar charts.

Before
![screenshot_2015-11-21-23-21-32](https://cloud.githubusercontent.com/assets/1486591/11322061/22658ae2-90a7-11e5-827a-1d09b2b47656.png)


After
![screenshot_2015-11-21-23-19-41](https://cloud.githubusercontent.com/assets/1486591/11322062/2ce37cea-90a7-11e5-9782-2528de08340c.png)
