### PR TITLE
Enable proguard

### DIFF
--- a/app/proguard_debug.cfg
+++ b/app/proguard_debug.cfg
@@ -2,6 +2,7 @@
 -dontusemixedcaseclassnames
 -dontskipnonpubliclibraryclasses
 -dontpreverify
+-dontobfuscate
 -verbose
 -optimizations !code/simplification/arithmetic,!field/*,!class/merging/*
 

--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ android {
     buildTypes {
       debug {
         debuggable true
-        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'app/proguard.cfg'
+        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'app/proguard_debug.cfg'
       }
 
       release {


### PR DESCRIPTION
Enabling proguard for both debug and release builds, with a separate config file for debug builds that includes the -dontobfuscate flag.