### PR TITLE
Stack areas

### DIFF
--- a/app/assets/graphing/graph.js
+++ b/app/assets/graphing/graph.js
@@ -88,6 +88,9 @@ document.addEventListener("DOMContentLoaded", function(event) {
         },
     };
 
+    // Don't use C3's default ordering for stacked series, use the order series are defined
+    config.data.order = false;
+
     // Post-processing
     config.onrendered = function() {
         // For annotations series, nudge text so it appears on top of data point

--- a/app/src/org/commcare/android/view/c3/DataConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/DataConfiguration.java
@@ -207,20 +207,31 @@ public class DataConfiguration extends Configuration {
     }
 
     /**
-     * Set up stacked bar graph, if needed.
+     * Set up stacked bar graph, if needed. Expects series data to have
+     * already been processed (specifically, expects mTypes to be populated).
      * @return JSONArray of configuration for groups, C3's version of stacking
      */
     private JSONArray getGroups() throws JSONException {
         JSONArray outer = new JSONArray();
+        JSONArray inner = new JSONArray();
         if (mData.getType().equals(Graph.TYPE_BAR)
                 && Boolean.valueOf(mData.getConfiguration("stack", "false"))) {
-            JSONArray inner = new JSONArray();
             for (Iterator<String> i = mTypes.keys(); i.hasNext();) {
                 String key = i.next();
                 if (mTypes.get(key).equals("bar")) {
                     inner.put(key);
                 }
             }
+        } else {
+            for (Iterator<String> i = mTypes.keys(); i.hasNext();) {
+                String yID = i.next();
+                if (mTypes.getString(yID).equals("area")) {
+                    inner.put(yID);
+                }
+            }
+        }
+
+        if (inner.length() > 0) {
             outer.put(inner);
         }
         return outer;


### PR DESCRIPTION
Translucent area graphs (which are desirable because C3 draws its grid lines underneath all of the series, which means you can't see the grid lines through parto's red/yellow zones unless they're translucent) get ugly when the areas overlap. Stack them.

Before
![screenshot_2015-11-22-21-06-23](https://cloud.githubusercontent.com/assets/1486591/11328741/42b933d6-915e-11e5-9f53-58c5e2728776.png)

After
![screenshot_2015-11-22-21-08-47](https://cloud.githubusercontent.com/assets/1486591/11328742/45d1e180-915e-11e5-9a56-4d9f10bf50c8.png)

