### PR TITLE
Fix clear user data crash

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareHomeActivity.java
@@ -271,6 +271,10 @@ public class CommCareHomeActivity
             // if handling new return code (want to return to home screen) but a return at the end of your statement
             switch(requestCode) {
             case PREFERENCES_ACTIVITY:
+                if (sessionWasEnded()) {
+                    // We may have just cleared user data, in which case calling UI methods will crash
+                    return;
+                }
                 // rebuild buttons in case language was changed
                 uiController.setupUI();
                 rebuildOptionMenu();
@@ -417,6 +421,21 @@ public class CommCareHomeActivity
             startNextSessionStepSafe();
         }
         super.onActivityResult(requestCode, resultCode, intent);
+    }
+
+    private boolean sessionWasEnded() {
+        try {
+            if (!CommCareApplication._().getSession().isActive()) {
+                setResult(RESULT_OK);
+                this.finish();
+                return true;
+            }
+            return false;
+        } catch (SessionUnavailableException e) {
+            setResult(RESULT_OK);
+            this.finish();
+            return true;
+        }
     }
 
     private void startNextSessionStepSafe() {


### PR DESCRIPTION
The fix for refreshing home screen languages (https://github.com/dimagi/commcare-odk/pull/991) makes CC crash when you clear user data, because that call to setupUI() requires a logged-in user. Fix is to check before we make that call for if the user session has been closed, and finish/return if so.