### PR TITLE
Don't show warning about restarting session when it was only for saved form

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -437,7 +437,7 @@ public class CommCareHomeActivity
                         String command = intent.getStringExtra(SessionFrame.STATE_COMMAND_ID);
                         session.setCommand(command);
                     } else {
-                        clearSessionAndExit(currentState);
+                        clearSessionAndExit(currentState, true);
                         return;
                     }
                 }
@@ -454,7 +454,7 @@ public class CommCareHomeActivity
                         String chosenCaseId = intent.getStringExtra(SessionFrame.STATE_DATUM_VAL);
                         currentSession.setDatum(sessionDatumId, chosenCaseId);
                     } else {
-                        clearSessionAndExit(asw);
+                        clearSessionAndExit(asw, true);
                         return;
                     }
                 }
@@ -511,7 +511,7 @@ public class CommCareHomeActivity
                     Toast.LENGTH_LONG).show();
             Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW,
                     "Form Entry couldn't save because of corrupt state.");
-            clearSessionAndExit(currentState);
+            clearSessionAndExit(currentState, true);
             return false;
         }
 
@@ -544,7 +544,7 @@ public class CommCareHomeActivity
                         Toast.LENGTH_LONG).show();
                 Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW,
                         "Form Entry did not return a form");
-                clearSessionAndExit(currentState);
+                clearSessionAndExit(currentState, true);
                 return false;
             }
 
@@ -595,9 +595,8 @@ public class CommCareHomeActivity
                 // to keep running the workflow
             } else {
                 // Form record is now stored.
-                // TODO: session state clearing might be something we want to
-                // do in InstanceProvider.bindToFormRecord.
-                clearSessionAndExit(currentState);
+                // TODO: session state clearing might be something we want to do in InstanceProvider.bindToFormRecord.
+                clearSessionAndExit(currentState, false);
                 return false;
             }
         } else if (resultCode == RESULT_CANCELED) {
@@ -631,13 +630,15 @@ public class CommCareHomeActivity
         return true;
     }
 
-    private void clearSessionAndExit(AndroidSessionWrapper currentState) {
+    private void clearSessionAndExit(AndroidSessionWrapper currentState, boolean shouldWarnUser) {
         currentState.reset();
         if (wasExternal) {
             this.finish();
         }
         uiController.refreshView();
-        showSessionRefreshWarning();
+        if (shouldWarnUser) {
+            showSessionRefreshWarning();
+        }
     }
 
     private void showSessionRefreshWarning() {


### PR DESCRIPTION
I added a dialog to warn users when we needed to restart their session due to some sort of error, but didn't realize that there is one case when we call clearSessionAndExit() that isn't an error state, it's just when we save a form; the user shouldn't see a warning in that case.