### PR TITLE
Dramatic Performance Improvements during large app install/init

### DIFF
--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -60,6 +60,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
                     return instance.getFixtureStorage();
                 }
             };
+            parser.setSkipResources(true);
 
             Suite s = parser.parse();
 


### PR DESCRIPTION
Ticket: http://manage.dimagi.com/default.asp?189554
X-Requested with: https://github.com/dimagi/commcare/pull/233

Pushes checking the install status to its own thread during install (could still be improved) and makes the suite parser skip adding resources to the table during startup, which was unnecessary and wasted an enormous amount of time for apps with lots of resources.