### PR TITLE
Make test framework use custom uncaught exception handler

### DIFF
--- a/unit-tests/src/org/commcare/dalvik/application/CommCareTestApplication.java
+++ b/unit-tests/src/org/commcare/dalvik/application/CommCareTestApplication.java
@@ -3,11 +3,24 @@ package org.commcare.dalvik.application;
 import org.commcare.android.database.HybridFileBackedSqlStorage;
 import org.commcare.android.database.HybridFileBackedSqlStorageMock;
 import org.javarosa.core.services.storage.Persistable;
+import org.junit.Assert;
 
 /**
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class CommCareTestApplication extends CommCareApplication {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread thread, Throwable ex) {
+                Assert.fail(ex.getMessage());
+            }
+        });
+    }
+
     @Override
     public <T extends Persistable> HybridFileBackedSqlStorage<T> getFileBackedAppStorage(String name, Class<T> c) {
         return getCurrentApp().getFileBackedStorage(name, c);


### PR DESCRIPTION
Sometimes running tests crashes my local machine because an uncaught exception triggers http log reporting, which somehow freezes my machine... hoping this addresses it.