### PR TITLE
Only start task progress dialogs once

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -83,7 +83,13 @@ public abstract class CommCareActivity<R> extends FragmentActivity
      * Activity has been put in the background. Flag prevents dialogs
      * from being shown while activity isn't active.
      */
-    private boolean activityPaused;
+    private boolean areFragmentsPaused;
+
+    /**
+     * Mark when task tried to show progress dialog before fragments have resumed,
+     * so that the dialog can be shown when fragments have fully resumed.
+     */
+    private boolean triedBlockingWhilePaused;
 
     /**
      * Store the id of a task progress dialog so it can be disabled/enabled
@@ -253,11 +259,9 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     protected void onResumeFragments() {
         super.onResumeFragments();
 
-        activityPaused = false;
+        areFragmentsPaused = false;
 
-        if (dialogId > -1) {
-            startBlockingForTask(dialogId);
-        }
+        syncTaskBlockingWithDialogFragment();
 
         showPendingAlertDialog();
     }
@@ -270,7 +274,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             managedUiState.setData(ManagedUiFramework.saveUiStateToBundle(this));
         }
 
-        activityPaused = true;
+        areFragmentsPaused = true;
         AudioController.INSTANCE.systemInducedPause();
     }
 
@@ -294,7 +298,22 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     protected int getWakeLockLevel() {
         return CommCareTask.DONT_WAKELOCK;
     }
-    
+
+    /**
+     * Sync progress dialog fragment with any task state changes that may have
+     * occurred while the activity was paused.
+     */
+    private void syncTaskBlockingWithDialogFragment() {
+        if (dialogId < 0) {
+            // A task may have finished while paused so blindly try
+            // dismissing the progress dialog fragment.
+            dismissProgressDialog();
+        } else if (triedBlockingWhilePaused) {
+            triedBlockingWhilePaused = false;
+            showNewProgressDialog();
+        }
+    }
+
     /*
      * Override these to control the UI for your task
      */
@@ -303,25 +322,30 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public void startBlockingForTask(int id) {
         dialogId = id;
 
-        if (activityPaused) {
-            // don't show the dialog if the activity is in the background
-            return;
+        if (areFragmentsPaused) {
+            // post-pone dialog transactions until after fragments have fully resumed.
+            triedBlockingWhilePaused = true;
+        } else {
+            showNewProgressDialog();
         }
+    }
 
+    private void showNewProgressDialog() {
         // attempt to dismiss the dialog from the last task before showing this
         // one
         attemptDismissDialog();
 
         // ONLY if shouldDismissDialog = true, i.e. if we chose to dismiss the
         // last dialog during transition, show a new one
-        if (id >= 0 && shouldDismissDialog) {
-            this.showProgressDialog(id);
+        if (shouldDismissDialog) {
+            showProgressDialog(dialogId);
         }
     }
 
     @Override
     public void stopBlockingForTask(int id) {
         dialogId = -1;
+
         if (id >= 0) {
             if (inTaskTransition) {
                 shouldDismissDialog = true;
@@ -557,9 +581,11 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     @Override
     public void showProgressDialog(int taskId) {
-        CustomProgressDialog dialog = generateProgressDialog(taskId);
-        if (dialog != null) {
-            dialog.show(getSupportFragmentManager(), KEY_PROGRESS_DIALOG_FRAG);
+        if (taskId >= 0) {
+            CustomProgressDialog dialog = generateProgressDialog(taskId);
+            if (dialog != null) {
+                dialog.show(getSupportFragmentManager(), KEY_PROGRESS_DIALOG_FRAG);
+            }
         }
     }
 
@@ -572,8 +598,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     @Override
     public void dismissProgressDialog() {
         CustomProgressDialog progressDialog = getCurrentProgressDialog();
-        if (progressDialog != null && progressDialog.isAdded()) {
-            progressDialog.dismissAllowingStateLoss();
+        if (!areFragmentsPaused && progressDialog != null && progressDialog.isAdded()) {
+            progressDialog.dismiss();
         }
     }
 
@@ -604,7 +630,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             return;
         }
         AlertDialogFragment dialog = AlertDialogFragment.fromFactory(f);
-        if (activityPaused) {
+        if (areFragmentsPaused) {
             dialogToShowOnResume = dialog;
         } else {
             dialog.show(getSupportFragmentManager(), KEY_ALERT_DIALOG_FRAG);
@@ -795,7 +821,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
      * Activity has been put in the background. Useful in knowing when to not
      * perform dialog or fragment transactions
      */
-    protected boolean isActivityPaused() {
-        return activityPaused;
+    protected boolean areFragmentsPaused() {
+        return areFragmentsPaused;
     }
 }

--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -68,12 +68,13 @@ public abstract class CommCareTask<A, B, C, R> extends ManagedAsyncTask<A, B, C>
     @Override
     protected void onPostExecute(C result) {
         super.onPostExecute(result);
+
         synchronized (connectorLock) {
             //TODO: extend blocking here?
             CommCareTaskConnector<R> connector = getConnector();
             if (connector != null) {
                 connector.startTaskTransition();
-                connector.stopBlockingForTask(getTaskId());
+                connector.stopBlockingForTask(taskId);
                 if (unknownError != null) {
                     deliverError(connector.getReceiver(), unknownError);
                     return;

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -246,7 +246,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     }
 
     private void uiStateScreenTransition() {
-        if (isActivityPaused()) {
+        if (areFragmentsPaused()) {
             // Don't perform fragment transactions when the activity isn't visible
             return;
         }


### PR DESCRIPTION
https://github.com/dimagi/commcare-odk/pull/924 introduced a bug where form load progress dialogs were not dismissed upon form load completion. I think this bug was being caused by multiple calls to `startBlockingForTask`, once when the task starts and once on `CommCareActivity.onResumeFragments`.

The fix in this PR is to introduce `syncTaskBlockingWithDialogFragment` and call it in `CommCareActivity.onResumeFragments`. Its behavior performs any progress dialog transactions relating task changes that occurred while the activity was in the background.