### PR TITLE
Don't re-consume one-time intent extras

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -134,6 +134,7 @@ public class CommCareHomeActivity
     // The API allows for external calls. When this occurs, redispatch to their
     // activity instead of commcare.
     private boolean wasExternal = false;
+    private static final String WAS_EXTERNAL_KEY = "was_external";
 
     private int mDeveloperModeClicks = 0;
 
@@ -141,9 +142,17 @@ public class CommCareHomeActivity
     private SessionNavigator sessionNavigator;
     private FormAndDataSyncer formAndDataSyncer;
 
+    private boolean loginExtraWasConsumed;
+    private static final String EXTRA_CONSUMED_KEY = "login_extra_was_consumed";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (savedInstanceState != null) {
+            wasExternal = savedInstanceState.getBoolean(WAS_EXTERNAL_KEY);
+            loginExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
+        }
 
         if (finishIfNotRoot()) {
             return;
@@ -183,7 +192,7 @@ public class CommCareHomeActivity
      */
     private void processFromExternalLaunch(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            wasExternal = savedInstanceState.getBoolean("was_external");
+            wasExternal = savedInstanceState.getBoolean(WAS_EXTERNAL_KEY);
         } else {
             if (getIntent().hasExtra(DispatchActivity.WAS_EXTERNAL)) {
                 wasExternal = true;
@@ -199,8 +208,10 @@ public class CommCareHomeActivity
     }
 
     private void processFromLoginLaunch() {
-        if (getIntent().getBooleanExtra(DispatchActivity.START_FROM_LOGIN, false)) {
+        if (getIntent().getBooleanExtra(DispatchActivity.START_FROM_LOGIN, false) &&
+                !loginExtraWasConsumed) {
             getIntent().removeExtra(DispatchActivity.START_FROM_LOGIN);
+            loginExtraWasConsumed = true;
 
             CommCareSession session = CommCareApplication._().getCurrentSession();
             if (session.getCommand() != null) {
@@ -274,15 +285,8 @@ public class CommCareHomeActivity
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putBoolean("was_external", wasExternal);
-    }
-
-    @Override
-    protected void onRestoreInstanceState(Bundle inState) {
-        super.onRestoreInstanceState(inState);
-        if (inState.containsKey("was_external")) {
-            wasExternal = inState.getBoolean("was_external");
-        }
+        outState.putBoolean(WAS_EXTERNAL_KEY, wasExternal);
+        outState.putBoolean(EXTRA_CONSUMED_KEY, loginExtraWasConsumed);
     }
 
     @Override

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -150,7 +150,6 @@ public class CommCareHomeActivity
         super.onCreate(savedInstanceState);
 
         if (savedInstanceState != null) {
-            wasExternal = savedInstanceState.getBoolean(WAS_EXTERNAL_KEY);
             loginExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
         }
 

--- a/app/src/org/commcare/dalvik/activities/DispatchActivity.java
+++ b/app/src/org/commcare/dalvik/activities/DispatchActivity.java
@@ -3,6 +3,7 @@ package org.commcare.dalvik.activities;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.widget.Toast;
 
@@ -44,6 +45,17 @@ public class DispatchActivity extends FragmentActivity {
     private boolean startFromLogin;
     private boolean shouldFinish;
     private boolean userTriggeredLogout;
+    private boolean shortcutExtraWasConsumed;
+
+    private static final String EXTRA_CONSUMED_KEY = "shortcut_extra_was_consumed";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (savedInstanceState != null) {
+            shortcutExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
+        }
+    }
 
     @Override
     protected void onResume() {
@@ -54,6 +66,12 @@ public class DispatchActivity extends FragmentActivity {
         } else {
             dispatch();
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(EXTRA_CONSUMED_KEY, shortcutExtraWasConsumed);
     }
 
     private void dispatch() {
@@ -95,7 +113,8 @@ public class DispatchActivity extends FragmentActivity {
                 } else if (this.getIntent().hasExtra(SESSION_REQUEST)) {
                     // CommCare was launched from an external app, with a session descriptor
                     handleExternalLaunch();
-                } else if (this.getIntent().hasExtra(AndroidShortcuts.EXTRA_KEY_SHORTCUT)) {
+                } else if (this.getIntent().hasExtra(AndroidShortcuts.EXTRA_KEY_SHORTCUT) &&
+                        !shortcutExtraWasConsumed) {
                     // CommCare was launched from a shortcut
                     handleShortcutLaunch();
                 } else {
@@ -218,6 +237,7 @@ public class DispatchActivity extends FragmentActivity {
                     this.getIntent().getStringExtra(AndroidShortcuts.EXTRA_KEY_SHORTCUT));
 
             getIntent().removeExtra(AndroidShortcuts.EXTRA_KEY_SHORTCUT);
+            shortcutExtraWasConsumed = true;
             Intent i = new Intent(this, CommCareHomeActivity.class);
             i.putExtra(WAS_SHORTCUT_LAUNCH, true);
             startActivityForResult(i, HOME_SCREEN);


### PR DESCRIPTION
Prevent re-consumption of one-time intent extras when an activity is launched from history