### PR TITLE
Remove explicit redirects to DispatchActivity + fix incorrect invalid state

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -237,13 +237,13 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     protected void onResume() {
         super.onResume();
 
-        // If clicking the regular app icon brought us to CommCareSetupActivity
-        // (because that's where we were last time the app was up), but there are now
-        // 1 or more available apps, we want to redirect to CCHomeActivity
-        if (!fromManager && !fromExternal &&
-                CommCareApplication._().usableAppsPresent()) {
-            Intent i = new Intent(this, DispatchActivity.class);
-            startActivity(i);
+        if (!fromManager && !fromExternal && CommCareApplication._().usableAppsPresent()) {
+            // If clicking the regular app icon brought us to CommCareSetupActivity
+            // (because that's where we were last time the app was up), but there are now
+            // 1 or more available apps, we want to fall back to dispatch activity
+            setResult(RESULT_OK);
+            this.finish();
+            return;
         }
 
         if (isSingleAppBuild()) {

--- a/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
@@ -125,8 +125,10 @@ public class CommCareVerificationActivity
         // the manager, or if the state of installed apps calls for it
         boolean shouldBeHere = fromManager || fromSettings || CommCareApplication._().shouldSeeMMVerification();
         if (!shouldBeHere) {
-            Intent i = new Intent(this, DispatchActivity.class);
-            startActivity(i);
+            // send back to dispatch activity
+            setResult(RESULT_OK);
+            this.finish();
+            return;
         }
     }
 

--- a/app/src/org/commcare/dalvik/activities/DispatchActivity.java
+++ b/app/src/org/commcare/dalvik/activities/DispatchActivity.java
@@ -83,15 +83,14 @@ public class DispatchActivity extends FragmentActivity {
         CommCareApp currentApp = CommCareApplication._().getCurrentApp();
 
         if (currentApp == null) {
-            // no app present, launch setup activity
             if (CommCareApplication._().usableAppsPresent()) {
-                // This is BAD -- means we ended up at home screen with no seated app, but there
-                // are other usable apps available. Should not be able to happen.
-                Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "In CommCareHomeActivity with no" +
-                        "seated app, but there are other usable apps available on the device.");
+                CommCareApplication._().initFirstUsableAppRecord();
+                // Recurse in order to make the correct decision based on the new state
+                dispatch();
+            } else {
+                Intent i = new Intent(getApplicationContext(), CommCareSetupActivity.class);
+                this.startActivityForResult(i, INIT_APP);
             }
-            Intent i = new Intent(getApplicationContext(), CommCareSetupActivity.class);
-            this.startActivityForResult(i, INIT_APP);
         } else {
             // Note that the order in which these conditions are checked matters!!
             try {

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -404,8 +404,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         // either case
         CommCareApp currentApp = CommCareApplication._().getCurrentApp();
         if (currentApp == null || !currentApp.getAppRecord().isUsable()) {
-            Intent i = new Intent(this, DispatchActivity.class);
-            startActivity(i);
+            // send back to dispatch activity
+            setResult(RESULT_OK);
+            this.finish();
             return;
         }
 


### PR DESCRIPTION
Fixes 2 multiple apps-related issues:

1) We should never be explicitly redirecting to DispatchActivity from another activity, since all activities are launched by DispatchActivity anyway and it messes up the back stack. In places where we want to direct back to dispatch for multiple apps navigation purposes, replace an explicit redirect with a call to finish().

2) After the DispatchActivity refactor, it is actually valid to be in the dispatch() method with usableAppsPresent() but no seated app; we should just attempt to seat an available app in this case.