### PR TITLE
Force logout to apply app update

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -12,13 +12,11 @@ updates.check.begin=Checking for updates...
 updates.check.failed=Failed to download updates
 updates.check.start=Recheck
 updates.check.cancel=Stop checking
-updates.check.install=Install
 updates.check.cancelling=Cancelling check for updates
 updates.install.finished=App update was successful
 updates.check.network_unavailable=No network connectivity
-updates.staged.version=Update to version ${0}
+updates.staged.version=Update to version ${0} & log out
 updates.error=Error encountered during update download
-updates.applied.on.login=(downloaded update will automatically be applied on next login.)
 
 updates.pinned.download=Downloading updates
 updates.pinned.progress=${0}/${1}

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -16,6 +16,7 @@ updates.check.cancelling=Cancelling check for updates
 updates.install.finished=App update was successful
 updates.check.network_unavailable=No network connectivity
 updates.staged.version=Update to version ${0} & log out
+updates.staged.version.app.manager=Update to version ${0}
 updates.error=Error encountered during update download
 
 updates.pinned.download=Downloading updates

--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -84,10 +84,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     private static final int SMS_PERMISSIONS_REQUEST = 2;
 
-    /**
-     * Should the user be logged out when this activity is done?
-     */
-    public static final String KEY_REQUIRE_REFRESH = "require_referesh";
     public static final String KEY_INSTALL_FAILED = "install_failed";
 
     /**
@@ -631,12 +627,10 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         if (Intent.ACTION_VIEW.equals(CommCareSetupActivity.this.getIntent().getAction())) {
             //Call out to CommCare Home
             Intent i = new Intent(getApplicationContext(), DispatchActivity.class);
-            i.putExtra(KEY_REQUIRE_REFRESH, requireRefresh);
             startActivity(i);
         } else {
             //Good to go
             Intent i = new Intent(getIntent());
-            i.putExtra(KEY_REQUIRE_REFRESH, requireRefresh);
             i.putExtra(KEY_INSTALL_FAILED, failed);
             setResult(RESULT_OK, i);
         }

--- a/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
@@ -18,7 +18,6 @@ import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.AlertDialogFactory;
 import org.commcare.dalvik.services.CommCareSessionService;
-import org.javarosa.core.services.locale.Localization;
 
 
 /**
@@ -125,12 +124,6 @@ public class SingleAppManagerActivity extends Activity {
                         Toast.makeText(this, R.string.update_canceled, Toast.LENGTH_LONG).show();
                         task.cancel(true);
                     }
-                } else if (resultCode == RESULT_OK) {
-                    if (intent.getBooleanExtra(CommCareSetupActivity.KEY_REQUIRE_REFRESH, true)) {
-                        Toast.makeText(this, Localization.get("update.success"), Toast.LENGTH_LONG).show();
-                        CommCareApplication._().expireUserSession();
-                    }
-                    return;
                 }
                 break;
             case DispatchActivity.MISSING_MEDIA_ACTIVITY:
@@ -225,6 +218,7 @@ public class SingleAppManagerActivity extends Activity {
             CommCareSessionService s = CommCareApplication._().getSession();
             if (s.isActive()) {
                 triggerLogoutWarning(LOGOUT_FOR_UPDATE);
+                update();
             } else {
                 update();
             }

--- a/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/dalvik/activities/SingleAppManagerActivity.java
@@ -218,7 +218,6 @@ public class SingleAppManagerActivity extends Activity {
             CommCareSessionService s = CommCareApplication._().getSession();
             if (s.isActive()) {
                 triggerLogoutWarning(LOGOUT_FOR_UPDATE);
-                update();
             } else {
                 update();
             }
@@ -233,6 +232,7 @@ public class SingleAppManagerActivity extends Activity {
     private void update() {
         CommCareApplication._().initializeAppResources(new CommCareApp(appRecord));
         Intent i = new Intent(getApplicationContext(), UpdateActivity.class);
+        i.putExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, true);
         startActivityForResult(i, CommCareHomeActivity.UPGRADE_APP);
     }
 

--- a/app/src/org/commcare/dalvik/activities/UpdateActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UpdateActivity.java
@@ -291,7 +291,8 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
 
     @Override
     public void initUIController() {
-        uiController = new UpdateUIController(this);
+        boolean fromAppManager = getIntent().getBooleanExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, false);
+        uiController = new UpdateUIController(this, fromAppManager);
     }
 
     @Override

--- a/app/src/org/commcare/dalvik/activities/UpdateActivity.java
+++ b/app/src/org/commcare/dalvik/activities/UpdateActivity.java
@@ -14,6 +14,7 @@ import org.commcare.android.tasks.InstallStagedUpdateTask;
 import org.commcare.android.tasks.TaskListener;
 import org.commcare.android.tasks.TaskListenerRegistrationException;
 import org.commcare.android.tasks.UpdateTask;
+import org.commcare.dalvik.application.CommCareApplication;
 import org.commcare.dalvik.dialogs.CustomProgressDialog;
 import org.commcare.dalvik.utils.ConnectivityStatus;
 import org.javarosa.core.services.locale.Localization;
@@ -237,7 +238,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
                     protected void deliverResult(UpdateActivity receiver,
                                                  AppInstallStatus result) {
                         if (result == AppInstallStatus.Installed) {
-                            receiver.exitOnSuccessfulUpdate();
+                            receiver.logoutOnSuccessfulUpdate();
                         } else {
                             receiver.uiController.errorUiState();
                         }
@@ -256,6 +257,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
                 };
         task.connect(this);
         task.execute();
+        uiController.applyingUpdateUiState();
     }
 
     @Override
@@ -273,10 +275,12 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         return dialog;
     }
 
-    private void exitOnSuccessfulUpdate() {
+    private void logoutOnSuccessfulUpdate() {
         final String upgradeFinishedText =
                 Localization.get("updates.install.finished");
         Toast.makeText(this, upgradeFinishedText, Toast.LENGTH_LONG).show();
+        CommCareApplication._().expireUserSession();
+        setResult(RESULT_OK);
         this.finish();
     }
 

--- a/app/src/org/commcare/dalvik/activities/UpdateUIController.java
+++ b/app/src/org/commcare/dalvik/activities/UpdateUIController.java
@@ -42,6 +42,7 @@ class UpdateUIController implements CommCareActivityUIController {
             Localization.get("updates.check.failed");
     private final String errorMsg = Localization.get("updates.error");
     private final String upToDateText = Localization.get("updates.success");
+    private final String applyUpdateButtonTextKey;
 
     private enum UIState {
         Idle, UpToDate, FailedCheck, Downloading, UnappliedUpdateAvailable,
@@ -50,7 +51,12 @@ class UpdateUIController implements CommCareActivityUIController {
 
     private UIState currentUIState;
 
-    public UpdateUIController(UpdateActivity updateActivity) {
+    public UpdateUIController(UpdateActivity updateActivity, boolean startedByAppManager) {
+        if (startedByAppManager) {
+            applyUpdateButtonTextKey = "updates.staged.version.app.manager";
+        } else {
+            applyUpdateButtonTextKey = "updates.staged.version";
+        }
         activity = updateActivity;
     }
 
@@ -105,7 +111,7 @@ class UpdateUIController implements CommCareActivityUIController {
             }
         });
         String updateVersionPlaceholderMsg =
-            Localization.get("updates.staged.version", new String[]{"-1"});
+            Localization.get(applyUpdateButtonTextKey, new String[]{"-1"});
         installUpdateButton.setText(updateVersionPlaceholderMsg);
     }
 
@@ -156,7 +162,7 @@ class UpdateUIController implements CommCareActivityUIController {
 
         int version = ResourceInstallUtils.upgradeTableVersion();
         String versionMsg =
-                Localization.get("updates.staged.version",
+                Localization.get(applyUpdateButtonTextKey,
                         new String[]{Integer.toString(version)});
         installUpdateButton.setText(versionMsg);
         updateProgressText("");


### PR DESCRIPTION
Should have done this a while ago, but better late than never:
Disable the ability to apply an update without logging out; because I guess that is sketch.

Also modified the single app manager code to still work. Now applies any updates in the single app manager activity upon return from the update activity. @amstone326 probably want to check that out.

Removing the ability to apply the update in the update screen fixes this QA ticket http://manage.dimagi.com/default.asp?215637