### PR TITLE
Awesome autoselect

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -804,28 +804,15 @@ public class CommCareHomeActivity
         TreeReference contextRef = sessionNavigator.getCurrentAutoSelection();
         if (this.getString(R.string.panes).equals("two")
                 && getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            // Large tablet in landscape: send to entity select activity
+            // (awesome mode, with case pre-selected) instead of entity detail
             Intent i = getSelectIntent(session);
             String caseId = SessionDatum.getCaseIdFromReference(
                     contextRef, selectDatum, asw.getEvaluationContext());
             i.putExtra(EntitySelectActivity.EXTRA_ENTITY_KEY, caseId);
             startActivityForResult(i, GET_CASE);
         } else {
-            //jls
-        /*
-
-        detailIntent.putExtra(SessionFrame.STATE_DATUM_VAL, caseId);
-
-        // Include long datum info if present
-        if (selectDatum.getLongDetail() != null) {
-            detailIntent.putExtra(EntityDetailActivity.DETAIL_ID,
-                    selectDatum.getLongDetail());
-            detailIntent.putExtra(EntityDetailActivity.DETAIL_PERSISTENT_ID,
-                    selectDatum.getPersistentDetail());
-        }
-
-        SerializationUtil.serializeToIntent(detailIntent,
-                EntityDetailActivity.CONTEXT_REFERENCE, contextRef);
-         */
+            // Launch entity detail activity
             Intent detailIntent = new Intent(getApplicationContext(), EntityDetailActivity.class);
             EntitySelectActivity.populateDetailIntent(
                     detailIntent, contextRef, selectDatum, asw);

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -8,6 +8,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -67,6 +68,7 @@ import org.commcare.suite.model.StackFrameStep;
 import org.commcare.suite.model.Text;
 import org.javarosa.core.model.User;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.xpath.XPathTypeMismatchException;
@@ -780,6 +782,10 @@ public class CommCareHomeActivity
     }
 
     private void launchEntitySelect(CommCareSession session) {
+        startActivityForResult(getSelectIntent(session), GET_CASE);
+    }
+
+    private Intent getSelectIntent(CommCareSession session) {
         Intent i = new Intent(getApplicationContext(), EntitySelectActivity.class);
         i.putExtra(SessionFrame.STATE_COMMAND_ID, session.getCommand());
         StackFrameStep lastPopped = session.getPoppedStep();
@@ -788,19 +794,45 @@ public class CommCareHomeActivity
         }
         addPendingDataExtra(i, session);
         addPendingDatumIdExtra(i, session);
-        startActivityForResult(i, GET_CASE);
+        return i;
     }
 
     // Launch an intent to load the confirmation screen for the current selection
     private void launchConfirmDetail(AndroidSessionWrapper asw) {
         CommCareSession session = asw.getSession();
         SessionDatum selectDatum = session.getNeededDatum();
-        Intent detailIntent = new Intent(getApplicationContext(), EntityDetailActivity.class);
-        EntitySelectActivity.populateDetailIntent(
-                detailIntent, sessionNavigator.getCurrentAutoSelection(), selectDatum, asw);
-        addPendingDataExtra(detailIntent, session);
-        addPendingDatumIdExtra(detailIntent, session);
-        startActivityForResult(detailIntent, GET_CASE);
+        TreeReference contextRef = sessionNavigator.getCurrentAutoSelection();
+        if (this.getString(R.string.panes).equals("two")
+                && getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            Intent i = getSelectIntent(session);
+            String caseId = SessionDatum.getCaseIdFromReference(
+                    contextRef, selectDatum, asw.getEvaluationContext());
+            i.putExtra(EntitySelectActivity.EXTRA_ENTITY_KEY, caseId);
+            startActivityForResult(i, GET_CASE);
+        } else {
+            //jls
+        /*
+
+        detailIntent.putExtra(SessionFrame.STATE_DATUM_VAL, caseId);
+
+        // Include long datum info if present
+        if (selectDatum.getLongDetail() != null) {
+            detailIntent.putExtra(EntityDetailActivity.DETAIL_ID,
+                    selectDatum.getLongDetail());
+            detailIntent.putExtra(EntityDetailActivity.DETAIL_PERSISTENT_ID,
+                    selectDatum.getPersistentDetail());
+        }
+
+        SerializationUtil.serializeToIntent(detailIntent,
+                EntityDetailActivity.CONTEXT_REFERENCE, contextRef);
+         */
+            Intent detailIntent = new Intent(getApplicationContext(), EntityDetailActivity.class);
+            EntitySelectActivity.populateDetailIntent(
+                    detailIntent, contextRef, selectDatum, asw);
+            addPendingDataExtra(detailIntent, session);
+            addPendingDatumIdExtra(detailIntent, session);
+            startActivityForResult(detailIntent, GET_CASE);
+        }
     }
 
     private static void addPendingDataExtra(Intent i, CommCareSession session) {

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -964,6 +964,7 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity
         adapter.registerDataSetObserver(this.mListStateObserver);
         containerFragment.setData(adapter);
 
+        // Pre-select entity if one was provided in original intent
         if (!resuming && !mNoDetailMode && this.getIntent().hasExtra(EXTRA_ENTITY_KEY)) {
             TreeReference entity =
                     selectDatum.getEntityFromID(asw.getEvaluationContext(),

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -964,6 +964,22 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity
         adapter.registerDataSetObserver(this.mListStateObserver);
         containerFragment.setData(adapter);
 
+        if (!resuming && !mNoDetailMode && this.getIntent().hasExtra(EXTRA_ENTITY_KEY)) {
+            TreeReference entity =
+                    selectDatum.getEntityFromID(asw.getEvaluationContext(),
+                            this.getIntent().getStringExtra(EXTRA_ENTITY_KEY));
+
+            if (entity != null) {
+                if (inAwesomeMode) {
+                    if (adapter != null) {
+                        displayReferenceAwesome(entity, adapter.getPosition(entity));
+                        adapter.setAwesomeMode(true);
+                        updateSelectedItem(entity, true);
+                    }
+                }
+            }
+        }
+
         findViewById(R.id.entity_select_loading).setVisibility(View.GONE);
 
         if (adapter != null && filterString != null && !"".equals(filterString)) {

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -965,19 +965,15 @@ public class EntitySelectActivity extends SessionAwareCommCareActivity
         containerFragment.setData(adapter);
 
         // Pre-select entity if one was provided in original intent
-        if (!resuming && !mNoDetailMode && this.getIntent().hasExtra(EXTRA_ENTITY_KEY)) {
+        if (!resuming && !mNoDetailMode && inAwesomeMode && this.getIntent().hasExtra(EXTRA_ENTITY_KEY)) {
             TreeReference entity =
                     selectDatum.getEntityFromID(asw.getEvaluationContext(),
                             this.getIntent().getStringExtra(EXTRA_ENTITY_KEY));
 
             if (entity != null) {
-                if (inAwesomeMode) {
-                    if (adapter != null) {
-                        displayReferenceAwesome(entity, adapter.getPosition(entity));
-                        adapter.setAwesomeMode(true);
-                        updateSelectedItem(entity, true);
-                    }
-                }
+                displayReferenceAwesome(entity, adapter.getPosition(entity));
+                adapter.setAwesomeMode(true);
+                updateSelectedItem(entity, true);
             }
         }
 


### PR DESCRIPTION
@ctsims 

Not much code, but I don't like having the awesome mode conditional in CommCareHomeActivity. Could simplify this PR by removing the pre-select logic I added to EntitySelectActivity.

Bug was that when CommCareHomeActivity detected the autoselect and launched an EntityDetailActivity, that detail activity would be immediately canceled because of this logic: https://github.com/dimagi/commcare-odk/blob/master/app/src/org/commcare/dalvik/activities/EntityDetailActivity.java#L109-L117