### PR TITLE
Don't proguard Bypass markup lib

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -46,6 +46,7 @@
 -keep class org.odk.collect.android.** { *; }
 -keep class org.javarosa.** { *; }
 -keep class com.readystatesoftware.** { *; }
+-keep class in.uncod.android.bypass.** { *; }
 
 -dontwarn sun.misc.Unsafe
 


### PR DESCRIPTION
Was getting a crash during form entry of TDH app linked to methods missing in bypass markup lib.

Blindly telling proguard to keep all code in that lib.