### PR TITLE
2nd part of 2.25.3 hotfix: Don't launch login using single top flag

### DIFF
--- a/app/src/org/commcare/android/framework/SessionActivityRegistration.java
+++ b/app/src/org/commcare/android/framework/SessionActivityRegistration.java
@@ -82,7 +82,7 @@ public class SessionActivityRegistration {
      */
     private static void letHomeScreenRedirectToLogin(Context context) {
         Intent i = new Intent(context.getApplicationContext(), CommCareHomeActivity.class);
-        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         context.startActivity(i);
     }
 }


### PR DESCRIPTION
Using the `FLAG_ACTIVITY_SINGLE_TOP` along with `FLAG_ACTIVITY_CLEAR_TOP` causes the existing `CommCareHomeActivity` to first be finished ([see here](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_CLEAR_TOP)), which routes code through `CommCareHomeActivity.onActivityResult`, in turn launching `processReturnFromFormEntry`, which causes a form save toast message to pop up when it shouldn't.

Tested the backstack by pressing back after being redirected to the logout screen on an Android 6 and 4.4.2 devices. Looked fine.