### PR TITLE
Make form save messages distinguish between incomplete/complete saves

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -136,6 +136,8 @@ sync.recover.started=Recovering local DB State. Please do not turn off the app!
 form.entry.segfault=There was an unrecoverable error during form entry! If the problem persists, seek technical support
 form.entry.processing=Processing your Form
 form.entry.processing.title=Processing Form
+form.entry.save.success=Form successfully saved!
+form.entry.save.error=Sorry, form save failed. Please contact technical support to look into the issue.
 
 login.attempt.badcred=Username or password are incorrect. Please try again.
 

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -136,7 +136,7 @@ sync.recover.started=Recovering local DB State. Please do not turn off the app!
 form.entry.segfault=There was an unrecoverable error during form entry! If the problem persists, seek technical support
 form.entry.processing=Processing your Form
 form.entry.processing.title=Processing Form
-form.entry.complete.save.success=Form saved and ready for submission
+form.entry.complete.save.success=Form successfully completed
 form.entry.incomplete.save.success=Form saved as incomplete
 form.entry.save.error=Sorry, form save failed. Please contact technical support to look into the issue.
 

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -136,7 +136,8 @@ sync.recover.started=Recovering local DB State. Please do not turn off the app!
 form.entry.segfault=There was an unrecoverable error during form entry! If the problem persists, seek technical support
 form.entry.processing=Processing your Form
 form.entry.processing.title=Processing Form
-form.entry.save.success=Form successfully saved!
+form.entry.complete.save.success=Form saved and ready for submission
+form.entry.incomplete.save.success=Form saved as incomplete
 form.entry.save.error=Sorry, form save failed. Please contact technical support to look into the issue.
 
 login.attempt.badcred=Username or password are incorrect. Please try again.

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -38,8 +38,6 @@
     <string name="clear_answer_no">Cancelar</string>
     <string name="completed_data">Completar (%s)</string>
     <string name="data">Formularios Guardados</string>
-    <string name="data_saved_error">Guardar el formulario fracaso!</string>
-    <string name="data_saved_ok">El formulario se guardo exitosamente!</string>
     <string name="delete_confirm">Borrar %s formulario(s)?</string>
     <string name="delete_file">Borrar los Seleccionados</string>
     <string name="delete_no">No Borrar</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -38,8 +38,6 @@ License.
     <string name="clear_answer_no">Annuler</string>
     <string name="completed_data">Complet (%s)</string>
     <string name="data">Formulaires sauvegardés</string>
-    <string name="data_saved_error">Désolé, la sauvegarde du formulaire a échoué.</string>
-    <string name="data_saved_ok">Le Formulaire a été enregistré avec succès.</string>
     <string name="delete_confirm">Supprimer %s formulaire(s)?</string>
     <string name="delete_file">Supprimer la sélection</string>
     <string name="delete_no">Ne pas supprimer</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -39,8 +39,6 @@
     <string name="clear_answer_no">Atšaukti</string>
     <string name="completed_data">Baigta (%s)</string>
     <string name="data">Išsaugotos formos</string>
-    <string name="data_saved_error">Deja, formos išsaugoti nepavyko!</string>
-    <string name="data_saved_ok">Forma sėkmingai išsaugota!</string>
     <string name="delete_confirm">Ištrinti %s formą(-as)?</string>
     <string name="delete_file">Ištrinti pažymėtas</string>
     <string name="delete_no">Neištrinti</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -39,8 +39,6 @@
     <string name="clear_answer_no">Avbryt</string>
     <string name="completed_data">Fullfør (%s)</string>
     <string name="data">Lagret skjemaer</string>
-    <string name="data_saved_error">Beklager, skjema lagring mislyktes!</string>
-    <string name="data_saved_ok">Skjema lagret!</string>
     <string name="delete_confirm">Slett %s skjema(er)?</string>
     <string name="delete_file">Slett utvalgte</string>
     <string name="delete_no">Ikke slett</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -39,8 +39,6 @@
     <string name="clear_answer_no">Cancel</string>
     <string name="completed_data">Complete (%s)</string>
     <string name="data">Saved Forms</string>
-    <string name="data_saved_error">Sorry, form save failed!</string>
-    <string name="data_saved_ok">Form successfully saved!</string>
     <string name="delete_confirm">Apagar %s formulário(s)?</string>
     <string name="delete_file">Apagar Selecionados</string>
     <string name="delete_no">Não Apagar</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -39,8 +39,6 @@
     <string name="clear_answer_no">Cancel</string>
     <string name="completed_data">Complete (%s)</string>
     <string name="data">Saved Forms</string>
-    <string name="data_saved_error">Sorry, form save failed!</string>
-    <string name="data_saved_ok">Form successfully saved!</string>
     <string name="delete_confirm">Delete %s form(s)?</string>
     <string name="delete_file">Delete Selected</string>
     <string name="delete_no">Do Not Delete</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -179,8 +179,6 @@ Copyright (c) 2012 readyState Software Ltd.</string>
     <string name="clear_answer_no" cc:translatable="true">CANCEL</string>
     <string name="completed_data" cc:translatable="true">Complete (%s)</string>
     <string name="data" cc:translatable="true">Saved Forms</string>
-    <string name="data_saved_error" cc:translatable="true">Sorry, form save failed. Please contact technical support to look into the issue.</string>
-    <string name="data_saved_ok" cc:translatable="true">Form successfully saved!</string>
     <string name="delete_confirm" cc:translatable="true">Delete %s form(s)?</string>
     <string name="delete_file" cc:translatable="true">Delete Selected</string>
     <string name="delete_no" cc:translatable="true">Do Not Delete</string>

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2094,11 +2094,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
      * Display save status notification and exit or continue on in the form.
      * If form entry is being saved because key session is expiring then
      * continue closing the session/logging out.
-     *
-     * @see org.odk.collect.android.listeners.FormSavedListener#savingComplete(int, boolean)
      */
     @Override
-    public void savingComplete(int saveStatus, boolean headless) {
+    public void savingComplete(SaveToDiskTask.SaveStatus saveStatus, boolean headless) {
         // Did we just save a form because the key session
         // (CommCareSessionService) is ending?
         if (savingFormOnKeySessionExpiration) {
@@ -2110,20 +2108,19 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             CommCareApplication._().expireUserSession();
         } else {
             switch (saveStatus) {
-                case SaveToDiskTask.SAVED:
+                case SAVED:
                     Toast.makeText(this, StringUtils.getStringSpannableRobust(this, R.string.data_saved_ok), Toast.LENGTH_SHORT).show();
                     hasSaved = true;
                     break;
-                case SaveToDiskTask.SAVED_AND_EXIT:
+                case SAVED_AND_EXIT:
                     Toast.makeText(this, StringUtils.getStringSpannableRobust(this, R.string.data_saved_ok), Toast.LENGTH_SHORT).show();
                     hasSaved = true;
                     finishReturnInstance();
                     break;
-                case SaveToDiskTask.SAVE_ERROR:
+                case SAVE_ERROR:
                     Toast.makeText(this, StringUtils.getStringSpannableRobust(this, R.string.data_saved_error), Toast.LENGTH_LONG).show();
                     break;
-                case FormEntryController.ANSWER_CONSTRAINT_VIOLATED:
-                case FormEntryController.ANSWER_REQUIRED_BUT_EMPTY:
+                case INVALID_ANSWER:
                     // an answer constraint was violated, so try to save the
                     // current question to trigger the constraint violation message
                     refreshCurrentView();

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1404,7 +1404,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     private void showSaveErrorAndExit() {
-        Toast.makeText(this, StringUtils.getStringSpannableRobust(this, R.string.data_saved_error), Toast.LENGTH_SHORT).show();
+        Toast.makeText(this, Localization.get("form.entry.save.error"), Toast.LENGTH_SHORT).show();
         hasSaved = false;
         finishReturnInstance();
     }
@@ -1434,7 +1434,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         } else if (!headless &&
                 !saveAnswersForCurrentScreen(EVALUATE_CONSTRAINTS, complete, headless)) {
             Toast.makeText(this,
-                    StringUtils.getStringSpannableRobust(this, R.string.data_saved_error),
+                    Localization.get("form.entry.save.error"),
                     Toast.LENGTH_SHORT).show();
             return;
         }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2108,12 +2108,16 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             CommCareApplication._().expireUserSession();
         } else {
             switch (saveStatus) {
-                case SAVED:
-                    Toast.makeText(this, Localization.get("form.entry.save.success"), Toast.LENGTH_SHORT).show();
+                case SAVED_COMPLETE:
+                    Toast.makeText(this, Localization.get("form.entry.complete.save.success"), Toast.LENGTH_SHORT).show();
+                    hasSaved = true;
+                    break;
+                case SAVED_INCOMPLETE:
+                    Toast.makeText(this, Localization.get("form.entry.incomplete.save.success"), Toast.LENGTH_SHORT).show();
                     hasSaved = true;
                     break;
                 case SAVED_AND_EXIT:
-                    Toast.makeText(this, Localization.get("form.entry.save.success"), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, Localization.get("form.entry.complete.save.success"), Toast.LENGTH_SHORT).show();
                     hasSaved = true;
                     finishReturnInstance();
                     break;

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2109,16 +2109,16 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         } else {
             switch (saveStatus) {
                 case SAVED:
-                    Toast.makeText(this, StringUtils.getStringSpannableRobust(this, R.string.data_saved_ok), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, Localization.get("form.entry.save.success"), Toast.LENGTH_SHORT).show();
                     hasSaved = true;
                     break;
                 case SAVED_AND_EXIT:
-                    Toast.makeText(this, StringUtils.getStringSpannableRobust(this, R.string.data_saved_ok), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, Localization.get("form.entry.save.success"), Toast.LENGTH_SHORT).show();
                     hasSaved = true;
                     finishReturnInstance();
                     break;
                 case SAVE_ERROR:
-                    Toast.makeText(this, StringUtils.getStringSpannableRobust(this, R.string.data_saved_error), Toast.LENGTH_LONG).show();
+                    Toast.makeText(this, Localization.get("form.entry.save.error"), Toast.LENGTH_LONG).show();
                     break;
                 case INVALID_ANSWER:
                     // an answer constraint was violated, so try to save the

--- a/app/src/org/odk/collect/android/listeners/FormSavedListener.java
+++ b/app/src/org/odk/collect/android/listeners/FormSavedListener.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.listeners;
 
+import org.odk.collect.android.tasks.SaveToDiskTask;
+
 /**
  * @author Carl Hartung (carlhartung@gmail.com)
  */
@@ -8,8 +10,7 @@ public interface FormSavedListener {
     /**
      * Callback to be run after a form has been saved.
      *
-     * @param saveStatus return status of form save, defined in SaveToDiskTask
      * @param headless is this thread running without a GUI?
      */
-    void savingComplete(int saveStatus, boolean headless);
+    void savingComplete(SaveToDiskTask.SaveStatus formSaveStatus, boolean headless);
 }

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -44,7 +44,7 @@ import javax.crypto.spec.SecretKeySpec;
 public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Void, String, SaveToDiskTask.SaveStatus, R> {
     // callback to run upon saving
     private FormSavedListener mSavedListener;
-    private final Boolean mSave;
+    private final Boolean exitAfterSave;
     private final Boolean mMarkCompleted;
     // URI to the thing we are saving
     private Uri mUri;
@@ -74,7 +74,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
         TAG = SaveToDiskTask.class.getSimpleName();
 
         this.mUri = mUri;
-        mSave = saveAndExit;
+        exitAfterSave = saveAndExit;
         mMarkCompleted = markCompleted;
         mInstanceName = updatedName;
         this.context = context;
@@ -105,7 +105,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
         FormEntryActivity.mFormController.postProcessInstance();
 
         if (exportData(mMarkCompleted)) {
-            return mSave ? SaveStatus.SAVED_AND_EXIT : SaveStatus.SAVED;
+            return exitAfterSave ? SaveStatus.SAVED_AND_EXIT : SaveStatus.SAVED;
         }
 
         return SaveStatus.SAVE_ERROR;

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -374,7 +374,6 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
                             FormEntryActivity.mFormController.checkCurrentQuestionConstraint();
                 }
                 if (markCompleted &&
-                        saveStatus != FormEntryController.ANSWER_OK && // not technically needed
                         (saveStatus == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY ||
                                 saveStatus == FormEntryController.ANSWER_CONSTRAINT_VIOLATED)) {
 

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -41,7 +41,7 @@ import javax.crypto.spec.SecretKeySpec;
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
-public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Void, String, Integer, R> {
+public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Void, String, SaveToDiskTask.SaveStatus, R> {
     // callback to run upon saving
     private FormSavedListener mSavedListener;
     private final Boolean mSave;
@@ -60,10 +60,12 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
     
     private final SecretKeySpec symetricKey;
 
-    public static final int SAVED = 500;
-    public static final int SAVE_ERROR = 501;
-    public static final int VALIDATED = 503;
-    public static final int SAVED_AND_EXIT = 504;
+    public enum SaveStatus {
+        SAVED,
+        SAVE_ERROR,
+        INVALID_ANSWER,
+        SAVED_AND_EXIT
+    }
 
     public static final int SAVING_TASK_ID = 17;
 
@@ -92,21 +94,21 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
      * an instance, it will be used to fill the {@link FormDef}.
      */
     @Override
-    protected Integer doTaskBackground(Void... nothing) {
+    protected SaveStatus doTaskBackground(Void... nothing) {
         // validation failed, pass specific failure
-        int validateStatus =
+        boolean areAnswersValid =
                 validateAnswers(mMarkCompleted, DeveloperPreferences.shouldFireTriggersOnSave());
-        if (validateStatus != VALIDATED) {
-            return validateStatus;
+        if (!areAnswersValid) {
+            return SaveStatus.INVALID_ANSWER;
         }
 
         FormEntryActivity.mFormController.postProcessInstance();
 
         if (exportData(mMarkCompleted)) {
-            return mSave ? SAVED_AND_EXIT : SAVED;
+            return mSave ? SaveStatus.SAVED_AND_EXIT : SaveStatus.SAVED;
         }
 
-        return SAVE_ERROR;
+        return SaveStatus.SAVE_ERROR;
     }
 
     /**
@@ -317,7 +319,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
     }
 
     @Override
-    protected void onPostExecute(Integer result) {
+    protected void onPostExecute(SaveStatus result) {
         super.onPostExecute(result);
 
         synchronized (this) {
@@ -327,7 +329,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
     }
 
     @Override
-    protected void deliverResult(R receiver, Integer result) {
+    protected void deliverResult(R receiver, SaveStatus result) {
     }
 
     @Override
@@ -352,7 +354,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
      * @param fireTriggerables re-fire the triggers associated with the
      *                         question when checking its constraints?
      */
-    private int validateAnswers(boolean markCompleted, boolean fireTriggerables) {
+    private boolean validateAnswers(boolean markCompleted, boolean fireTriggerables) {
         FormIndex i = FormEntryActivity.mFormController.getFormIndex();
         FormEntryActivity.mFormController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
 
@@ -373,13 +375,17 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
                     saveStatus =
                             FormEntryActivity.mFormController.checkCurrentQuestionConstraint();
                 }
-                if (markCompleted && saveStatus != FormEntryController.ANSWER_OK) {
-                    return saveStatus;
+                if (markCompleted &&
+                        saveStatus != FormEntryController.ANSWER_OK && // not technically needed
+                        (saveStatus == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY ||
+                                saveStatus == FormEntryController.ANSWER_CONSTRAINT_VIOLATED)) {
+
+                    return false;
                 }
             }
         }
 
         FormEntryActivity.mFormController.jumpToIndex(i);
-        return VALIDATED;
+        return true;
     }
 }

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -61,7 +61,8 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
     private final SecretKeySpec symetricKey;
 
     public enum SaveStatus {
-        SAVED,
+        SAVED_COMPLETE,
+        SAVED_INCOMPLETE,
         SAVE_ERROR,
         INVALID_ANSWER,
         SAVED_AND_EXIT
@@ -105,7 +106,13 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
         FormEntryActivity.mFormController.postProcessInstance();
 
         if (exportData(mMarkCompleted)) {
-            return exitAfterSave ? SaveStatus.SAVED_AND_EXIT : SaveStatus.SAVED;
+            if (exitAfterSave) {
+                return SaveStatus.SAVED_AND_EXIT;
+            } else if (mMarkCompleted) {
+                return SaveStatus.SAVED_COMPLETE;
+            } else {
+                return SaveStatus.SAVED_INCOMPLETE;
+            }
         }
 
         return SaveStatus.SAVE_ERROR;

--- a/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/app/src/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -96,10 +96,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
      */
     @Override
     protected SaveStatus doTaskBackground(Void... nothing) {
-        // validation failed, pass specific failure
-        boolean areAnswersValid =
-                validateAnswers(mMarkCompleted, DeveloperPreferences.shouldFireTriggersOnSave());
-        if (!areAnswersValid) {
+        if (hasInvalidAnswers(mMarkCompleted, DeveloperPreferences.shouldFireTriggersOnSave())) {
             return SaveStatus.INVALID_ANSWER;
         }
 
@@ -361,7 +358,7 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
      * @param fireTriggerables re-fire the triggers associated with the
      *                         question when checking its constraints?
      */
-    private boolean validateAnswers(boolean markCompleted, boolean fireTriggerables) {
+    private boolean hasInvalidAnswers(boolean markCompleted, boolean fireTriggerables) {
         FormIndex i = FormEntryActivity.mFormController.getFormIndex();
         FormEntryActivity.mFormController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
 
@@ -387,12 +384,12 @@ public class SaveToDiskTask<R extends FragmentActivity> extends CommCareTask<Voi
                         (saveStatus == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY ||
                                 saveStatus == FormEntryController.ANSWER_CONSTRAINT_VIOLATED)) {
 
-                    return false;
+                    return true;
                 }
             }
         }
 
         FormEntryActivity.mFormController.jumpToIndex(i);
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
Meryn and the PPIUD team brought up an interesting point that users were getting confused by the fact that when you save a form as incomplete via the drop down menu, you get the same message as when you save a form as complete.

This PR makes it so when you save a form using the drop down menu, you get:
> Form saved as incomplete

And when you complete a form at the end-of-form nav, it shows:
> Form saved and ready for submission

Perhaps the "ready for submission" part is confusing because it makes it seem like the user has something they need to do?

![screen1](https://cloud.githubusercontent.com/assets/94817/12678255/e757ed28-c66b-11e5-8851-66252c78ab21.png)

![screen](https://cloud.githubusercontent.com/assets/94817/12679161/991658fc-c670-11e5-8be4-f94f48330171.png)
