### PR TITLE
Correctly refresh view on constraint violation during form save

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2067,10 +2067,11 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
                     break;
                 case FormEntryController.ANSWER_CONSTRAINT_VIOLATED:
                 case FormEntryController.ANSWER_REQUIRED_BUT_EMPTY:
-                    // an answer constraint was violated, so do a 'swipe' to the next
-                    // question to display the proper toast(s)
-                    next();
-                    break;
+                    // an answer constraint was violated, so try to save the
+                    // current question to trigger the constraint violation message
+                    refreshCurrentView();
+                    saveAnswersForCurrentScreen(EVALUATE_CONSTRAINTS);
+                    return;
             }
             refreshCurrentView();
         }


### PR DESCRIPTION
Currently when you try to save and exit a form that has an answer that violates a question constraint, it jumps to that question. Unfortunately it doesn't correctly show the constraint violation message that it used to. This PR ensures that the constraint violation message is shown again.

Fix for http://manage.dimagi.com/default.asp?187237