### PR TITLE
Don't use color vars in xml drawables

### DIFF
--- a/app/res/drawable/install_start.xml
+++ b/app/res/drawable/install_start.xml
@@ -5,5 +5,5 @@
         android:viewportHeight="232.5">
     <path
         android:pathData="M238.1,74.1l-117.2,109.2l-0.8,-0.9l-23,-24.6l-34,-36.6l25.2,-23.4l34,36.4l91.9,-85.7z"
-        android:fillColor="@color/cc_install_button_bg"/>
+        android:fillColor="#D6EACC"/>
 </vector>

--- a/app/res/drawable/install_stop.xml
+++ b/app/res/drawable/install_stop.xml
@@ -5,5 +5,5 @@
         android:viewportHeight="232.5">
     <path
         android:pathData="M213.8,153.8l-38.4,-38.3l38.4,-38.2l-25.5,-25.5l-38.3,38.2l-38.2,-38.2l-25.5,25.5l38.2,38.2l-38.2,38.3l25.5,25.5l38.2,-38.3l38.3,38.3z"
-        android:fillColor="@color/cc_install_stop_button_bg"/>
+        android:fillColor="#D7D6D4"/>
 </vector>

--- a/app/res/drawable/update_recheck.xml
+++ b/app/res/drawable/update_recheck.xml
@@ -5,8 +5,8 @@
         android:viewportHeight="232.5">
     <path
         android:pathData="M150,156.3l37.5,-56.3l-18.8,0l0,-56.2l-37.4,0l0,56.2l-18.8,0z"
-        android:fillColor="@color/cc_update_recheck_button_bg"/>
+        android:fillColor="#C1DFF5"/>
     <path
         android:pathData="M225,188.8l0,-56.3l-18.7,0l0,37.5l-112.6,0l0,-37.5l-18.7,0l0,56.3z"
-        android:fillColor="@color/cc_update_recheck_button_bg"/>
+        android:fillColor="#C1DFF5"/>
 </vector>

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -129,9 +129,4 @@
     <!-- Error Colors -->
     <color name="cc_error_bg_color">#EE5555</color>
     <color name="cc_error_text_color">#FFFFFF</color>
-
-    <!-- Install/Update Button Colors -->
-    <color name="cc_install_stop_button_bg">#D7D6D4</color>
-    <color name="cc_install_button_bg">#D6EACC</color>
-    <color name="cc_update_recheck_button_bg">#C1DFF5</color>
 </resources>


### PR DESCRIPTION
The linter is always right...

This PR fixes a small bug where some button graphics appeared black. Was introduced in by https://github.com/dimagi/commcare-odk/pull/922 while trying to address https://github.com/dimagi/commcare-odk/pull/922#discussion_r48736171

The way that these drawables are loaded makes it such that they aren't able to reference color resources. Specifically, gradle will convert the xml vector drawables to PNGs at compile time, which I guess means they don't have access to specific resource references. The linter told me this, I thought I checked that it still worked, but I guess I didn't do a good job of that...