### PR TITLE
Launch tasks using executeOnExecutor

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1412,7 +1412,11 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
             mSaveToDiskTask.connect(this);
         }
         mSaveToDiskTask.setFormSavedListener(this);
-        mSaveToDiskTask.execute();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            mSaveToDiskTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        } else {
+            mSaveToDiskTask.execute();
+        }
     }
 
     /**
@@ -1846,7 +1850,11 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
                 }
             };
             mFormLoaderTask.connect(this);
-            mFormLoaderTask.execute(formUri);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                mFormLoaderTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, formUri);
+            } else {
+                mFormLoaderTask.execute(formUri);
+            }
             hasFormLoadBeenTriggered = true;
         }
     }


### PR DESCRIPTION
Tell android to use multiple threads when running async tasks.
Helps slightly when processing form send tasks and form save/load tasks at the same time 