### PR TITLE
Ask for all app permissions at ccz app install time

### DIFF
--- a/app/src/org/commcare/android/framework/Permissions.java
+++ b/app/src/org/commcare/android/framework/Permissions.java
@@ -1,0 +1,107 @@
+package org.commcare.android.framework;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+
+import org.commcare.dalvik.dialogs.DialogCreationHelpers;
+import org.javarosa.core.services.locale.Localization;
+
+/**
+ * Acquire Android permissions needed by CommCare.
+ *
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class Permissions {
+    public final static int ALL_PERMISSIONS_REQUEST = 1;
+
+    /**
+     * Ask for Android permissions needed by the app all at once.  This goes
+     * against what is suggested by Android, but asking for permissions on
+     * demand will confuse the hell out our users.
+     *
+     * @param activity        Used to show user dialog with rationale behind
+     *                        permission requests
+     * @param permRequester   performs user-facing permission request system calls
+     * @param permRequestCode make the permission request using this request code
+     */
+    public static void acquireAllAppPermissions(Activity activity,
+                                                RuntimePermissionRequester permRequester,
+                                                int permRequestCode) {
+        String[] permissions = getAppPermissions();
+
+        if (missingAppPermission(activity, permissions)) {
+            if (shouldShowPermissionRationale(activity, permissions)) {
+                AlertDialog dialog =
+                        DialogCreationHelpers.buildPermissionRequestDialog(activity, permRequester,
+                                permRequestCode,
+                                Localization.get("permission.all.title"),
+                                Localization.get("permission.all.message"));
+                dialog.show();
+            } else {
+                permRequester.requestNeededPermissions(permRequestCode);
+            }
+        }
+    }
+
+    private static boolean missingAppPermission(Activity activity,
+                                                String[] permissions) {
+        for (String perm : permissions) {
+            if (ContextCompat.checkSelfPermission(activity, perm) == PackageManager.PERMISSION_DENIED) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean shouldShowPermissionRationale(Activity activity,
+                                                         String[] permissions) {
+        for (String perm : permissions) {
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity, perm)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return Permissions needed for _normal_ CommCare functionality
+     */
+    public static String[] getAppPermissions() {
+        // leaving out READ_SMS, which is only needed for sms installs
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            // exclude READ_EXTERNAL_STORAGE which isn't compat. w/ API < 16
+            return new String[]{Manifest.permission.READ_PHONE_STATE,
+                    Manifest.permission.CALL_PHONE,
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            };
+        } else {
+            return new String[]{Manifest.permission.READ_PHONE_STATE,
+                    Manifest.permission.CALL_PHONE,
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_EXTERNAL_STORAGE
+            };
+        }
+    }
+
+    /**
+     * @return Minimal set of permissions needed for CommCare to function
+     */
+    public static String[] getRequiredPerms() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            // exclude READ_EXTERNAL_STORAGE which isn't compat. w/ API < 16
+            return new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
+        } else {
+            return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE};
+        }
+    }
+}

--- a/app/src/org/commcare/android/framework/RuntimePermissionRequester.java
+++ b/app/src/org/commcare/android/framework/RuntimePermissionRequester.java
@@ -6,6 +6,9 @@ package org.commcare.android.framework;
 public interface RuntimePermissionRequester {
     /**
      * Asks user for specific permissions needed to proceed
+     *
+     * @param requestCode Request permission using this code, allowing for
+     *                    callback distinguishing
      */
-    void requestNeededPermissions();
+    void requestNeededPermissions(int requestCode);
 }

--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -139,11 +139,12 @@ public class CallOutActivity extends Activity
             if (shouldShowPhonePermissionRationale()) {
                 AlertDialog dialog =
                         DialogCreationHelpers.buildPermissionRequestDialog(this, this,
+                                CALL_OR_SMS_PERMISSION_REQUEST,
                                 Localization.get("permission.case.callout.title"),
                                 Localization.get("permission.case.callout.message"));
                 dialog.show();
             } else {
-                requestNeededPermissions();
+                requestNeededPermissions(CALL_OR_SMS_PERMISSION_REQUEST);
             }
         } else {
             dispatchAction();
@@ -169,10 +170,10 @@ public class CallOutActivity extends Activity
     }
 
     @Override
-    public void requestNeededPermissions() {
+    public void requestNeededPermissions(int requestCode) {
         ActivityCompat.requestPermissions(this,
                 new String[]{getPermissionForAction()},
-                CALL_OR_SMS_PERMISSION_REQUEST);
+                requestCode);
     }
 
     @Override

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -1,8 +1,6 @@
 package org.commcare.dalvik.activities;
 
-import android.Manifest;
 import android.annotation.TargetApi;
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -14,7 +12,6 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -43,8 +40,9 @@ import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.database.user.DemoUserBuilder;
 import org.commcare.android.framework.CommCareActivity;
 import org.commcare.android.framework.ManagedUi;
-import org.commcare.android.framework.RuntimePermissionRequester;
 import org.commcare.android.framework.ManagedUiFramework;
+import org.commcare.android.framework.Permissions;
+import org.commcare.android.framework.RuntimePermissionRequester;
 import org.commcare.android.framework.UiElement;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.models.notifications.MessageTag;
@@ -62,7 +60,6 @@ import org.commcare.android.tasks.templates.HttpCalloutTask.HttpCalloutOutcomes;
 import org.commcare.android.ui.CustomBanner;
 import org.commcare.android.util.ACRAUtil;
 import org.commcare.android.util.MediaUtil;
-import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.android.view.ViewUtil;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApp;
@@ -86,16 +83,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     private static final String TAG = LoginActivity.class.getSimpleName();
 
-    private final static String[] appPermissions =
-            new String[]{Manifest.permission.READ_PHONE_STATE,
-                    Manifest.permission.CALL_PHONE,
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                    Manifest.permission.ACCESS_COARSE_LOCATION,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    Manifest.permission.READ_EXTERNAL_STORAGE
-                    // leaving out READ_SMS, which is only needed for sms installs
-            };
-
     private static final int MENU_DEMO = Menu.FIRST;
     private static final int MENU_ABOUT = Menu.FIRST + 1;
     private static final int MENU_PERMISSIONS = Menu.FIRST + 2;
@@ -107,7 +94,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     private static final int SEAT_APP_ACTIVITY = 0;
     public final static String KEY_APP_TO_SEAT = "app_to_seat";
     public final static String USER_TRIGGERED_LOGOUT = "user-triggered-logout";
-    private final static int ALL_PERMISSIONS_REQUEST = 1;
 
     @UiElement(value=R.id.screen_login_bad_password)
     private TextView errorBox;
@@ -258,57 +244,23 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             }
         });
 
-        acquireAllAppPerms();
-    }
-
-    private void acquireAllAppPerms() {
-        if (missingAppPermission()) {
-            if (shouldShowPermissionRationale()) {
-                AlertDialog dialog =
-                        DialogCreationHelpers.buildPermissionRequestDialog(this, this,
-                                Localization.get("permission.all.title"),
-                                Localization.get("permission.all.message"));
-                dialog.show();
-            } else {
-                requestNeededPermissions();
-            }
-        }
-    }
-
-    private boolean missingAppPermission() {
-        for (String perm : appPermissions) {
-            if (ContextCompat.checkSelfPermission(this, perm) == PackageManager.PERMISSION_DENIED) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean shouldShowPermissionRationale() {
-        for (String perm : appPermissions) {
-            if (ActivityCompat.shouldShowRequestPermissionRationale(this, perm)) {
-                return true;
-            }
-        }
-        return false;
+        Permissions.acquireAllAppPermissions(this, this, Permissions.ALL_PERMISSIONS_REQUEST);
     }
 
     @Override
     @TargetApi(Build.VERSION_CODES.M)
-    public void requestNeededPermissions() {
-        ActivityCompat.requestPermissions(this, appPermissions,
-                ALL_PERMISSIONS_REQUEST);
+    public void requestNeededPermissions(int requestCode) {
+        ActivityCompat.requestPermissions(this, Permissions.getAppPermissions(),
+                requestCode);
     }
 
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
-        String[] requiredPerms =
-                new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE};
+        String[] requiredPerms = Permissions.getRequiredPerms();
 
-        if (requestCode == ALL_PERMISSIONS_REQUEST) {
+        if (requestCode == Permissions.ALL_PERMISSIONS_REQUEST) {
             for (int i = 0; i < permissions.length; i++) {
                 for (String requiredPerm : requiredPerms) {
                     if (requiredPerm.equals(permissions[i]) &&
@@ -639,7 +591,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             DialogCreationHelpers.buildAboutCommCareDialog(this).show();
             return true;
         case MENU_PERMISSIONS:
-            acquireAllAppPerms();
+            Permissions.acquireAllAppPermissions(this, this, Permissions.ALL_PERMISSIONS_REQUEST);
             return true;
         default:
             return otherResult;

--- a/app/src/org/commcare/dalvik/dialogs/DialogCreationHelpers.java
+++ b/app/src/org/commcare/dalvik/dialogs/DialogCreationHelpers.java
@@ -53,6 +53,7 @@ public class DialogCreationHelpers {
      */
     public static AlertDialog buildPermissionRequestDialog(Activity activity,
                                                            final RuntimePermissionRequester permRequester,
+                                                           final int requestCode,
                                                            String title,
                                                            String body) {
         LayoutInflater li = LayoutInflater.from(activity);
@@ -67,7 +68,7 @@ public class DialogCreationHelpers {
         builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                permRequester.requestNeededPermissions();
+                permRequester.requestNeededPermissions(requestCode);
                 dialog.dismiss();
             }
         });


### PR DESCRIPTION
Fixes 2 bugs introduced when we bumped our app to target Android 6 (https://github.com/dimagi/commcare-odk/pull/818)

 - We weren't asking for storage permissions at app install time, which meant you couldn't install apps on Android 6 devices. The install activity now asks for all permissions that CommCare might need. We also check for all perms at login time to ensure functionality is smooth once logged in. 
 - On devices running API 15 and below, we shouldn't ask for READ_EXTERNAL_STORAGE permissions because it isn't available at those API levels and the compat library seems to always return false when checking if the device has those permissions. 