### PR TITLE
Skip setSortData if entity isn't cached

### DIFF
--- a/app/src/org/commcare/android/models/AsyncNodeEntityFactory.java
+++ b/app/src/org/commcare/android/models/AsyncNodeEntityFactory.java
@@ -152,8 +152,9 @@ public class AsyncNodeEntityFactory extends NodeEntityFactory {
             String entityId = walker.getString(walker.getColumnIndex("entity_key"));
             String cacheId = walker.getString(walker.getColumnIndex("cache_key"));
             String val = walker.getString(walker.getColumnIndex("value"));
-            AsyncEntity entity = this.mEntitySet.get(entityId);
-            entity.setSortData(cacheId, val);
+            if (this.mEntitySet.containsKey(entityId)) {
+                this.mEntitySet.get(entityId).setSortData(cacheId, val);
+            }
         }
         walker.close();
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?184603

Not sure if the entity not being in the cache is itself a bug.

@ctsims 