### PR TITLE
Fix for images providing too much padding in case lists

### DIFF
--- a/app/res/layout/entity_item_image.xml
+++ b/app/res/layout/entity_item_image.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" style="@style/EntityItemTextView" android:textAppearance="@style/EntityItemText">
+    android:layout_height="match_parent" style="@style/EntityItemImageView" android:textAppearance="@style/EntityItemText">
     
 
 </ImageView>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -70,6 +70,8 @@
 
     <dimen name="content_min_margin">16dp</dimen>
 
+    <dimen name="entity_item_image_margins">8dp</dimen>
+
     <dimen name="list_img_width">50dp</dimen>
     <dimen name="list_img_height">50dp</dimen>
 

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -40,6 +40,13 @@
         <item name="android:paddingBottom">@dimen/entity_padding</item>
         <item name="android:paddingRight">@dimen/entity_padding</item>
     </style>
+
+    <style name="EntityItemImageView">
+        <item name="android:paddingLeft">@dimen/entity_item_image_margins</item>
+        <item name="android:paddingTop">@dimen/entity_item_image_margins</item>
+        <item name="android:paddingBottom">@dimen/entity_item_image_margins</item>
+        <item name="android:paddingRight">@dimen/entity_item_image_margins</item>
+    </style>
     
     <style name="GridEntityItemTextView">
         <item name="android:paddingLeft">@dimen/grid_entity_padding</item>


### PR DESCRIPTION
Tested on a few screen sizes and it looked fine. Couldn't find a super super low density screen though

Old:
![icons](https://cloud.githubusercontent.com/assets/155066/11850219/f465c5e2-a3f9-11e5-9b41-c792c4283eee.jpg)

New
![lower_padding](https://cloud.githubusercontent.com/assets/155066/11850222/fb010024-a3f9-11e5-8420-3d32135ece5a.png)

ticket: http://manage.dimagi.com/default.asp?189511#1061324