### PR TITLE
Don't show both location disabled & form load error dialogs

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -182,6 +182,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     // rotation (or similar)
     private static final String KEY_FORM_LOAD_HAS_TRIGGERED = "newform";
     private static final String KEY_FORM_LOAD_FAILED = "form-failed";
+    private static final String KEY_LOC_ERROR = "location-not-enabled";
+    private static final String KEY_LOC_ERROR_PATH = "location-based-xpath-error";
 
     private static final int MENU_LANGUAGES = Menu.FIRST + 1;
     private static final int MENU_HIERARCHY_VIEW = Menu.FIRST + 2;
@@ -212,6 +214,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private boolean mIncompleteEnabled = true;
     private boolean hasFormLoadBeenTriggered = false;
     private boolean hasFormLoadFailed = false;
+    private String locationRecieverErrorAction = null;
+    private String badLocationXpath = null;
 
     // used to limit forward/backward swipes to one per question
     private boolean isAnimatingSwipe;
@@ -315,12 +319,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             @Override
             public void onReceive(Context context, Intent intent) {
                 context.removeStickyBroadcast(intent);
-                String action = intent.getAction();
-                if (GeoUtils.ACTION_CHECK_GPS_ENABLED.equals(action)) {
-                    handleNoGpsBroadcast(context);
-                } else if (PollSensorAction.XPATH_ERROR_ACTION.equals(action)) {
-                    handleXpathErrorBroadcast(intent);
-                }
+                badLocationXpath = intent.getStringExtra(PollSensorAction.KEY_UNRESOLVED_XPATH);
+                locationRecieverErrorAction = intent.getAction();
             }
         };
 
@@ -328,29 +328,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         filter.addAction(PollSensorAction.XPATH_ERROR_ACTION);
         filter.addAction(GeoUtils.ACTION_CHECK_GPS_ENABLED);
         registerReceiver(mLocationServiceIssueReceiver, filter);
-    }
-
-    private void handleNoGpsBroadcast(Context context) {
-        LocationManager manager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
-        Set<String> providers = GeoUtils.evaluateProviders(manager);
-        if (providers.isEmpty()) {
-            DialogInterface.OnClickListener onChangeListener = new DialogInterface.OnClickListener() {
-                public void onClick(DialogInterface dialog, int i) {
-                    if (i == DialogInterface.BUTTON_POSITIVE) {
-                        Intent intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-                        startActivity(intent);
-                    }
-                    dialog.dismiss();
-                }
-            };
-            GeoUtils.showNoGpsDialog(this, onChangeListener);
-        }
-    }
-
-    private void handleXpathErrorBroadcast(Intent intent) {
-        String problemXpath = intent.getStringExtra(PollSensorAction.KEY_UNRESOLVED_XPATH);
-        CommCareActivity.createErrorDialog(FormEntryActivity.this,
-                "There is a bug in one of your form's XPath Expressions \n" + problemXpath, EXIT);
     }
 
     private void setupUI() {
@@ -412,6 +389,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         outState.putString(KEY_FORMPATH, mFormPath);
         outState.putBoolean(KEY_FORM_LOAD_HAS_TRIGGERED, hasFormLoadBeenTriggered);
         outState.putBoolean(KEY_FORM_LOAD_FAILED, hasFormLoadFailed);
+        outState.putString(KEY_LOC_ERROR, locationRecieverErrorAction);
+        outState.putString(KEY_LOC_ERROR_PATH, badLocationXpath);
+
         outState.putString(KEY_FORM_CONTENT_URI, formProviderContentURI.toString());
         outState.putString(KEY_INSTANCE_CONTENT_URI, instanceProviderContentURI.toString());
         outState.putString(KEY_INSTANCEDESTINATION, mInstanceDestination);
@@ -1889,6 +1869,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 protected void deliverError(FormEntryActivity receiver, Exception e) {
                     receiver.setFormLoadFailure();
                     receiver.dismissProgressDialog();
+
                     if (e != null) {
                         CommCareActivity.createErrorDialog(receiver, e.getMessage(), EXIT);
                     } else {
@@ -1907,6 +1888,12 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     private void handleFormLoadCompletion(FormController fc) {
+        if (GeoUtils.ACTION_CHECK_GPS_ENABLED.equals(locationRecieverErrorAction)) {
+            handleNoGpsBroadcast();
+        } else if (PollSensorAction.XPATH_ERROR_ACTION.equals(locationRecieverErrorAction)) {
+            handleXpathErrorBroadcast();
+        }
+
         mFormController = fc;
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB){
             // Newer menus may have already built the menu, before all data was ready
@@ -1952,6 +1939,29 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         reportFormEntry();
         refreshCurrentView();
         FormNavigationUI.updateNavigationCues(this, mFormController, mCurrentView);
+    }
+
+    private void handleNoGpsBroadcast() {
+        LocationManager manager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+        Set<String> providers = GeoUtils.evaluateProviders(manager);
+        if (providers.isEmpty()) {
+            DialogInterface.OnClickListener onChangeListener = new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int i) {
+                    if (i == DialogInterface.BUTTON_POSITIVE) {
+                        Intent intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+                        startActivity(intent);
+                    }
+                    dialog.dismiss();
+                }
+            };
+            GeoUtils.showNoGpsDialog(this, onChangeListener);
+        }
+    }
+
+    private void handleXpathErrorBroadcast() {
+        CommCareActivity.createErrorDialog(FormEntryActivity.this,
+                "There is a bug in one of your form's XPath Expressions \n" + badLocationXpath, EXIT);
     }
 
     /**
@@ -2352,6 +2362,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             if (savedInstanceState.containsKey(KEY_FORM_LOAD_FAILED)) {
                 hasFormLoadFailed = savedInstanceState.getBoolean(KEY_FORM_LOAD_FAILED, false);
             }
+
+            locationRecieverErrorAction = savedInstanceState.getString(KEY_LOC_ERROR);
+            badLocationXpath = savedInstanceState.getString(KEY_LOC_ERROR_PATH);
+
             if (savedInstanceState.containsKey(KEY_FORM_CONTENT_URI)) {
                 formProviderContentURI = Uri.parse(savedInstanceState.getString(KEY_FORM_CONTENT_URI));
             }


### PR DESCRIPTION
If location services are off in a form that needs them and the form also has loading errors, the result is that the load error dialog isn't shown. Instead just the "turn on location services" dialog is shown. This puts the form in a state where you can swipe forward and crash the app.

Fix is to show "location service are disabled" dialog only when the form successfully loads, not during form loading.

http://manage.dimagi.com/default.asp?209449