### PR TITLE
Fix incorrect appearance of "Save Your Session" in FormEntry

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -802,7 +802,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         menu.add(0, MENU_PREFERENCES, 0, StringUtils.getStringRobust(this, R.string.form_entry_settings)).setIcon(
                 android.R.drawable.ic_menu_preferences);
-        return true;
+
+        return super.onPrepareOptionsMenu(menu);
     }
 
     @Override


### PR DESCRIPTION
Add call to super so that onPrepareOptionsMenu() in SaveSessionCommCareActivity gets called, hiding the "Save Your Session" menu option when that setting is not on.