### PR TITLE
Move dialog fragment transition to onResumeFragments

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -248,12 +248,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     protected void onResume() {
         super.onResume();
 
-        activityPaused = false;
-
-        if (dialogId > -1) {
-            startBlockingForTask(dialogId);
-        }
-
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
             // In honeycomb and above the fragment takes care of this
             this.setTitle(getTitle(this, getActivityTitle()));
@@ -265,6 +259,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     @Override
     protected void onResumeFragments() {
         super.onResumeFragments();
+
+        activityPaused = false;
+
+        if (dialogId > -1) {
+            startBlockingForTask(dialogId);
+        }
 
         showPendingAlertDialog();
     }


### PR DESCRIPTION
Hopefully fix another `java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState` crash by moving more dialog fragment code into `onResumeFragments` from out of `onResume`

https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/6d03fcbc58994b14d98a425d156d1819