### PR TITLE
Bump mapballoons to api 23 as well to not require 22 for building

### DIFF
--- a/libraries/mapballoons/build.gradle
+++ b/libraries/mapballoons/build.gradle
@@ -13,12 +13,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion "Google Inc.:Google APIs:22"
-  buildToolsVersion "22.0.1"
+  compileSdkVersion "Google Inc.:Google APIs:23"
+  buildToolsVersion "23.0.2"
 
   defaultConfig {
     minSdkVersion 7
-    targetSdkVersion 22
+    targetSdkVersion 23
   }
   sourceSets {
     main {


### PR DESCRIPTION
Eventually we will get rid of mapballoons, so I'm not going to look into the "right way" to do this. 