### PR TITLE
Hotfix 2.25.4: Call super.onPostExecute to get task connector code

### DIFF
--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -351,6 +351,8 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
 
     @Override
     protected void onPostExecute(Integer result) {
+        super.onPostExecute(result);
+
         synchronized (this) {
             if (mSavedListener != null)
                 mSavedListener.savingComplete(result, headless);


### PR DESCRIPTION
Saving a form via "Settings -> Save Form" leaves the save dialog up forever.
Introduced by 2.25.3 hotfix

http://manage.dimagi.com/default.asp?210500