### PR TITLE
Round II : Fix LoginActivity fragments not restoring properly

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -100,13 +100,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     private boolean isMainScreenBlocked;
 
     @Override
-    @TargetApi(14)
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         FragmentManager fm = this.getSupportFragmentManager();
 
-        stateHolder = (TaskConnectorFragment) fm.findFragmentByTag("state");
+        stateHolder = (TaskConnectorFragment<R>) fm.findFragmentByTag("state");
 
         // stateHolder and its previous state aren't null if the activity is
         // being created due to an orientation change.

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -210,7 +210,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     private void persistCommCareAppState() {
         FragmentManager fm = this.getSupportFragmentManager();
 
-        containerFragment = (ContainerFragment) fm.findFragmentByTag("cc-app");
+        containerFragment = (ContainerFragment<CommCareApp>) fm.findFragmentByTag("cc-app");
 
         if (containerFragment == null) {
             containerFragment = new ContainerFragment<>();

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -132,7 +132,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     }
 
     @Override
-    public void onSaveInstanceState(Bundle savedInstanceState) {
+    protected void onSaveInstanceState(Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+
         String enteredUsername = uiController.getEnteredUsername();
         if (!"".equals(enteredUsername) && enteredUsername != null) {
             savedInstanceState.putString(KEY_ENTERED_USER, enteredUsername);
@@ -267,7 +269,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     }
 
     @Override
-    public void onResumeFragments() {
+    protected void onResumeFragments() {
         super.onResumeFragments();
 
         tryAutoLogin();


### PR DESCRIPTION
Turns out when you don't call `super.onSaveInstanceState` when overriding `onSaveInstanceState`, then none of your fragments get restored :boom:

The result is that rotating the screen while any login task is running detaches the task from the activity, making the progress dialog disappear

Fix for http://manage.dimagi.com/default.asp?200782