### PR TITLE
Unify instances of restarting commcare

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CrashWarningActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CrashWarningActivity.java
@@ -2,7 +2,6 @@ package org.commcare.dalvik.activities;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -12,6 +11,7 @@ import android.widget.TextView;
 
 import org.commcare.android.util.CommCareExceptionHandler;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.application.CommCareApplication;
 import org.javarosa.core.services.locale.Localization;
 
 /**
@@ -54,7 +54,7 @@ public class CrashWarningActivity extends Activity {
         closeButton.setText(Localization.get("crash.warning.button"));
         closeButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                restartCommCare();
+                CommCareApplication._().restartCommCare(CrashWarningActivity.this);
             }
         });
 
@@ -64,20 +64,6 @@ public class CrashWarningActivity extends Activity {
                 toggleErrorMessageVisibility();
             }
         });
-    }
-
-    private void restartCommCare() {
-        Intent intent = new Intent(CrashWarningActivity.this, DispatchActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
-                Intent.FLAG_ACTIVITY_SINGLE_TOP |
-                Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
-        } else {
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
-        }
-        CrashWarningActivity.this.startActivity(intent);
-        CrashWarningActivity.this.finish();
     }
 
     private void setupText() {

--- a/app/src/org/commcare/dalvik/activities/CrashWarningActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CrashWarningActivity.java
@@ -54,7 +54,7 @@ public class CrashWarningActivity extends Activity {
         closeButton.setText(Localization.get("crash.warning.button"));
         closeButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                CommCareApplication._().restartCommCare(CrashWarningActivity.this);
+                CommCareApplication.restartCommCare(CrashWarningActivity.this);
             }
         });
 

--- a/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
@@ -151,7 +151,7 @@ public class SingleAppManagerActivity extends Activity {
     private void uninstall() {
         CommCareApplication._().expireUserSession();
         CommCareApplication._().uninstall(appRecord);
-        CommCareApplication._().restartCommCare(SingleAppManagerActivity.this);
+        CommCareApplication.restartCommCare(SingleAppManagerActivity.this);
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
@@ -154,7 +154,8 @@ public class SingleAppManagerActivity extends Activity {
     private void uninstall() {
         CommCareApplication._().expireUserSession();
         CommCareApplication._().uninstall(appRecord);
-        rebootCommCare();
+        CommCareApplication._().rebootCommCare(SingleAppManagerActivity.this);
+        //rebootCommCare();
     }
 
     /**
@@ -249,14 +250,26 @@ public class SingleAppManagerActivity extends Activity {
      * Relaunches CommCare after an app has been uninstalled
      */
     private void rebootCommCare() {
-        Context c = getApplicationContext();
+        Intent intent = new Intent(SingleAppManagerActivity.this, DispatchActivity.class);
+
+        //Make sure that the new stack starts with a dispatch activity, and clear everything
+        // between.
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET |
+                Intent.FLAG_ACTIVITY_CLEAR_TOP |
+                Intent.FLAG_ACTIVITY_SINGLE_TOP |
+                Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        SingleAppManagerActivity.this.startActivity(intent);
+
+        System.runFinalizersOnExit(true);
+        System.exit(0);
+        /*Context c = getApplicationContext();
         Intent i = new Intent(c, DispatchActivity.class);
         int mPendingIntentId = 123456;
         PendingIntent mPendingIntent = PendingIntent.getActivity(c, mPendingIntentId, i,
                 PendingIntent.FLAG_CANCEL_CURRENT);
         AlarmManager mgr = (AlarmManager) c.getSystemService(Context.ALARM_SERVICE);
         mgr.set(AlarmManager.RTC, System.currentTimeMillis() + 100, mPendingIntent);
-        System.exit(0);
+        System.exit(0);*/
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
@@ -1,10 +1,7 @@
 package org.commcare.dalvik.activities;
 
 import android.app.Activity;
-import android.app.AlarmManager;
 import android.app.AlertDialog;
-import android.app.PendingIntent;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -154,8 +151,7 @@ public class SingleAppManagerActivity extends Activity {
     private void uninstall() {
         CommCareApplication._().expireUserSession();
         CommCareApplication._().uninstall(appRecord);
-        CommCareApplication._().rebootCommCare(SingleAppManagerActivity.this);
-        //rebootCommCare();
+        CommCareApplication._().restartCommCare(SingleAppManagerActivity.this);
     }
 
     /**
@@ -244,32 +240,6 @@ public class SingleAppManagerActivity extends Activity {
         CommCareApplication._().initializeAppResources(new CommCareApp(appRecord));
         Intent i = new Intent(getApplicationContext(), UpdateActivity.class);
         startActivityForResult(i, CommCareHomeActivity.UPGRADE_APP);
-    }
-
-    /**
-     * Relaunches CommCare after an app has been uninstalled
-     */
-    private void rebootCommCare() {
-        Intent intent = new Intent(SingleAppManagerActivity.this, DispatchActivity.class);
-
-        //Make sure that the new stack starts with a dispatch activity, and clear everything
-        // between.
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET |
-                Intent.FLAG_ACTIVITY_CLEAR_TOP |
-                Intent.FLAG_ACTIVITY_SINGLE_TOP |
-                Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-        SingleAppManagerActivity.this.startActivity(intent);
-
-        System.runFinalizersOnExit(true);
-        System.exit(0);
-        /*Context c = getApplicationContext();
-        Intent i = new Intent(c, DispatchActivity.class);
-        int mPendingIntentId = 123456;
-        PendingIntent mPendingIntent = PendingIntent.getActivity(c, mPendingIntentId, i,
-                PendingIntent.FLAG_CANCEL_CURRENT);
-        AlarmManager mgr = (AlarmManager) c.getSystemService(Context.ALARM_SERVICE);
-        mgr.set(AlarmManager.RTC, System.currentTimeMillis() + 100, mPendingIntent);
-        System.exit(0);*/
     }
 
     /**

--- a/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
@@ -39,7 +39,7 @@ public class UnrecoverableErrorActivity extends Activity {
         AlertDialogFactory factory = new AlertDialogFactory(this, title, message);
         DialogInterface.OnClickListener buttonListener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
-               CommCareApplication._().restartCommCare(UnrecoverableErrorActivity.this);
+               CommCareApplication.restartCommCare(UnrecoverableErrorActivity.this);
             }
         };
         factory.setPositiveButton(Localization.get("app.storage.missing.button"), buttonListener);

--- a/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 
+import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.AlertDialogFactory;
 import org.javarosa.core.services.locale.Localization;
 
@@ -39,18 +40,7 @@ public class UnrecoverableErrorActivity extends Activity {
         AlertDialogFactory factory = new AlertDialogFactory(this, title, message);
         DialogInterface.OnClickListener buttonListener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
-               Intent intent = new Intent(UnrecoverableErrorActivity.this, DispatchActivity.class);
-
-                //Make sure that the new stack starts with a home activity, and clear everything between.
-               intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET |
-                       Intent.FLAG_ACTIVITY_CLEAR_TOP |
-                       Intent.FLAG_ACTIVITY_SINGLE_TOP |
-                       Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-               UnrecoverableErrorActivity.this.startActivity(intent);
-               UnrecoverableErrorActivity.this.moveTaskToBack(true);
-
-               System.runFinalizersOnExit(true);
-               System.exit(0);
+               CommCareApplication._().rebootCommCare(UnrecoverableErrorActivity.this);
             }
         };
         factory.setPositiveButton(Localization.get("app.storage.missing.button"), buttonListener);

--- a/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UnrecoverableErrorActivity.java
@@ -3,7 +3,6 @@ package org.commcare.dalvik.activities;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.os.Bundle;
 
 import org.commcare.dalvik.application.CommCareApplication;
@@ -40,7 +39,7 @@ public class UnrecoverableErrorActivity extends Activity {
         AlertDialogFactory factory = new AlertDialogFactory(this, title, message);
         DialogInterface.OnClickListener buttonListener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
-               CommCareApplication._().rebootCommCare(UnrecoverableErrorActivity.this);
+               CommCareApplication._().restartCommCare(UnrecoverableErrorActivity.this);
             }
         };
         factory.setPositiveButton(Localization.get("app.storage.missing.button"), buttonListener);

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -240,26 +240,30 @@ public class CommCareApplication extends Application {
         i.putExtra(UnrecoverableErrorActivity.EXTRA_ERROR_MESSAGE, message);
         i.putExtra(UnrecoverableErrorActivity.EXTRA_USE_MESSAGE, useExtraMessage);
 
-        // start a new stack and forget where we were (so we don't restart the
-        // app from there)
+        // start a new stack and forget where we were (so we don't restart the app from there)
         i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         c.startActivity(i);
     }
 
-    public void rebootCommCare(Activity activity) {
+    public static void restartCommCare(Activity activity) {
         Intent intent = new Intent(activity, DispatchActivity.class);
 
-        //Make sure that the new stack starts with a dispatch activity, and clear everything
+        // Make sure that the new stack starts with a dispatch activity, and clear everything
         // between.
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET |
-                Intent.FLAG_ACTIVITY_CLEAR_TOP |
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
                 Intent.FLAG_ACTIVITY_SINGLE_TOP |
                 Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
+        } else {
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+        }
+
         activity.moveTaskToBack(true);
         activity.startActivity(intent);
+        activity.finish();
 
-        System.runFinalizersOnExit(true);
         System.exit(0);
     }
 

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -2,6 +2,7 @@ package org.commcare.dalvik.application;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.Application;
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -74,6 +75,7 @@ import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.activities.DispatchActivity;
 import org.commcare.dalvik.activities.LoginActivity;
 import org.commcare.dalvik.activities.MessageActivity;
 import org.commcare.dalvik.activities.UnrecoverableErrorActivity;
@@ -243,6 +245,22 @@ public class CommCareApplication extends Application {
         i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         c.startActivity(i);
+    }
+
+    public void rebootCommCare(Activity activity) {
+        Intent intent = new Intent(activity, DispatchActivity.class);
+
+        //Make sure that the new stack starts with a dispatch activity, and clear everything
+        // between.
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET |
+                Intent.FLAG_ACTIVITY_CLEAR_TOP |
+                Intent.FLAG_ACTIVITY_SINGLE_TOP |
+                Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        activity.moveTaskToBack(true);
+        activity.startActivity(intent);
+
+        System.runFinalizersOnExit(true);
+        System.exit(0);
     }
 
     public void startUserSession(byte[] symetricKey, UserKeyRecord record, boolean restoreSession) {


### PR DESCRIPTION
We had a few different places in the app where we performed a restart of CommCare, and were doing it in slightly different (and in 1 case very different) ways in each. This unifies those instances to use 1 single helper method that does the restart in what (I think) is the most proper way.

@phillipm Also (mostly) fixes http://manage.dimagi.com/default.asp?186379, by performing the reboot after uninstall in a way that actually clears the back stack. This fixes the crash that was happening when you press back after being redirected to the install screen, but does NOT fix the fact that you are redirected to the install screen rather than back to the app manager..at least not entirely. This was previously a known shortcoming of the way I had set up restarting after uninstall, in that restarting CommCare consistently brought the app back to normal CommCare rather than the app manager, and I couldn't find a way around it. The odd thing is that after refactoring the way the restart is happening, it is now sometimes returning to the app manager, and sometimes returning to normal CommCare, and I can't really identify a pattern that is causing the distinction... Electing not to go crazy over that for now because it's not a huge deal, but will revisit later. 

**Question**: I tried to make sure I found all instances where we were doing a restart, but if anyone knows of something I missed, let me know please.