### PR TITLE
Sync key creation; preventing premature usage

### DIFF
--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -138,13 +138,11 @@ public class CommCareSessionService extends Service {
             public Cipher generateNewCipher() {
                 synchronized (lock) {
                     try {
-                        synchronized (key) {
-                            SecretKeySpec spec = new SecretKeySpec(key, "AES");
-                            Cipher decrypter = Cipher.getInstance("AES");
-                            decrypter.init(Cipher.DECRYPT_MODE, spec);
+                        SecretKeySpec spec = new SecretKeySpec(key, "AES");
+                        Cipher decrypter = Cipher.getInstance("AES");
+                        decrypter.init(Cipher.DECRYPT_MODE, spec);
 
-                            return decrypter;
-                        }
+                        return decrypter;
                     } catch (NoSuchPaddingException | NoSuchAlgorithmException | InvalidKeyException e) {
                         e.printStackTrace();
                     }
@@ -428,8 +426,14 @@ public class CommCareSessionService extends Service {
         }
     }
 
-    public SecretKey createNewSymetricKey() {
-        return CryptUtil.generateSymetricKey(CryptUtil.uniqueSeedFromSecureStatic(key));
+    public SecretKey createNewSymetricKey() throws SessionUnavailableException {
+        synchronized (lock) {
+            // Ensure we have a key to work with
+            if (!isActive()) {
+                throw new SessionUnavailableException("Can't generate new key when the user session key is empty.");
+            }
+            return CryptUtil.generateSymetricKey(CryptUtil.uniqueSeedFromSecureStatic(key));
+        }
     }
 
     public User getLoggedInUser() throws SessionUnavailableException {


### PR DESCRIPTION
Trying to address the ACRA crash below.

From what I can deduce: The log submission task launch on login is trying to access the user session key before it has been setup. Thus wrapping `createNewSymetricKey` in `synchronized (lock)` should hopefully address this.

I might completely off as to when this crash is occurring. If it is happening at a different time then this solution probably doesn't really help.

https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/ab17609d7e49b4bd56f02741c141e937