### PR TITLE
Remove BuildConfig.DEBUG logging

### DIFF
--- a/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
+++ b/app/src/org/commcare/android/fragments/SetupEnterURLFragment.java
@@ -93,9 +93,6 @@ public class SetupEnterURLFragment extends Fragment {
             return url;
         }
         // if it's not the last (which should be "Raw") choice, we'll use the prefix
-        if (BuildConfig.DEBUG) {
-            Log.v(TAG, "Selected prefix: " + selectedPrefix + ", selected item is: " + prefixURLSpinner.getSelectedItem());
-        }
         if (selectedPrefix < prefixURLSpinner.getCount() - 1) {
             url = prefixURLSpinner.getSelectedItem() + "/" + url;
         }

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -260,9 +260,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     @Override
     public void onURLChosen(String url) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "SetupEnterURLFragment returned: " + url);
-        }
         incomingRef = url;
         this.uiState = UiState.READY_TO_INSTALL;
         uiStateScreenTransition();
@@ -312,9 +309,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         int lastIndex = fgmts != null ? fgmts.size() - 1 : -1;
         if (lastIndex > -1) {
             fragment = fgmts.get(lastIndex);
-            if (BuildConfig.DEBUG) {
-                Log.v(TAG, "Last fragment: " + fragment);
-            }
         }
         if (!(fragment instanceof SetupEnterURLFragment)) {
             // last fragment wasn't url entry, so default to the installation method chooser

--- a/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareVerificationActivity.java
@@ -234,17 +234,11 @@ public class CommCareVerificationActivity
         CommCareApplication._().getCurrentApp().setMMResourcesValidated();
         if(Intent.ACTION_VIEW.equals(CommCareVerificationActivity.this.getIntent().getAction())) {
             //Call out to CommCare Home
-            if (BuildConfig.DEBUG) {
-                Log.v(TAG, "Returning to " + DispatchActivity.class.getSimpleName() + " on success");
-            }
             Intent i = new Intent(getApplicationContext(), DispatchActivity.class);
             i.putExtra(KEY_REQUIRE_REFRESH, true);
             startActivity(i);
         } else {
             //Good to go
-            if (BuildConfig.DEBUG) {
-                Log.v(TAG, "Returning to " + getIntent().getAction() + " on success");
-            }
             Intent i = new Intent(getIntent());
             i.putExtra(KEY_REQUIRE_REFRESH, true);
             setResult(RESULT_OK, i);

--- a/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/dalvik/activities/EntitySelectActivity.java
@@ -745,9 +745,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                         searchItem.expandActionView();
                     }
                     searchView.setQuery(lastQueryString, false);
-                    if (BuildConfig.DEBUG) {
-                        Log.v(TAG, "Setting lastQueryString in searchView: (" + lastQueryString + ")");
-                    }
                     if (adapter != null) {
                         adapter.applyFilter(lastQueryString == null ? "" : lastQueryString);
                     }
@@ -997,14 +994,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             int dividerWidth = viewWidth == 0 ? (int)getResources().getDimension(R.dimen.entity_select_divider_left_inset) : (int)(viewWidth / 6.0);
 
             Drawable divider = getResources().getDrawable(R.drawable.divider_case_list_modern);
-
-            if (BuildConfig.DEBUG) {
-                Log.v(TAG, "ListView divider is: " + divider + ", estimated divider width is: " + dividerWidth + ", viewWidth (dp) is: " + viewWidthDP);
-            }
-
-            if (BuildConfig.DEBUG && (divider == null || !(divider instanceof LayerDrawable))) {
-                throw new AssertionError("Divider should be a LayerDrawable!");
-            }
 
             LayerDrawable layerDrawable = (LayerDrawable)divider;
 

--- a/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/dalvik/activities/FormRecordListActivity.java
@@ -217,9 +217,6 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         restoreLastQueryString();
 
         if (!isUsingActionBar()) {
-            if (BuildConfig.DEBUG) {
-                Log.v(TAG, "Setting lastQueryString (" + lastQueryString + ") in searchbox");
-            }
             setSearchText(lastQueryString);
         }
     }
@@ -479,9 +476,6 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
                         searchItem.expandActionView();
                     }
                     setSearchText(lastQueryString);
-                    if (BuildConfig.DEBUG) {
-                        Log.v(TAG, "Setting lastQueryString in searchView: (" + lastQueryString + ")");
-                    }
                     if (adapter != null) {
                         adapter.applyTextFilter(lastQueryString == null ? "" : lastQueryString);
                     }
@@ -580,9 +574,6 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         }
         if (!isUsingActionBar()) {
             lastQueryString = filtertext;
-            if (BuildConfig.DEBUG) {
-                Log.v(TAG, "Setting lastQueryString to (" + lastQueryString + ") in searchbox afterTextChanged event");
-            }
         }
     }
 

--- a/app/src/org/commcare/dalvik/activities/MenuList.java
+++ b/app/src/org/commcare/dalvik/activities/MenuList.java
@@ -86,9 +86,6 @@ public class MenuList extends SaveSessionCommCareActivity implements OnItemClick
         Object value = listView.getAdapter().getItem(position);
         // if value is null, probably it means that we clicked on the header view, so we just ignore it
         if (value == null) {
-            if (BuildConfig.DEBUG) {
-                Log.d("MenuList", "Null value on position " + position);
-            }
             return;
         }
         if (value instanceof Entry) {


### PR DESCRIPTION
Better to rely on a Java debugger than asserts and logs wrapped in `if (BuildConfig.DEBUG) { ... }`