### PR TITLE
Make secondary y axis respect show-axes configuration

### DIFF
--- a/app/src/org/commcare/android/view/c3/AxisConfiguration.java
+++ b/app/src/org/commcare/android/view/c3/AxisConfiguration.java
@@ -27,10 +27,6 @@ public class AxisConfiguration extends Configuration {
             x.put("type", "timeseries");
         }
 
-        // Display secondary y axis, regardless of if it has data; this makes the
-        // whitespace around the graph look more reasonable. X and primary Y axis show by default.
-        y2.put("show", true);
-
         mConfiguration.put("x", x);
         mConfiguration.put("y", y);
         mConfiguration.put("y2", y2);
@@ -185,6 +181,11 @@ public class AxisConfiguration extends Configuration {
 
         JSONObject config = new JSONObject();
         boolean isX = prefix.equals("x");
+        
+        // X and primary Y axis show by default, but not secondary y. Force them all to show.
+        // Display secondary y axis, regardless of if it has data; this makes the
+        // whitespace around the graph look more reasonable.
+        config.put("show", true);
 
         // Undo C3's automatic axis padding
         config.put("padding", new JSONObject("{top: 0, right: 0, bottom: 0, left: 0}"));


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?189509

Putting in 2.25 after all because the bug turns out to not be specific to case list graphs and it's a tiny graphing-only change. That said, I don't know of anyone actually using `show-axes`.