### PR TITLE
Fix form save on session expiration

### DIFF
--- a/app/src/org/commcare/android/framework/SessionActivityRegistration.java
+++ b/app/src/org/commcare/android/framework/SessionActivityRegistration.java
@@ -82,7 +82,7 @@ public class SessionActivityRegistration {
      */
     private static void redirectToLogin(Context context) {
         Intent i = new Intent(context.getApplicationContext(), DispatchActivity.class);
-        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         context.startActivity(i);
     }
 }

--- a/app/src/org/odk/collect/android/listeners/FormSavedListener.java
+++ b/app/src/org/odk/collect/android/listeners/FormSavedListener.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.odk.collect.android.listeners;
 
 /**

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -331,7 +331,6 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
         }
     }
 
-
     /**
      * This method actually writes the xml to disk.
      */

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -348,13 +348,16 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
         }
     }
 
-
     @Override
-    protected void deliverResult(R receiver, Integer result) {
+    protected void onPostExecute(Integer result) {
         synchronized (this) {
             if (mSavedListener != null)
                 mSavedListener.savingComplete(result, headless);
         }
+    }
+
+    @Override
+    protected void deliverResult(R receiver, Integer result) {
     }
 
     @Override


### PR DESCRIPTION
Looks like form saving wasn't happening anymore when the user session expired.

Solution is to move form save callback code from `deliverResult`, which is only invoked when there is an activity (receiver) attached to the task, into `onPostExecute` which is always called.

Probably caused by refactors to CommCareTask that made it stricter in its behavior (like https://github.com/dimagi/commcare-odk/pull/862)

Also fix the way the login activity is launched when the session expires, which broke when I introduced the `DispatchActivity`