### PR TITLE
Fix progress dialog from being cut off

### DIFF
--- a/app/res/layout/progress_dialog_indeterminate.xml
+++ b/app/res/layout/progress_dialog_indeterminate.xml
@@ -2,8 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/progress_fragment_determinate"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:orientation="vertical" >
+    android:layout_height="wrap_content" >
 
     <include
         android:id="@+id/progress_dialog_title"
@@ -14,7 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/progress_dialog_title"
-        android:layout_marginBottom="@dimen/standard_spacer_large"
+        android:paddingBottom="@dimen/standard_spacer_large"
         android:layout_marginLeft="@dimen/standard_spacer_large"
         android:layout_marginRight="@dimen/standard_spacer_large" >
 
@@ -23,16 +22,13 @@
             style="?android:attr/progressBarStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="@dimen/standard_spacer"
-            android:visibility="visible"
-            android:layout_centerVertical="true" />
+            android:layout_marginRight="@dimen/standard_spacer" />
 
         <TextView
             android:id="@+id/progress_dialog_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toRightOf="@id/progress_bar"
-            android:layout_centerVertical="true"
             android:textSize="@dimen/font_size_dp_large" />
 
     </RelativeLayout>


### PR DESCRIPTION
On older phones, the bottom of progress dialogs with indeterminate progress bars was getting cut off. In fixing that, the dialog text is no longer centered vertically relative to the progress bar if it is a single line of text, and I can't figure out how to fix that (struggled with it for a while). But this is much better than before and don't want to keep sinking too much time into that for now.