### PR TITLE
Fix app update progress bar artifact

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -1,17 +1,3 @@
-<!-- Copyright (C) 2009 University of Washington
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not
-use this file except in compliance with the License. You may obtain a copy of
-the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations under
-the License.
--->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <ListPreference
         android:enabled="true"
@@ -58,7 +44,7 @@ the License.
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enable-auto-login"
-        android:title="Enable auto-login during debugging" />
+        android:title="Auto-login While Debugging" />
     <ListPreference
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"

--- a/app/src/org/commcare/dalvik/activities/UpdateUIState.java
+++ b/app/src/org/commcare/dalvik/activities/UpdateUIState.java
@@ -120,7 +120,6 @@ class UpdateUIState {
         stopUpdateButton.setEnabled(false);
         installUpdateButton.setEnabled(false);
 
-        progressBar.setEnabled(false);
         updateProgressText("");
         updateProgressBar(0, 100);
     }
@@ -137,7 +136,6 @@ class UpdateUIState {
         stopUpdateButton.setEnabled(true);
         installUpdateButton.setEnabled(false);
 
-        progressBar.setEnabled(true);
         updateProgressBar(0, 100);
         updateProgressText(beginCheckingText);
     }
@@ -149,7 +147,6 @@ class UpdateUIState {
         installUpdateButton.setEnabled(true);
 
         updateProgressBar(100, 100);
-        progressBar.setEnabled(false);
 
         int version = ResourceInstallUtils.upgradeTableVersion();
         String versionMsg =
@@ -165,7 +162,6 @@ class UpdateUIState {
         stopUpdateButton.setEnabled(false);
         installUpdateButton.setEnabled(false);
 
-        progressBar.setEnabled(false);
         updateProgressText(cancellingMsg);
     }
 
@@ -175,7 +171,6 @@ class UpdateUIState {
         stopUpdateButton.setEnabled(false);
         installUpdateButton.setEnabled(false);
 
-        progressBar.setEnabled(false);
         updateProgressText(errorMsg);
     }
 
@@ -185,7 +180,6 @@ class UpdateUIState {
         stopUpdateButton.setEnabled(false);
         installUpdateButton.setEnabled(false);
 
-        progressBar.setEnabled(false);
         updateProgressText(noConnectivityMsg);
     }
 
@@ -194,8 +188,8 @@ class UpdateUIState {
     }
 
     protected void updateProgressBar(int currentProgress, int max) {
-        progressBar.setProgress(currentProgress);
         progressBar.setMax(max);
+        progressBar.setProgress(currentProgress);
     }
 
     public void refreshStatusText() {


### PR DESCRIPTION
Fix issue where after performing an update check the progress bar shows partially complete:
![screen](https://cloud.githubusercontent.com/assets/94817/11447595/9178e8f2-9516-11e5-90c7-6783361be5a5.png)


Also rename dev setting entry "Enable auto-login during debugging" -> "Auto-login While Debugging"