### PR TITLE
Prevent home screen button loading on user data clearing

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -271,7 +271,7 @@ public class CommCareHomeActivity
             // if handling new return code (want to return to home screen) but a return at the end of your statement
             switch(requestCode) {
             case PREFERENCES_ACTIVITY:
-                if (resultCode == RESULT_CANCELED) {
+                if (resultCode != CommCarePreferences.RESULT_DATA_RESET) {
                     // rebuild home buttons in case language changed;
                     // but only if we didn't just clear user data
                     uiController.setupUI();

--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -271,8 +271,11 @@ public class CommCareHomeActivity
             // if handling new return code (want to return to home screen) but a return at the end of your statement
             switch(requestCode) {
             case PREFERENCES_ACTIVITY:
-                // rebuild buttons in case language was changed
-                uiController.setupUI();
+                if (resultCode == RESULT_CANCELED) {
+                    // rebuild home buttons in case language changed;
+                    // but only if we didn't just clear user data
+                    uiController.setupUI();
+                }
                 rebuildOptionMenu();
                 return;
             case MEDIA_VALIDATOR_ACTIVITY:

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -99,6 +99,8 @@ public class CommCarePreferences
     private static final int SUPERUSER_PREFS = Menu.FIRST + 3;
     private static final int MENU_CLEAR_SAVED_SESSION = Menu.FIRST + 4;
 
+    public static final int RESULT_DATA_RESET = RESULT_FIRST_USER + 1;
+
     // Fields for setting print template
     private static final int REQUEST_TEMPLATE = 0;
     public final static String PRINT_DOC_LOCATION = "print_doc_location";
@@ -189,7 +191,7 @@ public class CommCarePreferences
         switch (item.getItemId()) {
             case CLEAR_USER_DATA:
                 CommCareApplication._().clearUserData();
-                setResult(RESULT_OK);
+                setResult(RESULT_DATA_RESET);
                 this.finish();
                 return true;
             case FORCE_LOG_SUBMIT:

--- a/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java
@@ -189,6 +189,7 @@ public class CommCarePreferences
         switch (item.getItemId()) {
             case CLEAR_USER_DATA:
                 CommCareApplication._().clearUserData();
+                setResult(RESULT_OK);
                 this.finish();
                 return true;
             case FORCE_LOG_SUBMIT:


### PR DESCRIPTION
Small bug where clearing user data causes app to crash due to changes in https://github.com/dimagi/commcare-odk/pull/991