### PR TITLE
Downgrade httpmime to android compat version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     compile 'net.sf.kxml:kxml2:2.3.0'
     compile 'net.zetetic:android-database-sqlcipher:3.3.1-2@aar'
     compile 'org.apache.james:apache-mime4j:0.7.2'
-    compile('org.apache.httpcomponents:httpmime:4.5.1') {
+    compile('org.apache.httpcomponents:httpmime:4.3.6') {
         exclude module: 'httpclient'
     }
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5.1'


### PR DESCRIPTION
https://github.com/dimagi/commcare-odk/pull/934 bumped the httpmime version from 4.0 to 4.5.1. Turns out 4.5.1 isn't compatible with android, which was causing CommCare to crash when trying to submit forms.

Downgrade httpmime to 4.3.6, which is android compatible.
