### PR TITLE
Check for session expiration in home screen dispatch

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -969,6 +969,7 @@ public class CommCareHomeActivity
             this.finish();
         }
     }
+    
     private void createAskUseOldDialog(final AndroidSessionWrapper state, final SessionStateDescriptor existing) {
         final AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         String title = Localization.get("app.workflow.incomplete.continue.title");

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -951,15 +951,24 @@ public class CommCareHomeActivity
      * Decides if we should actually be on the home screen, or else should redirect elsewhere
      */
     private void attemptDispatchHomeScreen() {
-        if (CommCareApplication._().isSyncPending(false)) {
-            // Path 1f: There is a sync pending
-            handlePendingSync();
-        } else {
-            // Path 1g: Display the normal home screen!
-            uiController.refreshView();
+        try {
+            if (CommCareApplication._().isSyncPending(false)) {
+                // There is a sync pending
+                handlePendingSync();
+            } else if (!CommCareApplication._().getSession().isActive()) {
+                // User was logged out somehow, so we want to return to dispatch activity
+                setResult(RESULT_OK);
+                this.finish();
+            } else {
+                // Display the normal home screen!
+                uiController.refreshView();
+            }
+        } catch (SessionUnavailableException e) {
+            // User was logged out somehow, so we want to return to dispatch activity
+            setResult(RESULT_OK);
+            this.finish();
         }
     }
-
     private void createAskUseOldDialog(final AndroidSessionWrapper state, final SessionStateDescriptor existing) {
         final AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         String title = Localization.get("app.workflow.incomplete.continue.title");


### PR DESCRIPTION
The DispatchActivity refactor left the home screen dispatch logic such that it was no longer checking for the case where the user has been logged out, which I believe we still want to be doing. This PR fixes this by checking for session expiration in attemptDispatchHomeScreen(), and just calling finish() if so. The specific case that I noticed where this is necessary is clearing user data (the app was crashing whenever you did this because CommCareHomeActivity would try to set up the home screen after returning from the preference activity, when there was no longer any logged in user). But I imagine there are other ways in which this could happen, and we would want to handle those smoothly as well, so went for a catch-all fix.