### PR TITLE
Remove mapballoons from proguard, add some includedescriptorclasses

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -42,10 +42,9 @@
 -keepattributes Signature,RuntimeVisibleAnnotations,AnnotationDefault,*Annotation*
 
 -keep,allowshrinking,allowoptimization class org.xmlpull.**
--keep class org.commcare.** { *; }
--keep class org.odk.collect.android.** { *; }
--keep class org.javarosa.** { *; }
--keep class com.readystatesoftware.** { *; }
+-keep,includedescriptorclasses class org.commcare.** { *; }
+-keep,includedescriptorclasses class org.odk.collect.android.** { *; }
+-keep,includedescriptorclasses class org.javarosa.** { *; }
 -keep class in.uncod.android.bypass.** { *; }
 
 -dontwarn sun.misc.Unsafe


### PR DESCRIPTION
Release builds are failing due to some proguard warnings