### PR TITLE
Add hereFunctionHandler to entityDetailFragment

### DIFF
--- a/app/src/org/commcare/android/framework/EntityDetailFragment.java
+++ b/app/src/org/commcare/android/framework/EntityDetailFragment.java
@@ -18,6 +18,7 @@ import org.commcare.android.models.NodeEntityFactory;
 import org.commcare.android.util.DetailCalloutListener;
 import org.commcare.android.util.SerializationUtil;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.activities.EntitySelectActivity;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.suite.model.Detail;
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -110,10 +111,14 @@ public class EntityDetailFragment extends Fragment {
     }
 
     protected EvaluationContext getFactoryContext(TreeReference childReference) {
+        EvaluationContext factoryContext;
         if (getArguments().getInt(CHILD_DETAIL_INDEX, -1) != -1) {
-            return prepareEvaluationContext(childReference);
+            factoryContext = prepareEvaluationContext(childReference);
+        } else {
+            factoryContext = asw.getEvaluationContext();
         }
-        return asw.getEvaluationContext();
+        factoryContext.addFunctionHandler(EntitySelectActivity.getHereFunctionHandler());
+        return factoryContext;
     }
 
     /**

--- a/app/src/org/commcare/android/storage/framework/Persisted.java
+++ b/app/src/org/commcare/android/storage/framework/Persisted.java
@@ -38,7 +38,7 @@ public class Persisted implements Persistable, IMetaData {
                 readVal(f, this, in, pf);
             }
         } catch (IllegalAccessException iae) {
-            throw new DeserializationException(currentField == null ? "" : (" for field" + currentField));
+            throw new DeserializationException(currentField == null ? "" : (" for field" + currentField), iae);
         }
     }
 

--- a/app/src/org/commcare/android/storage/framework/Persisted.java
+++ b/app/src/org/commcare/android/storage/framework/Persisted.java
@@ -38,7 +38,7 @@ public class Persisted implements Persistable, IMetaData {
                 readVal(f, this, in, pf);
             }
         } catch (IllegalAccessException iae) {
-            throw new DeserializationException(currentField == null ? "" : (" for field" + currentField), iae);
+            throw new DeserializationException(currentField == null ? "" : (" for field" + currentField));
         }
     }
 


### PR DESCRIPTION
Fixed bug where "invalid XPath" was showing up in the detail view.

I wonder if there's a better way in the future to allow activities to use the here() function, without requiring them to addFunctionHandler whenever the evaluationContext is used.