### PR TITLE
Stop using CommCareWiFiDirectActivity.TAG outside of CommCareWiFiDirectActivity

### DIFF
--- a/app/src/org/commcare/android/framework/DeviceDetailFragment.java
+++ b/app/src/org/commcare/android/framework/DeviceDetailFragment.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.commcare.android.framework;
 
 import android.annotation.SuppressLint;
@@ -38,6 +22,7 @@ import org.commcare.dalvik.activities.CommCareWiFiDirectActivity;
  */
 @SuppressLint("NewApi")
 public class DeviceDetailFragment extends Fragment implements ConnectionInfoListener {
+    private static final String TAG = DeviceDetailFragment.class.getSimpleName();
 
     protected static final int CHOOSE_FILE_RESULT_CODE = 1;
     private View mContentView = null;
@@ -62,7 +47,7 @@ public class DeviceDetailFragment extends Fragment implements ConnectionInfoList
 
     @Override
     public void onConnectionInfoAvailable(final WifiP2pInfo info) {
-        Log.d(CommCareWiFiDirectActivity.TAG, "onConnectionInfoAvailable");
+        Log.d(TAG, "onConnectionInfoAvailable");
         if (progressDialog != null && progressDialog.isShowing()) {
             progressDialog.dismiss();
         }
@@ -76,7 +61,7 @@ public class DeviceDetailFragment extends Fragment implements ConnectionInfoList
      * @param device the device to be displayed 
      */
     public void showDetails(WifiP2pDevice device) {
-        Log.d(CommCareWiFiDirectActivity.TAG, "showing details in ddfragment with device: " +device.deviceAddress );
+        Log.d(TAG, "showing details in ddfragment with device: " +device.deviceAddress );
         this.device = device;
         this.getView().setVisibility(View.VISIBLE);
         TextView view = (TextView) mContentView.findViewById(R.id.device_address);
@@ -88,7 +73,7 @@ public class DeviceDetailFragment extends Fragment implements ConnectionInfoList
      * Clears the UI fields after a disconnect or direct mode disable operation.
      */
     public void resetViews() {
-        Log.d(CommCareWiFiDirectActivity.TAG, "resetting views");
+        Log.d(TAG, "resetting views");
         mContentView.findViewById(R.id.btn_connect).setVisibility(View.VISIBLE);
         TextView view = (TextView) mContentView.findViewById(R.id.device_address);
         view.setText("");

--- a/app/src/org/commcare/android/framework/DeviceListFragment.java
+++ b/app/src/org/commcare/android/framework/DeviceListFragment.java
@@ -31,8 +31,9 @@ import java.util.List;
  */
 @SuppressLint("NewApi")
 public class DeviceListFragment extends ListFragment implements PeerListListener {
+    private static final String TAG = DeviceListFragment.class.getSimpleName();
 
-    private List<WifiP2pDevice> peers = new ArrayList<WifiP2pDevice>();
+    private List<WifiP2pDevice> peers = new ArrayList<>();
     ProgressDialog progressDialog = null;
     View mContentView = null;
     private WifiP2pDevice device;
@@ -46,7 +47,7 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        Log.d(CommCareWiFiDirectActivity.TAG, "onCreateView DeviceListFragment");
+        Log.d(TAG, "onCreateView DeviceListFragment");
         mContentView = inflater.inflate(R.layout.device_list, container);
         return mContentView;
     }
@@ -59,7 +60,7 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
     }
 
     public static String getDeviceStatus(int deviceStatus) {
-        Log.d(CommCareWiFiDirectActivity.TAG, "Peer status :" + deviceStatus);
+        Log.d(TAG, "Peer status :" + deviceStatus);
         switch (deviceStatus) {
             case WifiP2pDevice.AVAILABLE:
                 return "Available";
@@ -82,9 +83,9 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
      */
     @Override
     public void onListItemClick(ListView l, View v, int position, long id) {
-        Log.d(CommCareWiFiDirectActivity.TAG, "onListItemClick");
+        Log.d(TAG, "onListItemClick");
         WifiP2pDevice device = (WifiP2pDevice) getListAdapter().getItem(position);
-        Log.d(CommCareWiFiDirectActivity.TAG, "device is: " + device.deviceAddress);
+        Log.d(TAG, "device is: " + device.deviceAddress);
         //((DeviceActionListener) getActivity()).showDetails(device);
         
         WifiP2pConfig config = new WifiP2pConfig();
@@ -145,7 +146,7 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
      * @param device WifiP2pDevice object
      */
     public void updateThisDevice(WifiP2pDevice device) {
-         Log.d(CommCareWiFiDirectActivity.TAG, "updating my device: " + device.deviceName + " with status: " + device.status);
+         Log.d(TAG, "updating my device: " + device.deviceName + " with status: " + device.status);
         this.device = device;
         TextView view = (TextView) mContentView.findViewById(R.id.my_name);
         view.setText(device.deviceName);
@@ -155,7 +156,7 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
 
     @Override
     public void onPeersAvailable(WifiP2pDeviceList peerList) {
-        Log.d(CommCareWiFiDirectActivity.TAG, "onPeersAvailable");
+        Log.d(TAG, "onPeersAvailable");
         if (progressDialog != null && progressDialog.isShowing()) {
             progressDialog.dismiss();
         }
@@ -163,7 +164,7 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
         peers.addAll(peerList.getDeviceList());
         ((WiFiPeerListAdapter) getListAdapter()).notifyDataSetChanged();
         if (peers.size() == 0) {
-            Log.d(CommCareWiFiDirectActivity.TAG, "No devices found");
+            Log.d(TAG, "No devices found");
             return;
         }
 
@@ -175,7 +176,7 @@ public class DeviceListFragment extends ListFragment implements PeerListListener
     }
 
     public void onInitiateDiscovery() {
-        Log.d(CommCareWiFiDirectActivity.TAG, "onInitiateDiscovery");
+        Log.d(TAG, "onInitiateDiscovery");
         if (progressDialog != null && progressDialog.isShowing()) {
             progressDialog.dismiss();
         }

--- a/app/src/org/commcare/android/framework/FileServerFragment.java
+++ b/app/src/org/commcare/android/framework/FileServerFragment.java
@@ -30,6 +30,7 @@ import java.net.Socket;
  */
 @SuppressLint("NewApi")
 public class FileServerFragment extends Fragment {
+    private static final String TAG = FileServerFragment.class.getSimpleName();
     private View mContentView = null;
 
     private static CommCareWiFiDirectActivity mActivity;
@@ -74,7 +75,7 @@ public class FileServerFragment extends Fragment {
     }
 
     public void startServer(String mReceiveZipDirectory) {
-        Logger.log(CommCareWiFiDirectActivity.TAG, "File Server starting...");
+        Logger.log(TAG, "File Server starting...");
 
         mStatusText.setText("Starting server");
 
@@ -107,7 +108,7 @@ public class FileServerFragment extends Fragment {
         private boolean socketOccupied;
 
         public FileServerAsyncTask(FileServerFragment mListener) {
-            Log.d(CommCareWiFiDirectActivity.TAG, "new fileasync task");
+            Log.d(TAG, "new fileasync task");
             this.mListener = mListener;
 
         }
@@ -115,7 +116,7 @@ public class FileServerFragment extends Fragment {
         @Override
         protected String doInBackground(Void... params) {
 
-            Logger.log(CommCareWiFiDirectActivity.TAG, "doing in background");
+            Logger.log(TAG, "doing in background");
             socketOccupied = false;
 
             try {
@@ -128,9 +129,9 @@ public class FileServerFragment extends Fragment {
 
                     Socket client = serverSocket.accept();
 
-                    Logger.log(CommCareWiFiDirectActivity.TAG, "Ready in wi-fi direct file server receive loop");
+                    Logger.log(TAG, "Ready in wi-fi direct file server receive loop");
 
-                    Log.d(CommCareWiFiDirectActivity.TAG, "server: copying files " + finalFileName);
+                    Log.d(TAG, "server: copying files " + finalFileName);
 
                     final File f = new File(finalFileName);
 
@@ -140,7 +141,7 @@ public class FileServerFragment extends Fragment {
 
                     f.createNewFile();
 
-                    Log.d(CommCareWiFiDirectActivity.TAG, "server: copying files " + f.toString());
+                    Log.d(TAG, "server: copying files " + f.toString());
                     InputStream inputstream = client.getInputStream();
                     CommCareWiFiDirectActivity.copyFile(inputstream, new FileOutputStream(f));
                     serverSocket.close();
@@ -149,7 +150,7 @@ public class FileServerFragment extends Fragment {
                     return f.getAbsolutePath();
 
                 } catch (IOException e) {
-                    Log.e(CommCareWiFiDirectActivity.TAG, e.getMessage());
+                    Log.e(TAG, e.getMessage());
                     final File f = new File(finalFileName);
                     if (f.exists()) {
                         FileUtil.deleteFileOrDir(f);
@@ -161,7 +162,7 @@ public class FileServerFragment extends Fragment {
                 }
             } catch (IOException ioe) {
                 publishProgress("Ready to accept new file transfer.", null);
-                Logger.log(CommCareWiFiDirectActivity.TAG, "couldn't open socket!");
+                Logger.log(TAG, "couldn't open socket!");
                 socketOccupied = true;
                 return null;
             }
@@ -169,23 +170,23 @@ public class FileServerFragment extends Fragment {
 
         @Override
         protected void onPostExecute(String result) {
-            Log.e(CommCareWiFiDirectActivity.TAG, "file server task post execute");
+            Log.e(TAG, "file server task post execute");
 
             if (socketOccupied) {
-                Logger.log(CommCareWiFiDirectActivity.TAG, "socket busy, cancelling this thread cycle");
+                Logger.log(TAG, "socket busy, cancelling this thread cycle");
                 return;
             }
 
             if (result != null) {
                 mActivity.onFormsCopied(result);
             }
-            Logger.log(CommCareWiFiDirectActivity.TAG, "file server post-execute, relaunching server");
+            Logger.log(TAG, "file server post-execute, relaunching server");
             mListener.startServer(receiveZipDirectory);
         }
 
         @Override
         protected void onPreExecute() {
-            Logger.log(CommCareWiFiDirectActivity.TAG, "pre-execute of file server launch");
+            Logger.log(TAG, "pre-execute of file server launch");
             // statusText.setText("Opening a server socket");
         }
 

--- a/app/src/org/commcare/android/framework/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/android/framework/WiFiDirectManagementFragment.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.commcare.android.framework;
 
 import android.annotation.SuppressLint;
@@ -47,6 +31,7 @@ import org.javarosa.core.services.Logger;
 @SuppressLint("NewApi")
 public class WiFiDirectManagementFragment extends Fragment
         implements ConnectionInfoListener, ActionListener, ChannelListener {
+    private static final String TAG = WiFiDirectManagementFragment.class.getSimpleName();
     private static CommCareWiFiDirectActivity mActivity;
 
     private TextView mStatusText;
@@ -97,18 +82,18 @@ public class WiFiDirectManagementFragment extends Fragment
     }
 
     public void onPeersChanged() {
-        Logger.log(CommCareWiFiDirectActivity.TAG, "Wi-fi direct peers changed");
+        Logger.log(TAG, "Wi-fi direct peers changed");
         mActivity.updatePeers();
     }
 
     public void onP2PConnectionChanged(boolean isConnected) {
         if (isConnected) {
 
-            Logger.log(CommCareWiFiDirectActivity.TAG, "Wifi direct P2P connection changed");
+            Logger.log(TAG, "Wifi direct P2P connection changed");
 
             // we are connected with the other device, request connection
             // info to find group owner IP
-            Log.d(CommCareWiFiDirectActivity.TAG, "requesting connection info activity");
+            Log.d(TAG, "requesting connection info activity");
             mManager.requestConnectionInfo(mChannel, this);
         } else {
             setDeviceConnected(false);
@@ -125,7 +110,7 @@ public class WiFiDirectManagementFragment extends Fragment
         int status = mDevice.status;
 
         if (status == WifiP2pDevice.AVAILABLE && isHost) {
-            Logger.log(CommCareWiFiDirectActivity.TAG, "Relaunching Wi-fi direct group as host");
+            Logger.log(TAG, "Relaunching Wi-fi direct group as host");
             setStatusText("Host relaunching group...");
             mManager.createGroup(mChannel, this);
         }
@@ -141,7 +126,7 @@ public class WiFiDirectManagementFragment extends Fragment
     }
 
     public void resetConnectionGroup() {
-        Logger.log(CommCareWiFiDirectActivity.TAG, "restting connection group");
+        Logger.log(TAG, "restting connection group");
         mManager.removeGroup(mChannel, this);
     }
 
@@ -151,7 +136,7 @@ public class WiFiDirectManagementFragment extends Fragment
     }
 
     public void setIsHost(boolean isHost) {
-        Logger.log(CommCareWiFiDirectActivity.TAG, "setting is host: " + isHost);
+        Logger.log(TAG, "setting is host: " + isHost);
         this.isHost = isHost;
         refreshStatusText();
     }
@@ -165,7 +150,7 @@ public class WiFiDirectManagementFragment extends Fragment
     }
 
     public void startReceiver(WifiP2pManager mManager, Channel mChannel, WiFiDirectBroadcastReceiver mReceiver) {
-        Logger.log(CommCareWiFiDirectActivity.TAG, "Starting receiver");
+        Logger.log(TAG, "Starting receiver");
         this.mReceiver = mReceiver;
         this.mChannel = mChannel;
         this.mManager = mManager;
@@ -222,7 +207,7 @@ public class WiFiDirectManagementFragment extends Fragment
     }
 
     public void setStatusText(String text) {
-        Log.d(CommCareWiFiDirectActivity.TAG, text);
+        Log.d(TAG, text);
         mStatusText.setText(text);
     }
 

--- a/app/src/org/commcare/android/tasks/FormTransferTask.java
+++ b/app/src/org/commcare/android/tasks/FormTransferTask.java
@@ -39,10 +39,10 @@ public abstract class FormTransferTask extends CommCareTask<String, String, Bool
     }
     
     public InputStream getFormInputStream(String fPath) throws FileNotFoundException{
-        Log.d(CommCareWiFiDirectActivity.TAG, "Getting form input stream");
+        Log.d(TAG, "Getting form input stream");
         InputStream is = null;
         String filepath = fPath;
-        Log.d(CommCareWiFiDirectActivity.TAG, " fileinptutstream  with filepath: " + filepath);
+        Log.d(TAG, " fileinptutstream  with filepath: " + filepath);
         is = new FileInputStream(filepath);
         return is;
         
@@ -51,17 +51,17 @@ public abstract class FormTransferTask extends CommCareTask<String, String, Bool
     @Override
     protected Boolean doTaskBackground(String... params) {
         
-        Log.d(CommCareWiFiDirectActivity.TAG, " in form transfer onHandle");
+        Log.d(TAG, " in form transfer onHandle");
         
         Socket socket = new Socket();
         InputStream is;
 
         try {
-            Log.d(CommCareWiFiDirectActivity.TAG, "Opening client socket with host: " + host +  " port, " + port);
+            Log.d(TAG, "Opening client socket with host: " + host +  " port, " + port);
             socket.bind(null);
             socket.connect((new InetSocketAddress(host, port)), SOCKET_TIMEOUT);
 
-            Log.d(CommCareWiFiDirectActivity.TAG, "Client socket - " + socket.isConnected());
+            Log.d(TAG, "Client socket - " + socket.isConnected());
             OutputStream stream = socket.getOutputStream();
 
             is = getFormInputStream(filepath);
@@ -70,7 +70,7 @@ public abstract class FormTransferTask extends CommCareTask<String, String, Bool
             return true;
         } catch (IOException ioe) {
             
-            Log.e(CommCareWiFiDirectActivity.TAG, ioe.getMessage());
+            Log.e(TAG, ioe.getMessage());
             publishProgress("Error opening input stream: " + ioe.getMessage());
             
             return false;

--- a/app/src/org/commcare/android/tasks/UnzipTask.java
+++ b/app/src/org/commcare/android/tasks/UnzipTask.java
@@ -5,7 +5,6 @@ import android.util.Log;
 import org.commcare.android.tasks.templates.CommCareTask;
 import org.commcare.android.util.AndroidStreamUtil;
 import org.commcare.android.util.FileUtil;
-import org.commcare.dalvik.activities.CommCareWiFiDirectActivity;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
@@ -22,13 +21,9 @@ import java.util.zip.ZipFile;
  * @author ctsims
  */
 public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer, R> {
-
     public static final int UNZIP_TASK_ID = 7212435;
 
-    public File mFile;
-
     public UnzipTask() {
-        Log.d(CommCareWiFiDirectActivity.TAG, "UnZip task constructor");
         this.taskId = UNZIP_TASK_ID;
 
         TAG = UnzipTask.class.getSimpleName();
@@ -36,15 +31,10 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
 
     @Override
     protected Integer doTaskBackground(String... params) {
-
-        Logger.log(CommCareWiFiDirectActivity.TAG, "Doing unzip task");
-
-        Log.d(CommCareWiFiDirectActivity.TAG, "Task in background");
-
         File archive = new File(params[0]);
         File destination = new File(params[1]);
 
-        Log.d(CommCareWiFiDirectActivity.TAG, "Doing task in background with archive: " + archive + " destination: " + destination);
+        Log.d(TAG, "Unzipping archive '" + archive + "' to  '" + destination + "'");
 
         int count = 0;
         ZipFile zipfile;
@@ -52,12 +42,10 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
         try {
             zipfile = new ZipFile(archive);
         } catch (IOException ioe) {
-            Log.d(CommCareWiFiDirectActivity.TAG, "IOException 4");
             publishProgress("Could not find target file for unzipping.");
             return -1;
         }
         for (Enumeration e = zipfile.entries(); e.hasMoreElements(); ) {
-            Log.d(CommCareWiFiDirectActivity.TAG, "In UnZip Loop");
             Localization.get("mult.install.progress", new String[]{String.valueOf(count)});
             count++;
             ZipEntry entry = (ZipEntry) e.nextElement();
@@ -83,7 +71,6 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
             try {
                 inputStream = new BufferedInputStream(zipfile.getInputStream(entry));
             } catch (IOException ioe) {
-                Log.d(CommCareWiFiDirectActivity.TAG, "IOEXception 0");
                 this.publishProgress(Localization.get("mult.install.progress.badentry", new String[]{entry.getName()}));
                 return -1;
             }
@@ -92,7 +79,6 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
             try {
                 outputStream = new BufferedOutputStream(new FileOutputStream(outputFile));
             } catch (IOException ioe) {
-                Log.d(CommCareWiFiDirectActivity.TAG, "IOException 1");
                 this.publishProgress(Localization.get("mult.install.progress.baddest", new String[]{outputFile.getName()}));
                 return -1;
             }
@@ -101,7 +87,6 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
                 try {
                     AndroidStreamUtil.writeFromInputToOutput(inputStream, outputStream);
                 } catch (IOException ioe) {
-                    Log.d(CommCareWiFiDirectActivity.TAG, "IOException 2");
                     this.publishProgress(Localization.get("mult.install.progress.errormoving"));
                     return -1;
                 }
@@ -117,8 +102,7 @@ public abstract class UnzipTask<R> extends CommCareTask<String, String, Integer,
             }
         }
 
-        Log.d(CommCareWiFiDirectActivity.TAG, "Exited Loop");
-        Logger.log(CommCareWiFiDirectActivity.TAG, "Successfully unzipped files");
+        Logger.log(TAG, "Successfully unzipped files");
 
         return count;
     }

--- a/app/src/org/commcare/android/tasks/WipeTask.java
+++ b/app/src/org/commcare/android/tasks/WipeTask.java
@@ -29,6 +29,7 @@ public abstract class WipeTask extends CommCareTask<String, String, Boolean, Com
         this.c = c;
         this.taskId = WIPE_TASK_ID;
         this.records = records;
+        TAG = WipeTask.class.getSimpleName();
     }
 
     @Override
@@ -51,7 +52,7 @@ public abstract class WipeTask extends CommCareTask<String, String, Boolean, Com
     @Override
     protected Boolean doTaskBackground(String... params) {
 
-        Log.d(CommCareWiFiDirectActivity.TAG, "doing wipe task in background");
+        Log.d(TAG, "doing wipe task in background");
         for (int i = 0; i < records.length; ++i) {
             FormRecord record = records[i];
             FormRecordCleanupTask.wipeRecord(c, record);

--- a/app/src/org/commcare/android/tasks/ZipTask.java
+++ b/app/src/org/commcare/android/tasks/ZipTask.java
@@ -132,19 +132,19 @@ public abstract class ZipTask extends CommCareTask<String, String, FormRecord[],
             // This is not the ideal long term solution for determining whether we need decryption, but works
             if (f.getName().endsWith(".xml")) {
                 try {
-                    Log.d(CommCareWiFiDirectActivity.TAG, "trying zip copy2");
+                    Log.d(TAG, "trying zip copy2");
                     FileUtil.copyFile(f, new File(myDir, f.getName()), decrypter, null);
                 } catch (IOException ie) {
-                    Log.d(CommCareWiFiDirectActivity.TAG, "faield zip copywith2: " + f.getName());
+                    Log.d(TAG, "faield zip copywith2: " + f.getName());
                     publishProgress(("File writing failed: " + ie.getMessage()));
                     return FormUploadUtil.FAILURE;
                 }
             } else {
                 try {
-                    Log.d(CommCareWiFiDirectActivity.TAG, "trying zip copy2");
+                    Log.d(TAG, "trying zip copy2");
                     FileUtil.copyFile(f, new File(myDir, f.getName()));
                 } catch (IOException ie) {
-                    Log.d(CommCareWiFiDirectActivity.TAG, "faield zip copy2 " + f.getName() + "with messageL " + ie.getMessage());
+                    Log.d(TAG, "faield zip copy2 " + f.getName() + "with messageL " + ie.getMessage());
                     publishProgress(("File writing failed: " + ie.getMessage()));
                     return FormUploadUtil.FAILURE;
                 }
@@ -155,7 +155,7 @@ public abstract class ZipTask extends CommCareTask<String, String, FormRecord[],
 
     private boolean zipTargetFolder(File targetFilePath, String zipFile) throws IOException {
 
-        Log.d(CommCareWiFiDirectActivity.TAG, "827 zipTarggetFolder with tfp: " + targetFilePath.toString() + ", zipFile: " + zipFile);
+        Log.d(TAG, "827 zipTarggetFolder with tfp: " + targetFilePath.toString() + ", zipFile: " + zipFile);
 
         ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(zipFile)));
 
@@ -219,7 +219,7 @@ public abstract class ZipTask extends CommCareTask<String, String, FormRecord[],
     @Override
     protected FormRecord[] doTaskBackground(String... params) {
 
-        Log.d(CommCareWiFiDirectActivity.TAG, "doing zip task in background");
+        Log.d(TAG, "doing zip task in background");
 
         // ensure that SD is available, writable, and not emulated
 

--- a/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareWiFiDirectActivity.java
@@ -66,7 +66,7 @@ import java.util.Vector;
 @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class CommCareWiFiDirectActivity extends SessionAwareCommCareActivity<CommCareWiFiDirectActivity> implements DeviceActionListener, FileServerListener, WifiDirectManagerListener {
 
-    public static final String TAG = CommCareWiFiDirectActivity.class.getSimpleName();
+    private static final String TAG = CommCareWiFiDirectActivity.class.getSimpleName();
 
     public static final String KEY_NUMBER_DUMPED ="wd_num_dumped";
 

--- a/app/src/org/commcare/dalvik/services/WiFiDirectBroadcastReceiver.java
+++ b/app/src/org/commcare/dalvik/services/WiFiDirectBroadcastReceiver.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.commcare.dalvik.services;
 
 import android.annotation.SuppressLint;
@@ -28,7 +12,6 @@ import android.os.Build;
 import android.util.Log;
 
 import org.commcare.android.framework.WiFiDirectManagementFragment;
-import org.commcare.dalvik.activities.CommCareWiFiDirectActivity;
 import org.javarosa.core.services.Logger;
 
 /**
@@ -38,6 +21,7 @@ import org.javarosa.core.services.Logger;
 @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
 
+    private static final String TAG = WiFiDirectBroadcastReceiver.class.getSimpleName();
     private final WifiP2pManager manager;
     private Channel channel;
     private final WiFiDirectManagementFragment activity;
@@ -58,26 +42,26 @@ public class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Override
     public void onReceive(Context context, Intent intent) {
-        Log.d(CommCareWiFiDirectActivity.TAG, "in on receive ");
+        Log.d(TAG, "in on receive ");
         String action = intent.getAction();
         
-        Logger.log(CommCareWiFiDirectActivity.TAG, "onReceive of BroadCastReceiver with action: " + action);
+        Logger.log(TAG, "onReceive of BroadCastReceiver with action: " + action);
         
         if (WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION.equals(action)) {
 
             // UI update to indicate wifi p2p status.
             int state = intent.getIntExtra(WifiP2pManager.EXTRA_WIFI_STATE, -1);
             if (state == WifiP2pManager.WIFI_P2P_STATE_ENABLED) {
-                Log.d(CommCareWiFiDirectActivity.TAG, "BR enabled");
+                Log.d(TAG, "BR enabled");
                 // Wifi Direct mode is enabled
                 activity.setIsWifiP2pEnabled(true);
             } else {
-                Log.d(CommCareWiFiDirectActivity.TAG, "BR not enabled");
+                Log.d(TAG, "BR not enabled");
                 activity.setIsWifiP2pEnabled(false);
                 activity.resetData();
 
             }
-            Log.d(CommCareWiFiDirectActivity.TAG, "P2P state changed - " + state);
+            Log.d(TAG, "P2P state changed - " + state);
         } else if (WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION.equals(action)) {
 
             // request available peers from the wifi p2p manager. This is an
@@ -88,7 +72,7 @@ public class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
                 activity.onPeersChanged();
                 
             }
-            Log.d(CommCareWiFiDirectActivity.TAG, "P2P peers changed2");
+            Log.d(TAG, "P2P peers changed2");
         } else if (WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION.equals(action)) {
 
             if (manager == null) {
@@ -101,7 +85,7 @@ public class WiFiDirectBroadcastReceiver extends BroadcastReceiver {
             activity.onP2PConnectionChanged(networkInfo.isConnected());
 
         } else if (WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION.equals(action)) {
-            Log.d(CommCareWiFiDirectActivity.TAG, "in last else with device: " + intent.getParcelableExtra(
+            Log.d(TAG, "in last else with device: " + intent.getParcelableExtra(
                     WifiP2pManager.EXTRA_WIFI_P2P_DEVICE).toString());
             
             


### PR DESCRIPTION
A bunch of files were performing debug logs using `CommCareWiFiDirectActivity.TAG` instead of their own `TAG` field. 
I'm assuming it was just a copy-paste mistake and not actually intended. 