### PR TITLE
Migrate fixtures to new serialization schema

### DIFF
--- a/app/src/org/commcare/android/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/android/database/app/AppDatabaseUpgrader.java
@@ -133,8 +133,9 @@ public class AppDatabaseUpgrader {
     }
 
     /**
-     * deserialize all user fixtures in db using old serialization scheme,
-     * and re-serialize them using the new scheme.
+     * Deserialize app fixtures in db using old form instance serialization
+     * scheme, and re-serialize them using the new scheme that preserves
+     * attributes.
      */
     private boolean upgradeSixSeven(SQLiteDatabase db) {
         return FixtureSerializationMigration.migrateFixtureDbBytes(db, context);

--- a/app/src/org/commcare/android/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/android/database/app/AppDatabaseUpgrader.java
@@ -6,6 +6,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.android.database.AndroidTableBuilder;
 import org.commcare.android.database.DbUtil;
+import org.commcare.android.database.migration.FixtureSerializationMigration;
 import org.commcare.android.resource.AndroidResourceManager;
 import org.commcare.resources.model.Resource;
 
@@ -13,10 +14,11 @@ import org.commcare.resources.model.Resource;
  * @author ctsims
  */
 public class AppDatabaseUpgrader {
-    private Context c;
 
-    public AppDatabaseUpgrader(Context c) {
-        this.c = c;
+    private final Context context;
+
+    public AppDatabaseUpgrader(Context context) {
+        this.context = context;
     }
 
     public void upgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
@@ -48,6 +50,11 @@ public class AppDatabaseUpgrader {
             }
         }
 
+        if (oldVersion == 6) {
+            if (upgradeSixSeven(db)) {
+                oldVersion = 7;
+            }
+        }
         //NOTE: If metadata changes are made to the Resource model, they need to be
         //managed by changing the TwoThree updater to maintain that metadata.
     }
@@ -123,5 +130,13 @@ public class AppDatabaseUpgrader {
         } finally {
             db.endTransaction();
         }
+    }
+
+    /**
+     * deserialize all user fixtures in db using old serialization scheme,
+     * and re-serialize them using the new scheme.
+     */
+    private boolean upgradeSixSeven(SQLiteDatabase db) {
+        return FixtureSerializationMigration.migrateFixtureDbBytes(db, context);
     }
 }

--- a/app/src/org/commcare/android/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/android/database/app/DatabaseAppOpenHelper.java
@@ -27,8 +27,9 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
      * V.4 - Table parent resource indices
      * V.5 - Added numbers table
      * V.6 - Added temporary upgrade table for ease of checking for new updates
+     * V.7 - Update serialized fixtures in db to use new schema
      */
-    private static final int DB_VERSION_APP = 6;
+    private static final int DB_VERSION_APP = 7;
 
     private static final String DB_LOCATOR_PREF_APP = "database_app_";
 

--- a/app/src/org/commcare/android/database/migration/FixtureSerializationMigration.java
+++ b/app/src/org/commcare/android/database/migration/FixtureSerializationMigration.java
@@ -20,8 +20,17 @@ import java.io.DataInputStream;
 import java.util.Vector;
 
 /**
- * Deserialize all fixtures in a db using old serialization scheme,
- * and re-serialize them using the new scheme.
+ * Deserialize all fixtures in a db using old form instance serialization
+ * scheme, and re-serialize them using the new scheme.
+ *
+ * The updated form instance serialization scheme provides more comprehensive
+ * handling of attributes, preserving datatypes, and other attributes across
+ * serializations.
+ *
+ * Used in app database migration V.7 and user database migration V.9
+ *
+ * This code becomes irrelevant once no more devices need to be migrated off of
+ * 2.24
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
@@ -53,6 +62,12 @@ public class FixtureSerializationMigration {
             db.setTransactionSuccessful();
             return true;
         } catch (Exception e) {
+            // Even if it failed, let the migration think it was successful,
+            // otherwise the app will crash. It's important to let user get to
+            // a point where they can sync data and then clear user data and
+            // restore, which ultimately has the same effect as running the
+            // fixture serialization migration.
+            db.setTransactionSuccessful();
             Logger.log(AndroidLogger.SOFT_ASSERT, "fixture serialization db migration failed");
             Logger.exception(e);
             return false;
@@ -67,7 +82,8 @@ public class FixtureSerializationMigration {
                 cur.close();
             }
             db.endTransaction();
-            Log.d(TAG, "Serialized fixture update complete in " + (System.currentTimeMillis() - start) + "ms");
+            long elapse = System.currentTimeMillis() - start;
+            Log.d(TAG, "Serialized fixture update complete in " + elapse + "ms");
         }
     }
 }

--- a/app/src/org/commcare/android/database/migration/FixtureSerializationMigration.java
+++ b/app/src/org/commcare/android/database/migration/FixtureSerializationMigration.java
@@ -1,0 +1,73 @@
+package org.commcare.android.database.migration;
+
+import android.content.Context;
+import android.util.Log;
+
+import net.sqlcipher.Cursor;
+import net.sqlcipher.database.SQLiteDatabase;
+
+import org.commcare.android.database.ConcreteAndroidDbHelper;
+import org.commcare.android.database.DbUtil;
+import org.commcare.android.database.SqlStorage;
+import org.commcare.android.javarosa.AndroidLogger;
+import org.commcare.dalvik.application.CommCareApplication;
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.storage.Persistable;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.Vector;
+
+/**
+ * Deserialize all fixtures in a db using old serialization scheme,
+ * and re-serialize them using the new scheme.
+ *
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class FixtureSerializationMigration {
+    private static final String TAG = FixtureSerializationMigration.class.getSimpleName();
+
+    public static boolean migrateFixtureDbBytes(SQLiteDatabase db, Context c) {
+        // Not sure how long this process should take, so tell the service to
+        // wait longer to make sure this can finish.
+        CommCareApplication._().setCustomServiceBindTimeout(60 * 5 * 1000);
+        long start = System.currentTimeMillis();
+        db.beginTransaction();
+        ConcreteAndroidDbHelper helper = new ConcreteAndroidDbHelper(c, db);
+        Cursor cur = null;
+        DataInputStream fixtureByteStream = null;
+        try {
+            SqlStorage<Persistable> userFixtureStorage =
+                    new SqlStorage<Persistable>("fixture", FormInstance.class, helper);
+            cur = db.query("fixture", new String[]{DbUtil.ID_COL}, null, null, null, null, null);
+            Vector<Integer> ids = SqlStorage.fillIdWindow(cur, DbUtil.ID_COL);
+            for (Integer id : ids) {
+                FormInstance fixture = new FormInstance();
+
+                fixtureByteStream =
+                        new DataInputStream(new ByteArrayInputStream(userFixtureStorage.readBytes(id)));
+                fixture.migrateSerialization(fixtureByteStream, helper.getPrototypeFactory());
+                userFixtureStorage.update(id, fixture);
+            }
+            db.setTransactionSuccessful();
+            return true;
+        } catch (Exception e) {
+            Logger.log(AndroidLogger.SOFT_ASSERT, "fixture serialization db migration failed");
+            Logger.exception(e);
+            return false;
+        } finally {
+            if (fixtureByteStream != null) {
+                try {
+                    fixtureByteStream.close();
+                } catch (Exception e) {
+                }
+            }
+            if (cur != null) {
+                cur.close();
+            }
+            db.endTransaction();
+            Log.d(TAG, "Serialized fixture update complete in " + (System.currentTimeMillis() - start) + "ms");
+        }
+    }
+}

--- a/app/src/org/commcare/android/database/user/CommCareUserOpenHelper.java
+++ b/app/src/org/commcare/android/database/user/CommCareUserOpenHelper.java
@@ -41,9 +41,10 @@ public class CommCareUserOpenHelper extends SQLiteOpenHelper {
      * V.7 - Case index models now maintain relationship types. Migration object
      * used to update DB
      * V.8 - Merge commcare-odk and commcare User, make AUser legacy type.
+     * V.9 - Update serialized fixtures in db to use new schema
      */
 
-    private static final int USER_DB_VERSION = 8;
+    private static final int USER_DB_VERSION = 9;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 
@@ -63,7 +64,6 @@ public class CommCareUserOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase database) {
-
         try {
             database.beginTransaction();
             

--- a/app/src/org/commcare/android/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/android/database/user/UserDatabaseUpgrader.java
@@ -11,6 +11,7 @@ import org.commcare.android.database.DbUtil;
 import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.SqlStorageIterator;
 import org.commcare.android.database.app.DatabaseAppOpenHelper;
+import org.commcare.android.database.migration.FixtureSerializationMigration;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.android.database.user.models.ACasePreV6Model;
 import org.commcare.android.database.user.models.AUser;
@@ -76,6 +77,11 @@ public class UserDatabaseUpgrader {
         if(oldVersion == 7) {
             if(upgradeSevenEight(db, oldVersion, newVersion)) {
                 oldVersion = 8;
+            }
+        }
+        if (oldVersion == 8) {
+            if (upgradeEightNine(db, oldVersion, newVersion)) {
+                oldVersion = 9;
             }
         }
     }
@@ -200,6 +206,14 @@ public class UserDatabaseUpgrader {
             db.endTransaction();
             Log.d(TAG, "Case model update complete in " + (System.currentTimeMillis() - start) + "ms");
         }
+    }
+
+    /**
+     * deserialize all user fixtures in db using old serialization scheme,
+     * and re-serialize them using the new scheme.
+     */
+    private boolean upgradeEightNine(SQLiteDatabase db, int oldVersion, int newVersion) {
+        return FixtureSerializationMigration.migrateFixtureDbBytes(db, c);
     }
 
     private void updateIndexes(SQLiteDatabase db) {

--- a/app/src/org/commcare/android/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/android/database/user/UserDatabaseUpgrader.java
@@ -209,8 +209,9 @@ public class UserDatabaseUpgrader {
     }
 
     /**
-     * deserialize all user fixtures in db using old serialization scheme,
-     * and re-serialize them using the new scheme.
+     * Deserialize user fixtures in db using old form instance serialization
+     * scheme, and re-serialize them using the new scheme that preserves
+     * attributes.
      */
     private boolean upgradeEightNine(SQLiteDatabase db, int oldVersion, int newVersion) {
         return FixtureSerializationMigration.migrateFixtureDbBytes(db, c);

--- a/app/src/org/commcare/dalvik/odk/provider/FormsProvider.java
+++ b/app/src/org/commcare/dalvik/odk/provider/FormsProvider.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2007 The Android Open Source Project
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.commcare.dalvik.odk.provider;
 
 import android.content.ContentProvider;
@@ -39,9 +25,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 
-/**
- * 
- */
 public class FormsProvider extends ContentProvider {
 
     private static final String t = "FormsProvider";
@@ -164,7 +147,6 @@ public class FormsProvider extends ContentProvider {
         }
     }
 
-
     @Override
     public Uri insert(Uri uri, ContentValues initialValues) {
         init();
@@ -234,10 +216,6 @@ public class FormsProvider extends ContentProvider {
 
         throw new SQLException("Failed to insert row into " + uri);
     }
-
-
-   
-
 
     /**
      * This method removes the entry from the content provider, and also removes any associated

--- a/app/src/org/commcare/dalvik/provider/FixtureDataAPI.java
+++ b/app/src/org/commcare/dalvik/provider/FixtureDataAPI.java
@@ -32,8 +32,7 @@ public class FixtureDataAPI {
     public static int UriMatch(Uri uri) {
         return sURIMatcher.match(uri);
     }
-    
-    
+
     /**
      * MetaData table for cases. Includes basic details like case type, ID, and name.
      * 
@@ -56,6 +55,5 @@ public class FixtureDataAPI {
         
         public static final String FIXTURE_ID = "instance_id";
         public static final String USER_ID = "user_id";
-        
     }
 }

--- a/app/src/org/commcare/dalvik/provider/FixtureDataContentProvider.java
+++ b/app/src/org/commcare/dalvik/provider/FixtureDataContentProvider.java
@@ -31,7 +31,6 @@ import java.io.IOException;
  * No write access is currently supported.
  * 
  * @author wspride
- *
  */
 public class FixtureDataContentProvider extends ContentProvider {
 
@@ -47,18 +46,17 @@ public class FixtureDataContentProvider extends ContentProvider {
         //Standard dispatcher following Android best practices
         int match = FixtureDataAPI.UriMatch(uri);
 
-        switch(match) {
-        case FixtureDataAPI.MetadataColumns.LIST_INSTANCE_ID:
-            return getFixtureNames();
-        case FixtureDataAPI.MetadataColumns.MATCH_INSTANCE_ID:
-            return getFixtureForId(uri.getLastPathSegment());
+        switch (match) {
+            case FixtureDataAPI.MetadataColumns.LIST_INSTANCE_ID:
+                return getFixtureNames();
+            case FixtureDataAPI.MetadataColumns.MATCH_INSTANCE_ID:
+                return getFixtureForId(uri.getLastPathSegment());
         }
         throw new IllegalArgumentException("URI: " + uri.toString() +" is not a valid content path for CommCare Case Data");
     }
 
     @Override
     public String getType(Uri uri) {
-
         int match = FixtureDataAPI.UriMatch(uri);
 
         switch(match) {
@@ -71,12 +69,10 @@ public class FixtureDataContentProvider extends ContentProvider {
         return null;
     }
     
-    /*
+    /**
      * Return a cursor over the list of all fixture IDs and names
      */
-
-    public Cursor getFixtureNames(){
-
+    private Cursor getFixtureNames() {
         MatrixCursor retCursor = new MatrixCursor(new String[] {FixtureDataAPI.MetadataColumns._ID, FixtureDataAPI.MetadataColumns.FIXTURE_ID});
 
         IStorageUtilityIndexed<FormInstance> userFixtureStorage = CommCareApplication._().getUserStorage("fixture", FormInstance.class);
@@ -88,15 +84,12 @@ public class FixtureDataContentProvider extends ContentProvider {
         }
 
         return retCursor;
-
     }
     
-    /*
+    /**
      * Return a cursor to the fixture associated with this id
      */
-    
-    public Cursor getFixtureForId(String instanceId){
-
+    private Cursor getFixtureForId(String instanceId){
         MatrixCursor retCursor = new MatrixCursor(new String[] {FixtureDataAPI.MetadataColumns._ID, FixtureDataAPI.MetadataColumns.FIXTURE_ID, "content"});
 
         IStorageUtilityIndexed<FormInstance> userFixtureStorage = CommCareApplication._().getUserStorage("fixture", FormInstance.class);
@@ -113,7 +106,7 @@ public class FixtureDataContentProvider extends ContentProvider {
 
                     DataModelSerializer s = new DataModelSerializer(bos, new AndroidInstanceInitializer(null));
 
-                    s.serialize((DataInstance)fi, fi.getRoot().getRef());
+                    s.serialize(fi, fi.getRoot().getRef());
 
                     String dump = new String(bos.toByteArray());
 
@@ -123,15 +116,15 @@ public class FixtureDataContentProvider extends ContentProvider {
             catch(IOException e){
                 e.printStackTrace();
             }
-
         }
 
         return retCursor;
-
     }
 
-    /** All of the below are invalid due to the read-only nature of the content provider. It's not 100% clear from spec how to express
-     * the read-only-ness. **/
+    /**
+     * All of the below are invalid due to the read-only nature of the content provider. It's not 100% clear from spec how to express
+     * the read-only-ness.
+     **/
 
     @Override
     public int update(Uri uri, ContentValues values, String selection,String[] selectionArgs) {


### PR DESCRIPTION
A bug came up in how TreeElements are serialized (fixed by https://github.com/dimagi/javarosa/pull/204). Since fixtures store serialized tree elements in a database, we need to do a database migration, otherwise fixtures won't load upon updating to CommCare 2.25

This PR performs the fixture db migration by (manually) loading the fixture instance from the db using the old serialization scheme and then serializing using the new scheme and updating the db.

cross-requested with https://github.com/dimagi/javarosa/pull/204 and https://github.com/dimagi/commcare/pull/215