### PR TITLE
2.25.5 hotfix -- Fix dynamic refresh of question list content

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -621,14 +621,15 @@ public class FormEntryActivity extends SessionAwareCommCareActivity<FormEntryAct
         }
     }
 
-    private void updateFormRelevancies(){
-        saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
-
+    private void updateFormRelevancies() {
+        
         ArrayList<QuestionWidget> oldWidgets = mCurrentView.getWidgets();
         // These 2 calls need to be made here, rather than in the for loop below, because at that
         // point the widgets will have already started being updated to the values for the new view
         ArrayList<Vector<SelectChoice>> oldSelectChoices = getOldSelectChoicesForEachWidget(oldWidgets);
         ArrayList<String> oldQuestionTexts = getOldQuestionTextsForEachWidget(oldWidgets);
+
+        saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
 
         FormEntryPrompt[] newValidPrompts = mFormController.getQuestionPrompts();
         Set<FormEntryPrompt> promptsLeftInView = new HashSet<>();


### PR DESCRIPTION
Move call to saveAnswers() so that old widgets haven't updated yet