### PR TITLE
Ensure form save task doesn't cancel when headless

### DIFF
--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tasks.templates;
 
 import android.os.AsyncTask;
+import android.util.Log;
 
 import org.javarosa.core.services.Logger;
 
@@ -148,6 +149,7 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver> extends M
                 // dialog/activity (i.e. task id != -1) then cancel because the
                 // task isn't expected to live past the associated
                 // dialog/activity
+                Log.d(TAG, "Cancelling " + TAG + " because the activity it was connected to is gone");
                 this.cancel(false);
             }
 

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -84,7 +84,12 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
         this.instanceContentUri = instanceContentUri;
         this.symetricKey = symetricKey;
         this.headless = headless;
-        this.taskId = SAVING_TASK_ID;
+
+        if (headless) {
+            this.taskId = -1;
+        } else {
+            this.taskId = SAVING_TASK_ID;
+        }
     }
 
     /**


### PR DESCRIPTION
Changes in https://github.com/dimagi/commcare-odk/pull/862 seem to have broken form saving upon session expiration. The issue was that the form save task was happening without being connected to an activity but using a non-negative task id, causing it to get cancelled via code in `CommCareTask`

Added logging to the task cancelling code in `CommCareTask` in case it is cancelling other tasks without us wanting it to.