### PR TITLE
Dismiss error dialog when the okay button is pressed

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -553,6 +553,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                             activity.setResult(RESULT_CANCELED);
                             activity.finish();
                         }
+                        dialog.dismiss();
                     }
                 };
         factory.setOnCancelListener(cancelListener);
@@ -567,6 +568,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                             activity.setResult(RESULT_CANCELED);
                             activity.finish();
                         }
+                        dialog.dismiss();
                     }
                 };
         factory.setPositiveButton(buttonDisplayText, buttonListener);


### PR DESCRIPTION
Pressing the OK button wasn't doing anything when the `shouldExit` param of `CommCareActivity.createErrorDialog` wasn't set.