### PR TITLE
Remove new doc flags for restart intent

### DIFF
--- a/app/src/org/commcare/dalvik/application/CommCareApplication.java
+++ b/app/src/org/commcare/dalvik/application/CommCareApplication.java
@@ -278,11 +278,6 @@ public class CommCareApplication extends Application {
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
                 Intent.FLAG_ACTIVITY_SINGLE_TOP |
                 Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
-        } else {
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
-        }
 
         activity.moveTaskToBack(true);
         activity.startActivity(intent);


### PR DESCRIPTION
Strangely, on my particular device (Nexus 5x / Android 6) when I uninstall an app in the app manger the call to `CommCareApplication.restartCommCare` trashes my app, freezing everything until I force close it. 

Removing these flags fix it.
Not really sure what they do / why they were put here in the first place. @ctsims, do you know?