### PR TITLE
Rename CommCareUserOpenHelper to be consistent w/ other openers

### DIFF
--- a/app/src/org/commcare/android/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/android/database/user/DatabaseUserOpenHelper.java
@@ -15,18 +15,19 @@ import org.commcare.android.database.user.models.EntityStorageCache;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.GeocodeCacheModel;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
-import org.javarosa.core.model.User;
 import org.commcare.android.javarosa.DeviceReportRecord;
 import org.commcare.cases.ledger.Ledger;
 import org.commcare.dalvik.application.CommCareApplication;
+import org.javarosa.core.model.User;
 import org.javarosa.core.model.instance.FormInstance;
 
 /**
- * The central db point for
+ * The helper for opening/updating the user (encrypted) db space for
+ * CommCare. This stores users, cases, fixtures, form records, etc.
  *
  * @author ctsims
  */
-public class CommCareUserOpenHelper extends SQLiteOpenHelper {
+public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
 
     /**
      * Version History
@@ -49,7 +50,7 @@ public class CommCareUserOpenHelper extends SQLiteOpenHelper {
 
     private final String mUserId;
 
-    public CommCareUserOpenHelper(Context context, String userId) {
+    public DatabaseUserOpenHelper(Context context, String userId) {
         super(context, getDbName(userId), null, USER_DB_VERSION);
         this.context = context;
         this.mUserId = userId;

--- a/app/src/org/commcare/android/database/user/DemoUserBuilder.java
+++ b/app/src/org/commcare/android/database/user/DemoUserBuilder.java
@@ -92,7 +92,7 @@ public class DemoUserBuilder {
     private void writeNewUser(UserKeyRecord keyRecord) {
         SQLiteDatabase userDatabase = null;
         try {
-            userDatabase = new CommCareUserOpenHelper(CommCareApplication._(),
+            userDatabase = new DatabaseUserOpenHelper(CommCareApplication._(),
                     keyRecord.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(randomKey));
 
             User user = new User(username, passwordHash, username, userType);

--- a/app/src/org/commcare/android/database/user/UserSandboxUtils.java
+++ b/app/src/org/commcare/android/database/user/UserSandboxUtils.java
@@ -33,8 +33,8 @@ public class UserSandboxUtils {
         //Step one: Make a copy of the incoming sandbox's database and re-key it to use the new key.
         Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Migrating an existing user sandbox for " + newSandbox.getUsername());
 
-        File oldDb = c.getDatabasePath(CommCareUserOpenHelper.getDbName(incomingSandbox.getUuid()));
-        File newDb = c.getDatabasePath(CommCareUserOpenHelper.getDbName(newSandbox.getUuid()));
+        File oldDb = c.getDatabasePath(DatabaseUserOpenHelper.getDbName(incomingSandbox.getUuid()));
+        File newDb = c.getDatabasePath(DatabaseUserOpenHelper.getDbName(newSandbox.getUuid()));
 
         //TODO: Make sure old sandbox is already on newest version?
 
@@ -62,7 +62,7 @@ public class UserSandboxUtils {
 
         //OK, so now we have the Db transitioned. What we need to do now is go through and rekey all of our file references.
 
-        final SQLiteDatabase db = new CommCareUserOpenHelper(CommCareApplication._(), newSandbox.getUuid()).getWritableDatabase(newKeyEncoded);
+        final SQLiteDatabase db = new DatabaseUserOpenHelper(CommCareApplication._(), newSandbox.getUuid()).getWritableDatabase(newKeyEncoded);
 
         try {
 
@@ -193,14 +193,14 @@ public class UserSandboxUtils {
         //Ok, three steps here. Wipe files out, wipe database, remove key record
 
         //If the db is gone already, just remove the record and move on (something odd has happened)
-        if (!context.getDatabasePath(CommCareUserOpenHelper.getDbName(sandbox.getUuid())).exists()) {
+        if (!context.getDatabasePath(DatabaseUserOpenHelper.getDbName(sandbox.getUuid())).exists()) {
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Sandbox " + sandbox.getUuid() + " has already been purged. removing the record");
 
             SqlStorage<UserKeyRecord> ukr = app.getStorage(UserKeyRecord.class);
             ukr.remove(sandbox);
         }
 
-        final SQLiteDatabase db = new CommCareUserOpenHelper(CommCareApplication._(), sandbox.getUuid()).getWritableDatabase(getSqlCipherEncodedKey(key));
+        final SQLiteDatabase db = new DatabaseUserOpenHelper(CommCareApplication._(), sandbox.getUuid()).getWritableDatabase(getSqlCipherEncodedKey(key));
 
         try {
             AndroidDbHelper dbh = new AndroidDbHelper(context) {
@@ -249,7 +249,7 @@ public class UserSandboxUtils {
 
         Logger.log(AndroidLogger.TYPE_MAINTENANCE, "All files removed for sandbox. Deleting DB");
 
-        context.getDatabasePath(CommCareUserOpenHelper.getDbName(sandbox.getUuid())).delete();
+        context.getDatabasePath(DatabaseUserOpenHelper.getDbName(sandbox.getUuid())).delete();
 
         Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Database is gone. Get rid of this record");
 

--- a/app/src/org/commcare/android/db/legacy/LegacyInstallUtils.java
+++ b/app/src/org/commcare/android/db/legacy/LegacyInstallUtils.java
@@ -21,7 +21,7 @@ import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.app.models.ResourceModelUpdater;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.global.models.ApplicationRecord;
-import org.commcare.android.database.user.CommCareUserOpenHelper;
+import org.commcare.android.database.user.DatabaseUserOpenHelper;
 import org.commcare.android.database.user.UserSandboxUtils;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.android.database.user.models.FormRecord;
@@ -457,12 +457,12 @@ public class LegacyInstallUtils {
         SQLiteDatabase ourDb;
         //If we were able to iterate over the users, the key was fine, so let's use it to open our db
         try {
-            ourDb = new CommCareUserOpenHelper(CommCareApplication._(), ukr.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(oldKey));
+            ourDb = new DatabaseUserOpenHelper(CommCareApplication._(), ukr.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(oldKey));
         } catch (SQLiteException sle) {
             //Our database got corrupted. Fortunately this represents a new record, so we can't actually need it.
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Attempted migrated database got corrupted. Deleting it and starting over");
-            c.getDatabasePath(CommCareUserOpenHelper.getDbName(ukr.getUuid())).delete();
-            ourDb = new CommCareUserOpenHelper(CommCareApplication._(), ukr.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(oldKey));
+            c.getDatabasePath(DatabaseUserOpenHelper.getDbName(ukr.getUuid())).delete();
+            ourDb = new DatabaseUserOpenHelper(CommCareApplication._(), ukr.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(oldKey));
         }
 
         final SQLiteDatabase currentUserDatabase = ourDb;

--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -43,7 +43,7 @@ import org.commcare.android.database.app.DatabaseAppOpenHelper;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.global.DatabaseGlobalOpenHelper;
 import org.commcare.android.database.global.models.ApplicationRecord;
-import org.commcare.android.database.user.CommCareUserOpenHelper;
+import org.commcare.android.database.user.DatabaseUserOpenHelper;
 import org.commcare.android.db.legacy.LegacyInstallUtils;
 import org.commcare.android.framework.SessionActivityRegistration;
 import org.commcare.android.javarosa.AndroidLogEntry;
@@ -610,7 +610,7 @@ public class CommCareApplication extends Application {
         // 4) Delete all the user databases associated with this app
         SqlStorage<UserKeyRecord> userDatabase = app.getStorage(UserKeyRecord.class);
         for (UserKeyRecord user : userDatabase) {
-            File f = getDatabasePath(CommCareUserOpenHelper.getDbName(user.getUuid()));
+            File f = getDatabasePath(DatabaseUserOpenHelper.getDbName(user.getUuid()));
             if (!FileUtil.deleteFileOrDir(f)) {
                 Logger.log(AndroidLogger.TYPE_RESOURCES, "A user database was unable to be " +
                         "deleted during app uninstall. Aborting uninstall process for now.");
@@ -788,7 +788,7 @@ public class CommCareApplication extends Application {
         for (String id : dbIdsToRemove) {
             //TODO: We only wanna do this if the user is the _last_ one with a key to this id, actually.
             //(Eventually)
-            this.getDatabasePath(CommCareUserOpenHelper.getDbName(id)).delete();
+            this.getDatabasePath(DatabaseUserOpenHelper.getDbName(id)).delete();
         }
         CommCareApplication._().closeUserSession();
     }

--- a/app/src/org/commcare/dalvik/services/CommCareSessionService.java
+++ b/app/src/org/commcare/dalvik/services/CommCareSessionService.java
@@ -17,7 +17,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 import org.commcare.android.crypt.CipherPool;
 import org.commcare.android.crypt.CryptUtil;
 import org.commcare.android.database.app.models.UserKeyRecord;
-import org.commcare.android.database.user.CommCareUserOpenHelper;
+import org.commcare.android.database.user.DatabaseUserOpenHelper;
 import org.commcare.android.database.user.UserSandboxUtils;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.tasks.DataSubmissionListener;
@@ -25,7 +25,6 @@ import org.commcare.android.tasks.ProcessAndSendTask;
 import org.commcare.android.util.SessionStateUninitException;
 import org.commcare.android.util.SessionUnavailableException;
 import org.commcare.dalvik.R;
-import org.commcare.dalvik.activities.CommCareHomeActivity;
 import org.commcare.dalvik.activities.DispatchActivity;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.preferences.CommCarePreferences;
@@ -252,7 +251,7 @@ public class CommCareSessionService extends Service {
             if (userDatabase != null && userDatabase.isOpen()) {
                 userDatabase.close();
             }
-            userDatabase = new CommCareUserOpenHelper(CommCareApplication._(), record.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(key));
+            userDatabase = new DatabaseUserOpenHelper(CommCareApplication._(), record.getUuid()).getWritableDatabase(UserSandboxUtils.getSqlCipherEncodedKey(key));
         }
     }
 

--- a/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -6,7 +6,7 @@ import org.commcare.android.cases.AndroidCaseInstanceTreeElement;
 import org.commcare.android.database.ConcreteAndroidDbHelper;
 import org.commcare.android.database.DbUtil;
 import org.commcare.android.database.SqlStorage;
-import org.commcare.android.database.user.CommCareUserOpenHelper;
+import org.commcare.android.database.user.DatabaseUserOpenHelper;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.android.database.user.models.CaseIndexTable;
 import org.commcare.android.database.user.models.EntityStorageCache;
@@ -153,7 +153,7 @@ public class TestUtils {
      * @return The hook for the test user-db 
      */
     public static SQLiteDatabase getTestDb() {
-        CommCareUserOpenHelper helper = new CommCareUserOpenHelper(RuntimeEnvironment.application, "Test");
+        DatabaseUserOpenHelper helper = new DatabaseUserOpenHelper(RuntimeEnvironment.application, "Test");
         return helper.getWritableDatabase("Test");
     }
 


### PR DESCRIPTION
Rename `CommCareUserOpenHelper` to be consistent with other database open helpers like `DatabaseAppOpenHelper` and `DatabaseGlobalOpenHelper`