### PR TITLE
Support graphs in case lists

### DIFF
--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -65,6 +65,9 @@ public class GraphView {
         settings.setJavaScriptEnabled(true);
 
         webView.setClickable(true);
+        webView.setFocusable(false);
+        webView.setFocusableInTouchMode(false);
+
         settings.setBuiltInZoomControls(mIsFullScreen);
         settings.setSupportZoom(mIsFullScreen);
         settings.setDisplayZoomControls(mIsFullScreen);


### PR DESCRIPTION
Graphs in the case list weren't allowing you to actually select an item and proceed to case detail.