### PR TITLE
Wrap cursor ops in finally/close

### DIFF
--- a/app/src/org/commcare/android/database/SqlStorage.java
+++ b/app/src/org/commcare/android/database/SqlStorage.java
@@ -95,20 +95,24 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
     }
 
     public static Vector<Integer> fillIdWindow(Cursor c, String columnName) {
-        if (c.getCount() == 0) {
-            c.close();
-            return new Vector<Integer>();
-        } else {
-            c.moveToFirst();
-            Vector<Integer> indices = new Vector<Integer>();
-            int index = c.getColumnIndexOrThrow(columnName);
-            while (!c.isAfterLast()) {
-                int id = c.getInt(index);
-                indices.add(id);
-                c.moveToNext();
+        try {
+            if (c.getCount() == 0) {
+                return new Vector<>();
+            } else {
+                c.moveToFirst();
+                Vector<Integer> indices = new Vector<>();
+                int index = c.getColumnIndexOrThrow(columnName);
+                while (!c.isAfterLast()) {
+                    int id = c.getInt(index);
+                    indices.add(id);
+                    c.moveToNext();
+                }
+                return indices;
             }
-            c.close();
-            return indices;
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
     }
 
@@ -125,20 +129,24 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         } catch (SessionUnavailableException e) {
             throw new UserStorageClosedException(e.getMessage());
         }
-        if (c.getCount() == 0) {
-            c.close();
-            return new Vector<T>();
-        } else {
-            c.moveToFirst();
-            Vector<T> indices = new Vector<T>();
-            int index = c.getColumnIndexOrThrow(DbUtil.DATA_COL);
-            while (!c.isAfterLast()) {
-                byte[] data = c.getBlob(index);
-                indices.add(newObject(data));
-                c.moveToNext();
+        try {
+            if (c.getCount() == 0) {
+                return new Vector<>();
+            } else {
+                c.moveToFirst();
+                Vector<T> indices = new Vector<>();
+                int index = c.getColumnIndexOrThrow(DbUtil.DATA_COL);
+                while (!c.isAfterLast()) {
+                    byte[] data = c.getBlob(index);
+                    indices.add(newObject(data));
+                    c.moveToNext();
+                }
+                return indices;
             }
-            c.close();
-            return indices;
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
     }
 
@@ -151,35 +159,45 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         } catch (SessionUnavailableException e) {
             throw new UserStorageClosedException(e.getMessage());
         }
-        if (c.getCount() == 0) {
-            c.close();
-            throw new NoSuchElementException("No record in table " + table + " for ID " + recordId);
+        try {
+            if (c.getCount() == 0) {
+                throw new NoSuchElementException("No record in table " + table + " for ID " + recordId);
+            }
+            c.moveToFirst();
+            return c.getString(c.getColumnIndexOrThrow(scrubbedName));
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
-        c.moveToFirst();
-        String result = c.getString(c.getColumnIndexOrThrow(scrubbedName));
-        c.close();
-        return result;
-
     }
 
     public T getRecordForValues(String[] rawFieldNames, Object[] values) throws NoSuchElementException, InvalidIndexException {
-        Pair<String, String[]> whereClause = helper.createWhereAndroid(rawFieldNames, values, em, t);
-        Cursor c;
+        SQLiteDatabase appDb;
         try {
-            c = helper.getHandle().query(table, new String[]{DbUtil.ID_COL, DbUtil.DATA_COL}, whereClause.first, whereClause.second, null, null, null);
+            appDb = helper.getHandle();
         } catch (SessionUnavailableException e) {
             throw new UserStorageClosedException(e.getMessage());
         }
-        if (c.getCount() == 0) {
-            throw new NoSuchElementException("No element in table " + table + " with names " + Arrays.toString(rawFieldNames) + " and values " + Arrays.toString(values));
+
+        Cursor c;
+        Pair<String, String[]> whereClause = helper.createWhereAndroid(rawFieldNames, values, em, t);
+        c = appDb.query(table, new String[]{DbUtil.ID_COL, DbUtil.DATA_COL}, whereClause.first, whereClause.second, null, null, null);
+        try {
+            int queryCount = c.getCount();
+            if (queryCount  == 0) {
+                throw new NoSuchElementException("No element in table " + table + " with names " + Arrays.toString(rawFieldNames) + " and values " + Arrays.toString(values));
+            } else if (queryCount > 1) {
+                throw new InvalidIndexException("Invalid unique column set" + Arrays.toString(rawFieldNames) + ". Multiple records found with value " + Arrays.toString(values), Arrays.toString(rawFieldNames));
+            }
+            c.moveToFirst();
+            byte[] data = c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
+            return newObject(data);
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
-        if (c.getCount() > 1) {
-            throw new InvalidIndexException("Invalid unique column set" + Arrays.toString(rawFieldNames) + ". Multiple records found with value " + Arrays.toString(values), Arrays.toString(rawFieldNames));
-        }
-        c.moveToFirst();
-        byte[] data = c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
-        c.close();
-        return newObject(data);
     }
 
     @Override
@@ -200,18 +218,21 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         
         String scrubbedName = AndroidTableBuilder.scrubName(rawFieldName);
         Cursor c = db.query(table, new String[] {DbUtil.DATA_COL} ,whereClause.first, whereClause.second, null, null, null);
-        if(c.getCount() == 0) {
-            c.close();
-            throw new NoSuchElementException("No element in table " + table + " with name " + scrubbedName + " and value " + value.toString());
+        try {
+            int queryCount = c.getCount();
+            if (queryCount == 0) {
+                throw new NoSuchElementException("No element in table " + table + " with name " + scrubbedName + " and value " + value.toString());
+            } else if (queryCount > 1) {
+                throw new InvalidIndexException("Invalid unique column " + scrubbedName + ". Multiple records found with value " + value.toString(), scrubbedName);
+            }
+            c.moveToFirst();
+            byte[] data = c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
+            return newObject(data);
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
-        if (c.getCount() > 1) {
-            c.close();
-            throw new InvalidIndexException("Invalid unique column " + scrubbedName + ". Multiple records found with value " + value.toString(), scrubbedName);
-        }
-        c.moveToFirst();
-        byte[] data = c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
-        c.close();
-        return newObject(data);
     }
 
     public T newObject(byte[] data) {
@@ -288,15 +309,18 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
             throw new UserStorageClosedException(e.getMessage());
         }
 
-        if (c.getCount() == 0) {
-            c.close();
-            return false;
+        try {
+            int queryCount = c.getCount();
+            if (queryCount == 0) {
+                return false;
+            } else if (queryCount > 1) {
+                throw new InvalidIndexException("Invalid ID column. Multiple records found with value " + id, "ID");
+            }
+        } finally {
+            if (c != null) {
+                c.close();
+            }
         }
-        if (c.getCount() > 1) {
-            c.close();
-            throw new InvalidIndexException("Invalid ID column. Multiple records found with value " + id, "ID");
-        }
-        c.close();
         return true;
     }
 
@@ -336,10 +360,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
 
     @Override
     public boolean isEmpty() {
-        if (getNumRecords() == 0) {
-            return true;
-        }
-        return false;
+        return (getNumRecords() == 0);
     }
 
     @Override
@@ -445,10 +466,14 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
             throw new UserStorageClosedException(e.getMessage());
         }
 
-        c.moveToFirst();
-        byte[] blob = c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
-        c.close();
-        return blob;
+        try {
+            c.moveToFirst();
+            return c.getBlob(c.getColumnIndexOrThrow(DbUtil.DATA_COL));
+        } finally {
+            if (c != null) {
+                c.close();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Months later I'm still trying to figure out how to prevent the following exception trace from popping up: 
```
11-27 14:45:06.627 3606-3614/org.commcare.dalvik E/Cursor: Finalizing a Cursor that has not been deactivated or closed. database = /data/user/0/org.commcare.dalvik/databases/database_app_448082f04dde416e840e4a00d5e793e4, table = user_key_records, query = SELECT commcare_sql_id, commcare_sql_record FROM user_key_records WHERE sandbox_id=? AND username=?
                                                           net.sqlcipher.database.DatabaseObjectNotClosedException: Application did not close the cursor or database object that was opened here
                                                               at net.sqlcipher.database.SQLiteCursor.<init>(SQLiteCursor.java:217)
                                                               at net.sqlcipher.database.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:53)
                                                               at net.sqlcipher.database.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1758)
                                                               at net.sqlcipher.database.SQLiteDatabase.queryWithFactory(SQLiteDatabase.java:1620)
                                                               at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1572)
                                                               at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1661)
                                                               at org.commcare.android.database.SqlStorage.getRecordForValues(SqlStorage.java:169)
                                                               at org.commcare.android.tasks.ManageKeyRecordTask.processSuccesfulRequest(ManageKeyRecordTask.java:282)
                                                               at org.commcare.android.tasks.templates.HttpCalloutTask.doTaskBackground(HttpCalloutTask.java:97)
                                                               at org.commcare.android.tasks.templates.HttpCalloutTask.doTaskBackground(HttpCalloutTask.java:28)
                                                               at org.commcare.android.tasks.templates.CommCareTask.doInBackground(CommCareTask.java:34)
                                                               at android.os.AsyncTask$2.call(AsyncTask.java:295)
                                                               at java.util.concurrent.FutureTask.run(FutureTask.java:237)
                                                               at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234)
                                                               at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
                                                               at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
                                                               at java.lang.Thread.run(Thread.java:818)
```