### PR TITLE
Call super.onPostExecute to get task connector code

### DIFF
--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -318,6 +318,8 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
 
     @Override
     protected void onPostExecute(Integer result) {
+        super.onPostExecute(result);
+
         synchronized (this) {
             if (mSavedListener != null)
                 mSavedListener.savingComplete(result, headless);


### PR DESCRIPTION
Saving a form via "Settings -> Save Form" leaves the save dialog up forever...

Gonna hotfix this, but might as well get it into master/2.26 now

http://manage.dimagi.com/default.asp?210500