### PR TITLE
Move play store launcher bugfix from home to dispatch activity

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -40,8 +40,8 @@ import org.commcare.android.util.AndroidInstanceInitializer;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.android.util.StorageUtils;
 import org.commcare.android.view.HorizontalMediaView;
-import org.commcare.dalvik.BuildConfig;
 import org.commcare.core.process.CommCareInstanceInitializer;
+import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.AlertDialogFactory;
@@ -153,10 +153,6 @@ public class CommCareHomeActivity
             loginExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
         }
 
-        if (finishIfNotRoot()) {
-            return;
-        }
-
         ACRAUtil.registerAppData();
         uiController = new HomeActivityUIController(this);
         sessionNavigator = new SessionNavigator(this);
@@ -165,25 +161,6 @@ public class CommCareHomeActivity
         processFromExternalLaunch(savedInstanceState);
         processFromShortcutLaunch();
         processFromLoginLaunch();
-    }
-
-    /**
-     * A workaround required by Android Bug #2373 -- An app launched from the Google Play store
-     * has different intent flags than one launched from the App launcher, which ruins the back
-     * stack and prevents the app from launching a high affinity task.
-     *
-     * @return if finish() was called
-     */
-    private boolean finishIfNotRoot() {
-        if (!isTaskRoot()) {
-            Intent intent = getIntent();
-            String action = intent.getAction();
-            if (intent.hasCategory(Intent.CATEGORY_LAUNCHER) && action != null && action.equals(Intent.ACTION_MAIN)) {
-                finish();
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/DispatchActivity.java
+++ b/app/src/org/commcare/dalvik/activities/DispatchActivity.java
@@ -52,10 +52,35 @@ public class DispatchActivity extends FragmentActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (finishIfNotRoot()) {
+            return;
+        }
+
         if (savedInstanceState != null) {
             shortcutExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
         }
     }
+
+    /**
+     * A workaround required by Android Bug #2373 -- An app launched from the Google Play store
+     * has different intent flags than one launched from the App launcher, which ruins the back
+     * stack and prevents the app from launching a high affinity task.
+     *
+     * @return if finish() was called
+     */
+    private boolean finishIfNotRoot() {
+        if (!isTaskRoot()) {
+            Intent intent = getIntent();
+            String action = intent.getAction();
+            if (intent.hasCategory(Intent.CATEGORY_LAUNCHER) && action != null && action.equals(Intent.ACTION_MAIN)) {
+                finish();
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     @Override
     protected void onResume() {

--- a/app/src/org/commcare/dalvik/activities/HomeActivityUIController.java
+++ b/app/src/org/commcare/dalvik/activities/HomeActivityUIController.java
@@ -15,7 +15,6 @@ import org.commcare.dalvik.preferences.CommCarePreferences;
 import org.commcare.dalvik.preferences.DeveloperPreferences;
 import org.commcare.suite.model.Profile;
 
-import java.util.Arrays;
 import java.util.Vector;
 
 /**


### PR DESCRIPTION
Move over fix for [this bug](https://code.google.com/p/android/issues/detail?id=2373) from the home activity, which used to be the activity launched upon app start, to the dispatch activity, which is now the launched activity.

I didn't test this because I don't really have context on it and it would require deploying to the play store.... @ctsims let me know if you know of a good way to test it, or if it simple enough to expect to work. 