### PR TITLE
Make EntityView child view IDs unique

### DIFF
--- a/app/src/org/commcare/android/view/EntityView.java
+++ b/app/src/org/commcare/android/view/EntityView.java
@@ -81,7 +81,7 @@ public class EntityView extends LinearLayout {
         for (int i = 0; i < views.length; ++i) {
             if (mHints[i] == null || !mHints[i].startsWith("0")) {
                 views[i] = initView(e.getField(i), forms[i], new ViewId(rowId, i, false), e.getSortField(i));
-                views[i].setId(i);
+                views[i].setId(AndroidUtil.generateViewId());
             }
         }
         refreshViewsForNewEntity(e, false, rowId);
@@ -116,7 +116,7 @@ public class EntityView extends LinearLayout {
                 LayoutParams l = new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT);
                 ViewId uniqueId = new ViewId(rowId, i, false);
                 views[i] = initView(headerText[i], headerForms[i], uniqueId, null);
-                views[i].setId(i);
+                views[i].setId(AndroidUtil.generateViewId());
                 if (colors[1] != -1) {
                     TextView tv = (TextView) views[i].findViewById(R.id.component_audio_text_txt);
                     if (tv != null) tv.setTextColor(colors[1]);


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?187729

@ctsims has context, but as explanation seems like there was an issue with view ids not being unique, so when you selected a case in awesome mode (which highlights that row, which triggers a redraw on the view) that row was re-added to the list in the wrong place (namely, as a child of the first row), causing that first row to expand in height and get distorted.

Putting in master because it's been broken since 2.23 and if the fix breaks anything, it'll likely be something obscure. Did some testing with scrolling case lists. Didn't get multimedia in case lists working (at all, not with this code applied), but I'm going to stop sinking time into this and let QA do its thing.