### PR TITLE
Setup temp storage dirs after gaining external write perms 

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -825,6 +825,9 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                     }
                 }
             }
+            // external storage perms were enabled, so setup temp storage,
+            // which fails in application setup without external storage perms.
+            CommCareApplication._().prepareTemporaryStorage();
         }
     }
 

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -146,6 +146,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         this.fromManager = this.getIntent().
                 getBooleanExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, false);
 
@@ -476,13 +477,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         super.onCreateOptionsMenu(menu);
         menu.add(0, MODE_ARCHIVE, 0, Localization.get("menu.archive")).setIcon(android.R.drawable.ic_menu_upload);
         menu.add(0, MODE_SMS, 1, Localization.get("menu.sms")).setIcon(android.R.drawable.stat_notify_chat);
-        return true;
-    }
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        super.onPrepareOptionsMenu(menu);
-
         return true;
     }
 

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -75,7 +75,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         RuntimePermissionRequester {
     private static final String TAG = CommCareSetupActivity.class.getSimpleName();
 
-    public static final String KEY_PROFILE_REF = "app_profile_ref";
     private static final String KEY_UI_STATE = "current_install_ui_state";
     private static final String KEY_OFFLINE =  "offline_install";
     private static final String KEY_FROM_EXTERNAL = "from_external";
@@ -174,8 +173,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                     this.uiState = UiState.READY_TO_INSTALL;
                     //Now just start up normally.
                 }
-            } else {
-                incomingRef = this.getIntent().getStringExtra(KEY_PROFILE_REF);
             }
         } else {
             loadStateFromInstance(savedInstanceState);
@@ -282,9 +279,9 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         switch (uiState) {
             case READY_TO_INSTALL:
                 if (incomingRef == null || incomingRef.length() == 0) {
-                    Log.e(TAG, "During install: IncomingRef is empty!");
-                    Toast.makeText(getApplicationContext(), "Invalid URL: '" +
-                            incomingRef + "'", Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "During install: incomingRef is empty!");
+                    Toast.makeText(getApplicationContext(), "Empty URL provided",
+                            Toast.LENGTH_SHORT).show();
                     return;
                 }
 
@@ -364,7 +361,9 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 }
                 break;
         }
-        if (result == null) return;
+        if (result == null) {
+            return;
+        }
         incomingRef = result;
         this.uiState = UiState.READY_TO_INSTALL;
 
@@ -382,10 +381,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         }
 
         uiStateScreenTransition();
-    }
-
-    private String getRef() {
-        return incomingRef;
     }
 
     private CommCareApp getCommCareApp() {
@@ -470,7 +465,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                     };
 
             task.connect(this);
-            task.execute(getRef());
+            task.execute(incomingRef);
         } else {
             Log.i(TAG, "During install: blocked a resource install press since a task was already running");
         }

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -771,7 +771,7 @@ public class CommCareApplication extends Application {
         CommCareApplication._().closeUserSession();
     }
 
-    private void prepareTemporaryStorage() {
+    public void prepareTemporaryStorage() {
         String tempRoot = this.getAndroidFsTemp();
         FileUtil.deleteFileOrDir(tempRoot);
         boolean success = FileUtil.createFolder(tempRoot);


### PR DESCRIPTION
Android 6 related install issue where the temporary storage directory created in `CommCareApplication` wasn't actually being created because we didn't yet acquire external storage permissions from the user.

This PR simply calls the temp storage setup method again after the perms are acquired from the user.

Other changes are addressing no-opy code