### PR TITLE
Augment session restoration

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -97,6 +97,7 @@ home.menu.about=About CommCare
 home.developer.options.enabled=Developer Mode Enabled
 
 menu.save.session=Save Your Session
+menu.clear.saved.session=Clear Saved Session
 
 install.version.mismatch=The application requires CommCare version ${0}. You are running ${1}.
 install.major.mismatch=Please uninstall your CommCare Application from the phone Settings Menu, navigate to the marketplace, and install the proper version.

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -96,6 +96,8 @@ home.menu.about=About CommCare
 
 home.developer.options.enabled=Developer Mode Enabled
 
+menu.save.session=Save Your Session
+
 install.version.mismatch=The application requires CommCare version ${0}. You are running ${1}.
 install.major.mismatch=Please uninstall your CommCare Application from the phone Settings Menu, navigate to the marketplace, and install the proper version.
 install.minor.mismatch=Please update your version of CommCare from the Android Market to run this application. 

--- a/app/res/layout/screen_login.xml
+++ b/app/res/layout/screen_login.xml
@@ -133,6 +133,15 @@
                                 android:textStyle="bold"
                                 android:visibility="gone"/>
 
+                            <CheckBox
+                                android:id="@+id/restore_session_checkbox"
+                                android:layout_width="fill_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginBottom="@dimen/standard_spacer"
+                                android:text="@string/restore_session_prompt"
+                                android:textSize="16dp"
+                                android:visibility="gone" />
+
                             <Button
                                 android:id="@+id/login_button"
                                 android:layout_width="fill_parent"

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -144,6 +144,8 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="title_activity_report_problem">ReportProblemActivity</string>
     <string name="title_activity_comm_care_verification">CommCareVerificationActivity</string>
     <string name="panes">one</string>
+    <string name="restore_session_prompt">Restore saved session upon login</string>
+
 
     <!-- Start Collect Strings -->
 

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -49,6 +49,12 @@
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-enable-session-saving"
+        android:title="Enable Session Saving" />
+    <ListPreference
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
         android:key="cc-css-enabled"
         android:title="CSS Enabled" />
     <ListPreference

--- a/app/src/org/commcare/android/api/ExternalApiReceiver.java
+++ b/app/src/org/commcare/android/api/ExternalApiReceiver.java
@@ -259,8 +259,10 @@ public class ExternalApiReceiver extends BroadcastReceiver {
             }
             //TODO: See if it worked first?
 
-            CommCareApplication._().startUserSession(key, matchingRecord);
-            ManageKeyRecordTask mKeyRecordTask = new ManageKeyRecordTask<Object>(context, 0, matchingRecord.getUsername(), password, CommCareApplication._().getCurrentApp(), new ManageKeyRecordListener() {
+            CommCareApplication._().startUserSession(key, matchingRecord, false);
+            ManageKeyRecordTask mKeyRecordTask = new ManageKeyRecordTask<Object>(context, 0,
+                    matchingRecord.getUsername(), password, CommCareApplication._().getCurrentApp(),
+                    false, new ManageKeyRecordListener() {
 
                 @Override
                 public void keysLoginComplete(Object o) {

--- a/app/src/org/commcare/android/framework/SaveSessionCommCareActivity.java
+++ b/app/src/org/commcare/android/framework/SaveSessionCommCareActivity.java
@@ -1,0 +1,36 @@
+package org.commcare.android.framework;
+
+import android.view.Menu;
+import android.view.MenuItem;
+
+import org.commcare.android.session.DevSessionRestorer;
+import org.javarosa.core.services.locale.Localization;
+
+/**
+ * Any CC activity from which we want the user to be able to save the current session via an item
+ * in the options menu should subclass this class
+ *
+ * @author amstone
+ */
+public abstract class SaveSessionCommCareActivity<R> extends SessionAwareCommCareActivity<R> {
+
+    // Choose a high number so that it will be higher than the menu ids of all other menu items
+    // created by subclasses
+    private static final int MENU_SAVE_SESSION = 9999;
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        menu.add(Menu.NONE, MENU_SAVE_SESSION, Menu.NONE, Localization.get("menu.save.session"));
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == MENU_SAVE_SESSION) {
+            DevSessionRestorer.saveSessionToPrefs();
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+}

--- a/app/src/org/commcare/android/framework/SaveSessionCommCareActivity.java
+++ b/app/src/org/commcare/android/framework/SaveSessionCommCareActivity.java
@@ -4,6 +4,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import org.commcare.android.session.DevSessionRestorer;
+import org.commcare.dalvik.preferences.DeveloperPreferences;
 import org.javarosa.core.services.locale.Localization;
 
 /**
@@ -14,9 +15,7 @@ import org.javarosa.core.services.locale.Localization;
  */
 public abstract class SaveSessionCommCareActivity<R> extends SessionAwareCommCareActivity<R> {
 
-    // Choose a high number so that it will be higher than the menu ids of all other menu items
-    // created by subclasses
-    private static final int MENU_SAVE_SESSION = 9999;
+    private static final int MENU_SAVE_SESSION = Menu.FIRST;
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
@@ -26,9 +25,17 @@ public abstract class SaveSessionCommCareActivity<R> extends SessionAwareCommCar
     }
 
     @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        menu.findItem(MENU_SAVE_SESSION).setVisible(DeveloperPreferences.isSessionSavingEnabled());
+        return true;
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == MENU_SAVE_SESSION) {
             DevSessionRestorer.saveSessionToPrefs();
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/org/commcare/android/session/DevSessionRestorer.java
+++ b/app/src/org/commcare/android/session/DevSessionRestorer.java
@@ -134,7 +134,6 @@ public class DevSessionRestorer {
         SharedPreferences prefs =
                 CommCareApplication._().getCurrentApp().getAppPreferences();
         String serializedSession = prefs.getString(CommCarePreferences.CURRENT_SESSION, null);
-        Log.i("12/1", "Saved Session Present: " + (serializedSession != null));
         return serializedSession != null;
     }
 

--- a/app/src/org/commcare/android/session/DevSessionRestorer.java
+++ b/app/src/org/commcare/android/session/DevSessionRestorer.java
@@ -130,6 +130,14 @@ public class DevSessionRestorer {
         }
     }
 
+    public static boolean savedSessionPresent() {
+        SharedPreferences prefs =
+                CommCareApplication._().getCurrentApp().getAppPreferences();
+        String serializedSession = prefs.getString(CommCarePreferences.CURRENT_SESSION, null);
+        Log.i("12/1", "Saved Session Present: " + (serializedSession != null));
+        return serializedSession != null;
+    }
+
     public static void clearSession(SharedPreferences prefs) {
         prefs.edit().remove(CommCarePreferences.CURRENT_SESSION).commit();
     }

--- a/app/src/org/commcare/android/session/DevSessionRestorer.java
+++ b/app/src/org/commcare/android/session/DevSessionRestorer.java
@@ -137,6 +137,10 @@ public class DevSessionRestorer {
         return serializedSession != null;
     }
 
+    public static void clearSession() {
+        clearSession(CommCareApplication._().getCurrentApp().getAppPreferences());
+    }
+
     public static void clearSession(SharedPreferences prefs) {
         prefs.edit().remove(CommCarePreferences.CURRENT_SESSION).commit();
     }

--- a/app/src/org/commcare/android/tasks/DataPullTask.java
+++ b/app/src/org/commcare/android/tasks/DataPullTask.java
@@ -74,7 +74,8 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
     private int mTotalItems = -1;
     private long mSyncStartTime;
     
-    private boolean wasKeyLoggedIn = false;
+    private boolean wasKeyLoggedIn;
+    private boolean restoreSession;
     
     public static final int DATA_PULL_TASK_ID = 10;
     
@@ -98,16 +99,21 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
     public static final int PROGRESS_PROCESSING = 128;
     public static final int PROGRESS_DOWNLOADING = 256;
     private DataPullRequester dataPullRequester;
-    
-    public DataPullTask(String username, String password, String server, Context context) {
+
+    public DataPullTask(String username, String password, String server, Context context, boolean restoreOldSession) {
         this.server = server;
         this.username = username;
         this.password = password;
         this.context = context;
         this.taskId = DATA_PULL_TASK_ID;
         this.dataPullRequester = new DataPullResponseFactory();
+        this.restoreSession = restoreOldSession;
 
         TAG = DataPullTask.class.getSimpleName();
+    }
+    
+    public DataPullTask(String username, String password, String server, Context context) {
+        this(username, password, server, context, false);
     }
 
     public DataPullTask(String username, String password, String server, Context context, DataPullRequester dataPullRequester) {
@@ -230,7 +236,8 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, Intege
                     if(loginNeeded) {                        
                         //This is necessary (currently) to make sure that data
                         //is encoded. Probably a better way to do this.
-                        CommCareApplication._().startUserSession(CryptUtil.unWrapKey(ukr.getEncryptedKey(), password), ukr);
+                        CommCareApplication._().startUserSession(CryptUtil.unWrapKey(
+                                ukr.getEncryptedKey(), password), ukr, restoreSession);
                         wasKeyLoggedIn = true;
                     }
                     

--- a/app/src/org/commcare/android/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/android/tasks/ManageKeyRecordTask.java
@@ -59,14 +59,18 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
     
     boolean calloutNeeded = false;
     boolean calloutRequired = false;
+    boolean restoreSession;
     
     User loggedIn = null;
     
-    public ManageKeyRecordTask(Context c, int taskId, String username, String password, CommCareApp app, ManageKeyRecordListener<R> listener) {
+    public ManageKeyRecordTask(Context c, int taskId, String username, String password,
+                               CommCareApp app, boolean restoreSession,
+                               ManageKeyRecordListener<R> listener) {
         super(c);
         this.username = username;
         this.password = password;
         this.app = app;
+        this.restoreSession = restoreSession;
         
         keyServerUrl = app.getAppPreferences().getString("key_server", null);
         //long story
@@ -358,7 +362,7 @@ public abstract class ManageKeyRecordTask<R> extends HttpCalloutTask<R> {
         }
         
         //Ok, so we're done with everything now. We should log in our local sandbox and proceed to the next step.
-        CommCareApplication._().startUserSession(current.unWrapKey(password), current);
+        CommCareApplication._().startUserSession(current.unWrapKey(password), current, restoreSession);
         
         //So we may have logged in a key record but not a user (if we just received the
         //key, but not the user's data, for instance). 

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -11,6 +11,7 @@ import android.widget.Button;
 import android.widget.RelativeLayout;
 
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SaveSessionCommCareActivity;
 import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.logic.DetailCalloutListenerDefaultImpl;
@@ -35,7 +36,7 @@ import org.javarosa.core.services.locale.Localization;
  */
 @ManagedUi(R.layout.entity_detail)
 public class EntityDetailActivity
-        extends SessionAwareCommCareActivity
+        extends SaveSessionCommCareActivity
         implements DetailCalloutListener {
 
     // reference id of selected element being detailed

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -36,7 +36,7 @@ import org.javarosa.core.services.locale.Localization;
  */
 @ManagedUi(R.layout.entity_detail)
 public class EntityDetailActivity
-        extends SaveSessionCommCareActivity
+        extends SessionAwareCommCareActivity
         implements DetailCalloutListener {
 
     // reference id of selected element being detailed

--- a/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java
@@ -11,7 +11,6 @@ import android.widget.Button;
 import android.widget.RelativeLayout;
 
 import org.commcare.android.framework.ManagedUi;
-import org.commcare.android.framework.SaveSessionCommCareActivity;
 import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.logic.DetailCalloutListenerDefaultImpl;

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -42,7 +42,6 @@ import org.commcare.android.adapters.EntityListAdapter;
 import org.commcare.android.fragments.ContainerFragment;
 import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.SaveSessionCommCareActivity;
-import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.android.models.AndroidSessionWrapper;
 import org.commcare.android.models.Entity;
@@ -109,9 +108,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     private static final int BARCODE_FETCH = 1;
     private static final int CALLOUT = 3;
 
-    private static final int MENU_SORT = Menu.FIRST;
-    private static final int MENU_MAP = Menu.FIRST + 1;
-    private static final int MENU_ACTION = Menu.FIRST + 2;
+    private static final int MENU_SORT = Menu.FIRST + 1;
+    private static final int MENU_MAP = Menu.FIRST + 2;
+    private static final int MENU_ACTION = Menu.FIRST + 3;
 
     private EditText searchbox;
     private TextView searchResultStatus;

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -41,6 +41,7 @@ import android.widget.Toast;
 import org.commcare.android.adapters.EntityListAdapter;
 import org.commcare.android.fragments.ContainerFragment;
 import org.commcare.android.framework.CommCareActivity;
+import org.commcare.android.framework.SaveSessionCommCareActivity;
 import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.android.models.AndroidSessionWrapper;
@@ -89,7 +90,7 @@ import java.util.TimerTask;
  *
  * @author ctsims
  */
-public class EntitySelectActivity extends SessionAwareCommCareActivity
+public class EntitySelectActivity extends SaveSessionCommCareActivity
         implements TextWatcher,
         EntityLoaderListener,
         OnItemClickListener,

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -20,6 +20,7 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.Spinner;
@@ -100,6 +101,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
     @UiElement(value=R.id.login_button, locale="login.button")
     private Button loginButton;
 
+    @UiElement(value=R.id.restore_session_checkbox)
+    private CheckBox restoreSessionCheckbox;
+
     @UiElement(R.id.app_selection_spinner)
     private Spinner spinner;
 
@@ -141,13 +145,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        final SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
-
-        username.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
-        setLoginBoxesColorNormal();
-
-        //Only on the initial creation
+        // Only on the initial creation
         if(savedInstanceState == null) {
+            SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
             String lastUser = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
             if(lastUser != null) {
                 username.setText(lastUser);
@@ -155,9 +155,18 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
             }
         }
 
+        setupUIElements();
+    }
+
+    private void setupUIElements() {
+        username.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS |
+                InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+
+        setLoginBoxesColorNormal();
+
         loginButton.setOnClickListener(new OnClickListener() {
             public void onClick(View arg0) {
-                loginButtonPressed();
+                loginButtonPressed(isRestoreSessionChecked());
             }
         });
 
@@ -169,6 +178,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
         password.setHint(Localization.get("login.password"));
 
         final View activityRootView = findViewById(R.id.screen_login_main);
+        final SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
         activityRootView.getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
@@ -187,7 +197,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
                     if (!"".equals(customBannerURI)) {
                         Bitmap bitmap = MediaUtil.inflateDisplayImage(LoginActivity.this, customBannerURI);
                         if (bitmap != null) {
-                            ImageView bannerView = (ImageView)banner.findViewById(R.id.main_top_banner);
+                            ImageView bannerView = (ImageView) banner.findViewById(R.id.main_top_banner);
                             bannerView.setImageBitmap(bitmap);
                         }
                     }
@@ -197,7 +207,11 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
         });
     }
 
-    private void loginButtonPressed() {
+    private boolean isRestoreSessionChecked() {
+        return restoreSessionCheckbox.isChecked();
+    }
+
+    private void loginButtonPressed(boolean restoreSession) {
         errorBox.setVisibility(View.GONE);
         ViewUtil.hideVirtualKeyboard(LoginActivity.this);
 
@@ -207,7 +221,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
             // install update, which triggers login upon completion
             installPendingUpdate();
         } else {
-            localLoginOrPullAndLogin();
+            localLoginOrPullAndLogin(restoreSession);
         }
     }
 
@@ -248,7 +262,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
                             receiver.raiseLoginMessage(StockMessages.Storage_Full, true);
                             break;
                         case DataPullTask.DOWNLOAD_SUCCESS:
-                            if(!tryLocalLogin(true)) {
+                            if(!tryLocalLogin(true, isRestoreSessionChecked())) {
                                 receiver.raiseLoginMessage(StockMessages.Auth_CredentialMismatch, true);
                             }
                             break;
@@ -335,7 +349,8 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
             password.setText(userAndPass.second);
 
             if (!getIntent().getBooleanExtra(USER_TRIGGERED_LOGOUT, false)) {
-                loginButtonPressed();
+                // If we are attempting auto-login, assume that we want to restore a saved session
+                loginButtonPressed(true);
             }
         }
     }
@@ -362,13 +377,14 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
         return username.getText().toString().toLowerCase().trim();
     }
     
-    private boolean tryLocalLogin(final boolean warnMultipleAccounts) {
+    private boolean tryLocalLogin(final boolean warnMultipleAccounts, boolean restoreSession) {
         //TODO: check username/password for emptiness
-        return tryLocalLogin(getUsername(), password.getText().toString(), warnMultipleAccounts);
+        return tryLocalLogin(getUsername(), password.getText().toString(), warnMultipleAccounts,
+                restoreSession);
     }
         
     private boolean tryLocalLogin(final String username, String password,
-                                  final boolean warnMultipleAccounts) {
+                                  final boolean warnMultipleAccounts, final boolean restoreSession) {
         try{
             // TODO: We don't actually even use this anymore other than for hte
             // local login count, which seems super silly.
@@ -402,7 +418,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
             ManageKeyRecordTask<LoginActivity> task =
                 new ManageKeyRecordTask<LoginActivity>(this, TASK_KEY_EXCHANGE,
                         username, password,
-                        CommCareApplication._().getCurrentApp(),
+                        CommCareApplication._().getCurrentApp(), restoreSession,
                         new ManageKeyRecordListener<LoginActivity>() {
 
                 @Override
@@ -504,7 +520,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
         switch(item.getItemId()) {
         case MENU_DEMO:
             DemoUserBuilder.build(this, CommCareApplication._().getCurrentApp());
-            tryLocalLogin(DemoUserBuilder.DEMO_USERNAME, DemoUserBuilder.DEMO_PASSWORD, false);
+            tryLocalLogin(DemoUserBuilder.DEMO_USERNAME, DemoUserBuilder.DEMO_PASSWORD, false ,false);
             return true;
         case MENU_ABOUT:
             DialogCreationHelpers.buildAboutCommCareDialog(this).show();
@@ -662,6 +678,13 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
 
         // Refresh welcome msg separately bc cannot set a single locale for its UiElement
         welcomeMessage.setText(Localization.get("login.welcome.multiple"));
+
+        // Update checkbox visibility 
+        if (DevSessionRestorer.savedSessionPresent()) {
+            restoreSessionCheckbox.setVisibility(View.VISIBLE);
+        } else {
+            restoreSessionCheckbox.setVisibility(View.GONE);
+        }
     }
 
     @Override
@@ -704,7 +727,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
                             CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(result));
                         }
 
-                        localLoginOrPullAndLogin();
+                        localLoginOrPullAndLogin(isRestoreSessionChecked());
                     }
 
                     @Override
@@ -721,15 +744,15 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
                                 Localization.get("login.update.install.failure"),
                                 Toast.LENGTH_LONG).show();
 
-                        localLoginOrPullAndLogin();
+                        localLoginOrPullAndLogin(isRestoreSessionChecked());
                     }
                 };
         task.connect(this);
         task.execute();
     }
 
-    private void localLoginOrPullAndLogin() {
-        if (tryLocalLogin(false)) {
+    private void localLoginOrPullAndLogin(boolean restoreSession) {
+        if (tryLocalLogin(false, restoreSession)) {
             return;
         }
 

--- a/app/src/org/commcare/dalvik/activities/MenuGrid.java
+++ b/app/src/org/commcare/dalvik/activities/MenuGrid.java
@@ -28,6 +28,7 @@ import android.widget.GridView;
 import org.commcare.android.adapters.GridMenuAdapter;
 import org.commcare.android.adapters.MenuAdapter;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SaveSessionCommCareActivity;
 import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.R;
@@ -50,7 +51,7 @@ import java.io.IOException;
  */
 
 @ManagedUi(R.layout.grid_menu_layout)
-public class MenuGrid extends SessionAwareCommCareActivity implements OnItemClickListener, OnItemLongClickListener {
+public class MenuGrid extends SaveSessionCommCareActivity implements OnItemClickListener, OnItemLongClickListener {
     
     private CommCarePlatform platform;
     

--- a/app/src/org/commcare/dalvik/activities/MenuGrid.java
+++ b/app/src/org/commcare/dalvik/activities/MenuGrid.java
@@ -29,7 +29,6 @@ import org.commcare.android.adapters.GridMenuAdapter;
 import org.commcare.android.adapters.MenuAdapter;
 import org.commcare.android.framework.ManagedUi;
 import org.commcare.android.framework.SaveSessionCommCareActivity;
-import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
@@ -153,4 +152,5 @@ public class MenuGrid extends SaveSessionCommCareActivity implements OnItemClick
         onBackPressed();
         return true;
     }
+
 }

--- a/app/src/org/commcare/dalvik/activities/MenuList.java
+++ b/app/src/org/commcare/dalvik/activities/MenuList.java
@@ -13,7 +13,6 @@ import org.commcare.android.adapters.MenuAdapter;
 import org.commcare.android.framework.BreadcrumbBarFragment;
 import org.commcare.android.framework.ManagedUi;
 import org.commcare.android.framework.SaveSessionCommCareActivity;
-import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
@@ -107,4 +106,5 @@ public class MenuList extends SaveSessionCommCareActivity implements OnItemClick
         onBackPressed();
         return true;
     }
+
 }

--- a/app/src/org/commcare/dalvik/activities/MenuList.java
+++ b/app/src/org/commcare/dalvik/activities/MenuList.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import org.commcare.android.adapters.MenuAdapter;
 import org.commcare.android.framework.BreadcrumbBarFragment;
 import org.commcare.android.framework.ManagedUi;
+import org.commcare.android.framework.SaveSessionCommCareActivity;
 import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.framework.UiElement;
 import org.commcare.dalvik.BuildConfig;
@@ -23,7 +24,7 @@ import org.commcare.suite.model.Menu;
 import org.commcare.util.CommCarePlatform;
 
 @ManagedUi(R.layout.screen_suite_menu)
-public class MenuList extends SessionAwareCommCareActivity implements OnItemClickListener {
+public class MenuList extends SaveSessionCommCareActivity implements OnItemClickListener {
 
     private MenuAdapter adapter;
 

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -249,14 +249,14 @@ public class CommCareApplication extends Application {
         c.startActivity(i);
     }
 
-    public void startUserSession(byte[] symetricKey, UserKeyRecord record) {
+    public void startUserSession(byte[] symetricKey, UserKeyRecord record, boolean restoreSession) {
         synchronized (serviceLock) {
             // if we already have a connection established to
             // CommCareSessionService, close it and open a new one
             if (this.mIsBound) {
                 releaseUserResourcesAndServices();
             }
-            bindUserSessionService(symetricKey, record);
+            bindUserSessionService(symetricKey, record, restoreSession);
         }
     }
 
@@ -837,7 +837,8 @@ public class CommCareApplication extends Application {
         }
     }
 
-    private void bindUserSessionService(final byte[] key, final UserKeyRecord record) {
+    private void bindUserSessionService(final byte[] key, final UserKeyRecord record,
+                                        final boolean restoreSession) {
         mConnection = new ServiceConnection() {
             public void onServiceConnected(ComponentName className, IBinder service) {
                 // This is called when the connection with the service has been
@@ -874,7 +875,7 @@ public class CommCareApplication extends Application {
                     if (user != null) {
                         mBoundService.startSession(user);
                         attachCallListener();
-                        if (DevSessionRestorer.autoLoginEnabled()) {
+                        if (restoreSession) {
                             CommCareApplication.this.sessionWrapper = DevSessionRestorer.restoreSessionFromPrefs(getCommCarePlatform());
                         } else {
                             CommCareApplication.this.sessionWrapper = new AndroidSessionWrapper(CommCareApplication.this.getCommCarePlatform());

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -16,6 +16,7 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import org.commcare.android.framework.SessionAwarePreferenceActivity;
+import org.commcare.android.session.DevSessionRestorer;
 import org.commcare.android.util.ChangeLocaleUtil;
 import org.commcare.android.util.CommCareUtil;
 import org.commcare.android.util.TemplatePrinterUtils;
@@ -96,6 +97,7 @@ public class CommCarePreferences
     private static final int FORCE_LOG_SUBMIT = Menu.FIRST + 1;
     private static final int RECOVERY_MODE = Menu.FIRST + 2;
     private static final int SUPERUSER_PREFS = Menu.FIRST + 3;
+    private static final int MENU_CLEAR_SAVED_SESSION = Menu.FIRST + 4;
 
     // Fields for setting print template
     private static final int REQUEST_TEMPLATE = 0;
@@ -166,6 +168,7 @@ public class CommCarePreferences
         super.onCreateOptionsMenu(menu);
         menu.add(0, CLEAR_USER_DATA, 0, "Clear User Data").setIcon(
                 android.R.drawable.ic_menu_delete);
+        menu.add(0, MENU_CLEAR_SAVED_SESSION, 1, Localization.get("menu.clear.saved.session"));
         menu.add(0, FORCE_LOG_SUBMIT, 2, "Force Log Submission").setIcon(
                 android.R.drawable.ic_menu_upload);
         menu.add(0, RECOVERY_MODE, 3, "Recovery Mode").setIcon(android.R.drawable.ic_menu_report_image);
@@ -177,6 +180,7 @@ public class CommCarePreferences
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         menu.findItem(SUPERUSER_PREFS).setVisible(DeveloperPreferences.isSuperuserEnabled());
+        menu.findItem(MENU_CLEAR_SAVED_SESSION).setVisible(DevSessionRestorer.savedSessionPresent());
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -197,6 +201,9 @@ public class CommCarePreferences
             case SUPERUSER_PREFS:
                 Intent intent = new Intent(this, DeveloperPreferences.class);
                 this.startActivity(intent);
+                return true;
+            case MENU_CLEAR_SAVED_SESSION:
+                DevSessionRestorer.clearSession();
                 return true;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
@@ -27,6 +27,8 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
      */
     public final static String ENABLE_AUTO_LOGIN = "cc-enable-auto-login";
 
+    public final static String ENABLE_SAVE_SESSION = "cc-enable-session-saving";
+
     /**
      * Does the user want to download the latest app version deployed (built),
      * not just the latest app version released (starred)?
@@ -58,9 +60,10 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals(ENABLE_AUTO_LOGIN) &&
-                (sharedPreferences.getString(ENABLE_AUTO_LOGIN, CommCarePreferences.NO).equals(CommCarePreferences.NO))) {
+        if (key.equals(ENABLE_AUTO_LOGIN) && !isAutoLoginEnabled()) {
             DevSessionRestorer.clearPassword(sharedPreferences);
+        } else if (key.equals(ENABLE_SAVE_SESSION) && !isSessionSavingEnabled()) {
+            DevSessionRestorer.clearSession();
         }
     }
 
@@ -150,6 +153,12 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean isAutoLoginEnabled() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
         return properties.getString(ENABLE_AUTO_LOGIN, CommCarePreferences.NO).equals(CommCarePreferences.YES);
+    }
+
+    public static boolean isSessionSavingEnabled() {
+        SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
+        return properties.getString(ENABLE_SAVE_SESSION, CommCarePreferences.NO).
+                equals(CommCarePreferences.YES);
     }
 
     public static boolean isMarkdownEnabled(){

--- a/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
@@ -61,7 +61,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         if (key.equals(ENABLE_AUTO_LOGIN) &&
                 (sharedPreferences.getString(ENABLE_AUTO_LOGIN, CommCarePreferences.NO).equals(CommCarePreferences.NO))) {
             DevSessionRestorer.clearPassword(sharedPreferences);
-            DevSessionRestorer.clearSession(sharedPreferences);
         }
     }
 

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -51,7 +51,6 @@ import android.widget.Toast;
 
 import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.SaveSessionCommCareActivity;
-import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.util.FormUploadUtil;
 import org.commcare.android.util.SessionUnavailableException;
@@ -179,10 +178,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private static final String KEY_FORM_LOAD_HAS_TRIGGERED = "newform";
     private static final String KEY_FORM_LOAD_FAILED = "form-failed";
 
-    private static final int MENU_LANGUAGES = Menu.FIRST;
-    private static final int MENU_HIERARCHY_VIEW = Menu.FIRST + 1;
-    private static final int MENU_SAVE = Menu.FIRST + 2;
-    private static final int MENU_PREFERENCES = Menu.FIRST + 3;
+    private static final int MENU_LANGUAGES = Menu.FIRST + 1;
+    private static final int MENU_HIERARCHY_VIEW = Menu.FIRST + 2;
+    private static final int MENU_SAVE = Menu.FIRST + 3;
+    private static final int MENU_PREFERENCES = Menu.FIRST + 4;
 
     public static final String NAV_STATE_NEXT = "next";
 

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -50,6 +50,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.commcare.android.framework.CommCareActivity;
+import org.commcare.android.framework.SaveSessionCommCareActivity;
 import org.commcare.android.framework.SessionAwareCommCareActivity;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.util.FormUploadUtil;
@@ -128,7 +129,7 @@ import javax.crypto.spec.SecretKeySpec;
  * 
  * @author Carl Hartung (carlhartung@gmail.com)
  */
-public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryActivity>
+public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActivity>
         implements AnimationListener, FormSavedListener, FormSaveCallback,
         AdvanceToNextListener, WidgetChangedListener {
     private static final String TAG = FormEntryActivity.class.getSimpleName();


### PR DESCRIPTION
Added:
-A checkbox on login screen to indicate if you want to restore the saved session (only visible if there is a session currently saved for that app)
-An item in the options menus of EntitySelectActivity, MenuItem, MenuGrid, and FormEntryActivity for saving the current session
-An item in the options menu of CommCarePreferences (very hidden) for clearing the saved session

@phillipm A couple of things:
1. Should we make the "Save Session" items in the menus only visible based on a developer setting flag? I'm loathe to keep it coupled with auto-login, but we could just make it its own flag really quick.
2. From quick testing, it seems like the session restorer can't take you back to an entity detail screen, it just takes you to the Entity Select screen immediately prior to that. That makes total sense because when there is an entity detail enabled, nothing gets added onto the session stack to represent entity selection until you press confirm on the detail screen. I think this is totally fine for now, just a heads up (I didn't put the Save Session menu item in EntityDetailActivity for this reason)