### PR TITLE
Check odk view for null before dispatch in onScroll

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2243,7 +2243,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
         // The onFling() captures the 'up' event so our view thinks it gets long pressed.
         // We don't wnat that, so cancel it.
-        mCurrentView.cancelLongPress();
+        if (mCurrentView != null) {
+            mCurrentView.cancelLongPress();
+        }
         return false;
     }
 


### PR DESCRIPTION
Address NPE caused by `onScroll` being called before the ODKView gets setup (not sure how that happens...). 

https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/381ce75a8fa267043e5335130e4c6700