### PR TITLE
2.25.3 hotfix: persist login dialog and save form on session expiration

### DIFF
--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -209,6 +209,8 @@ public class LoginActivity extends CommCareActivity<LoginActivity> implements On
 
     @Override
     public void onSaveInstanceState(Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+
         String enteredUsername = username.getText().toString();
         if (!"".equals(enteredUsername) && enteredUsername != null) {
             savedInstanceState.putString(KEY_ENTERED_USER, enteredUsername);

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -84,7 +84,11 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
         this.instanceContentUri = instanceContentUri;
         this.symetricKey = symetricKey;
         this.headless = headless;
-        this.taskId = SAVING_TASK_ID;
+        if (headless) {
+            this.taskId = -1;
+        } else {
+            this.taskId = SAVING_TASK_ID;
+        }
     }
 
     /**
@@ -346,11 +350,15 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
 
 
     @Override
-    protected void deliverResult(R receiver, Integer result) {
+    protected void onPostExecute(Integer result) {
         synchronized (this) {
             if (mSavedListener != null)
                 mSavedListener.savingComplete(result, headless);
         }
+    }
+
+    @Override
+    protected void deliverResult(R receiver, Integer result) {
     }
 
     @Override


### PR DESCRIPTION
Issue worth hotfixing: when the user session expires during form entry the form is supposed to save and the user should immediately be forwarded to the login screen. This broke in 2.25, probably due to a refactor to the task connector logic, https://github.com/dimagi/commcare-odk/pull/862.

Additionally, if you rotate the screen when the login progress dialog is showing then the dialog disappears, while the task continues. This results in the login not occurring in certain cases, because the task result callback launches additional login logic. This broke in 2.25 due to a bug fix that persisted login text, https://github.com/dimagi/commcare-odk/pull/890

Fix for:
http://manage.dimagi.com/default.asp?200782
http://manage.dimagi.com/default.asp?190893

Similar PRs targeting master:
https://github.com/dimagi/commcare-odk/pull/990
https://github.com/dimagi/commcare-odk/pull/994