### PR TITLE
App version code setting wasn't happening; fix that

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ def ccDomainSafe = ccDomain.replaceAll("-", "")
  * 
  * @return int If the param -PversionCode is present then return int value or 1
  */
-def computeVersionCode() = {
+def computeVersionCode() {
     def code = project.hasProperty('versionCode') ? versionCode.toInteger() : 1
     println "VersionCode is set to $code"
     return code

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,23 @@ def ccAppId = project.hasProperty('cc_app_id') ? cc_app_id : ""
 def ccDomain = project.hasProperty('cc_domain') ? cc_domain : ""
 def ccDomainSafe = ccDomain.replaceAll("-", "")
 
+/**
+ * Get the version code from command line param
+ * 
+ * @return int If the param -PversionCode is present then return int value or 1
+ */
+def computeVersionCode() = {
+    def code = project.hasProperty('versionCode') ? versionCode.toInteger() : 1
+    println "VersionCode is set to $code"
+    return code
+}
+
+def getDate() {
+    def date = new Date()
+    def formattedDate = date.format('yyyy-MM-dd')
+    return formattedDate
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -122,7 +139,7 @@ android {
         def odkProviderStr = "org.commcare.android.provider.odk"
         manifestPlaceholders = [ odkProvider:odkProviderStr]
 
-        versionCode getVersionCode()
+        versionCode computeVersionCode()
 
         // when set, app won't show install screen and try to install
         // resources from assets folder
@@ -136,7 +153,7 @@ android {
         buildConfigField "String", "ACRA_USER", "\"${project.ext.ACRA_USER}\""
         buildConfigField "String", "MAPS_API_KEY", "\"${project.ext.MAPS_API_KEY}\""
         buildConfigField "String", "BUILD_DATE", "\"" + getDate() + "\""
-        buildConfigField "String", "BUILD_NUMBER", "\"" + getVersionCode() + "\""
+        buildConfigField "String", "BUILD_NUMBER", "\"" + computeVersionCode() + "\""
         buildConfigField "String", "TRUSTED_SOURCE_PUBLIC_KEY", "\"${project.ext.TRUSTED_SOURCE_PUBLIC_KEY}\""
     }
 
@@ -320,21 +337,4 @@ def numbersToLetters(String version) {
         }
     }
     return words.toString();
-}
-
-/**
- * Get the version code from command line param
- * 
- * @return int If the param -PversionCode is present then return int value or 1
- */
-def getVersionCode = { ->
-    def code = project.hasProperty('versionCode') ? versionCode.toInteger() : 1
-    println "VersionCode is set to $code"
-    return code
-}
-
-def getDate() {
-    def date = new Date()
-    def formattedDate = date.format('yyyy-MM-dd')
-    return formattedDate
 }


### PR DESCRIPTION
Somewhere between 2.25 and now version code setting got messed up: probably https://github.com/dimagi/commcare-odk/pull/909 ...

Turns out there is already a method called `getVersionCode` so the one I had defined in the build.gradle file wasn't getting called.

Groovy also likes it when method defs come before method usages.