### PR TITLE
Make keyboard next and done buttons work again

### DIFF
--- a/app/res/layout/screen_login.xml
+++ b/app/res/layout/screen_login.xml
@@ -95,6 +95,7 @@
                                 android:drawableLeft="@drawable/icon_user_neutral50"
                                 android:hint="Username"
                                 android:inputType="text"
+                                android:imeOptions="actionNext"
                                 android:nextFocusDown="@+id/edit_password"
                                 android:textSize="@dimen/text_medium">
                                 <requestFocus/>
@@ -110,8 +111,8 @@
                                 android:drawableLeft="@drawable/icon_lock_neutral50"
                                 android:hint="Password"
                                 android:inputType="textPassword"
-                                android:nextFocusDown="@+id/checkserver"
                                 android:nextFocusUp="@+id/edit_username"
+                                android:imeOptions="actionDone"
                                 android:textSize="@dimen/text_medium"/>
 
                             <TextView


### PR DESCRIPTION
Phillip noticed that in 2.26, the next and done buttons on the android soft keyboard on the login screen were no longer working properly. This is definitely a regression from 2.25, but I couldn't identify what caused it, because we definitely never used to need the lines I added to make this work. Nevertheless, adding them fixes it, and it seems like a reasonable thing to add since this is what those fields are meant for, so am comfortable with not digging further for the source of the change.