### PR TITLE
Dedicated fragment for handling denied permissions

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -41,6 +41,9 @@ install.button.start=Start Install
 install.bad.ref=You did not scan a valid URL. Please try again.
 install.bad.login=Login to Existing App
 install.appprofile=Enter your app code
+install.perms.request=Request required permissions
+install.perms.rationale.message=CommCare requires at least external storage read & write permissions in order to store form submissions.
+install.perms.denied.message=Crucial permissions denied ${0} times.\n\n If requesting permissions here fails, please enable permissions under Android's 'Settings -> Apps -> CommCare -> Permissions'.
 
 upgrade.button.retry=Retry Upgrade
 upgrade.button.startover=Restart Upgrade

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -41,7 +41,6 @@ install.button.start=Start Install
 install.bad.ref=You did not scan a valid URL. Please try again.
 install.bad.login=Login to Existing App
 install.appprofile=Enter your app code
-install.perms.request=Request required permissions
 install.perms.rationale.message=CommCare requires at least external storage read & write permissions in order to store form submissions.
 install.perms.denied.message=Crucial permissions denied ${0} times.\n\n If requesting permissions here fails, please enable permissions under Android's 'Settings -> Apps -> CommCare -> Permissions'.
 
@@ -276,7 +275,6 @@ bulk.form.dump.success=${1} forms dumped successfully
 mult.install.error=Unexpected Error installing the multimedia! Please try again. Error Text: ${0}  
 
 login.menu.demo=Enter as Demo User
-login.menu.permission=Acquire Required Permissions
 login.menu.password.mode=Switch to Password Login Mode
 main.sync.demo=You cannot sync data down from the server when logged in in demo mode
 
@@ -647,3 +645,4 @@ permission.sms.install.title=Permission for obtaining SMS app code
 permission.sms.install.message=CommCare would like to scan your recent messages for an app install code.
 permission.form.gps.title=Permission to capture location during form entry
 permission.form.gps.message=CommCare would like to capture your location and provide it to forms you complete.
+permission.acquire.required=Acquire Required Permissions

--- a/app/res/layout/install_permission_requester.xml
+++ b/app/res/layout/install_permission_requester.xml
@@ -28,11 +28,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/content_min_margin"
                 android:layout_marginRight="@dimen/content_min_margin"
+                android:gravity="center"
                 android:paddingBottom="@dimen/content_start"
                 android:paddingTop="@dimen/content_start"
-                android:gravity="center"
-                android:textSize="@dimen/text_small"
-                android:textStyle="bold"/>
+                android:textSize="@dimen/text_small"/>
 
             <TextView
                 android:id="@+id/needed_perms_message"
@@ -40,11 +39,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/content_min_margin"
                 android:layout_marginRight="@dimen/content_min_margin"
+                android:gravity="center"
                 android:paddingBottom="@dimen/content_start"
                 android:paddingTop="@dimen/content_start"
-                android:gravity="center"
-                android:textSize="@dimen/text_small"
-                android:textStyle="bold"/>
+                android:textSize="@dimen/text_small"/>
 
             <Button
                 android:id="@+id/get_perms_button"

--- a/app/res/layout/install_permission_requester.xml
+++ b/app/res/layout/install_permission_requester.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    android:id="@+id/screen_first_start_main"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="@color/cc_core_bg"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/cc_core_bg"
+        android:paddingLeft="@dimen/login_box_margins"
+        android:paddingRight="@dimen/login_box_margins"
+        android:scrollbars="none">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <include layout="@layout/grid_header_top_banner"/>
+
+            <TextView
+                android:id="@+id/perms_rationale_message"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/content_min_margin"
+                android:layout_marginRight="@dimen/content_min_margin"
+                android:paddingBottom="@dimen/content_start"
+                android:paddingTop="@dimen/content_start"
+                android:gravity="center"
+                android:textSize="@dimen/text_small"
+                android:textStyle="bold"/>
+
+            <TextView
+                android:id="@+id/needed_perms_message"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/content_min_margin"
+                android:layout_marginRight="@dimen/content_min_margin"
+                android:paddingBottom="@dimen/content_start"
+                android:paddingTop="@dimen/content_start"
+                android:gravity="center"
+                android:textSize="@dimen/text_small"
+                android:textStyle="bold"/>
+
+            <Button
+                android:id="@+id/get_perms_button"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:background="@color/cc_brand_color"
+                android:nextFocusUp="@+id/edit_password"
+                android:paddingBottom="@dimen/content_start"
+                android:paddingTop="@dimen/content_start"
+                android:textColor="@color/cc_neutral_bg"/>
+
+        </LinearLayout>
+    </ScrollView>
+</RelativeLayout>

--- a/app/res/layout/scrolling_info_dialog.xml
+++ b/app/res/layout/scrolling_info_dialog.xml
@@ -8,21 +8,19 @@
 
     <include
         android:id="@+id/dialog_title"
-        layout="@layout/dialog_title" />
+        layout="@layout/dialog_title"/>
 
     <ScrollView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/standard_spacer_large"
         android:layout_marginLeft="@dimen/standard_spacer_large"
-        android:layout_marginRight="@dimen/standard_spacer_large"
-        android:layout_marginBottom="@dimen/standard_spacer_large" >
+        android:layout_marginRight="@dimen/standard_spacer_large">
 
         <TextView
             android:id="@+id/dialog_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/font_size_dp_large" />
-
+            android:textSize="@dimen/font_size_dp_large"/>
     </ScrollView>
-
 </LinearLayout>

--- a/app/src/org/commcare/android/fragments/InstallPermissionsFragment.java
+++ b/app/src/org/commcare/android/fragments/InstallPermissionsFragment.java
@@ -1,0 +1,59 @@
+package org.commcare.android.fragments;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import org.commcare.android.framework.Permissions;
+import org.commcare.android.framework.RuntimePermissionRequester;
+import org.commcare.dalvik.R;
+import org.javarosa.core.services.locale.Localization;
+
+/**
+ * Block user until they accept necessary permissions. Shows permissions
+ * requirement rationale and allows user to ask for permissions again.
+ *
+ * NOTE: Pressing the 'Never show again' on the permission request dialog
+ * results in the Android platform denying future permission requests w/o UI
+ * queues, hence show permission request attempt count to user.
+ *
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class InstallPermissionsFragment extends Fragment {
+    private int attemptCount = 0;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.install_permission_requester, container, false);
+
+        TextView neededPermDetails = (TextView)view.findViewById(R.id.perms_rationale_message);
+        neededPermDetails.setText(Localization.get("install.perms.rationale.message"));
+
+        Button requestPermsButton = (Button)view.findViewById(R.id.get_perms_button);
+        requestPermsButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                RuntimePermissionRequester permissionRequester = (RuntimePermissionRequester)getActivity();
+                Permissions.acquireAllAppPermissions(getActivity(), permissionRequester,
+                        Permissions.ALL_PERMISSIONS_REQUEST);
+            }
+        });
+        requestPermsButton.setText(Localization.get("install.perms.request"));
+
+        return view;
+    }
+
+    public void updateDeniedState() {
+        attemptCount++;
+        View currentView = getView();
+        if (currentView != null) {
+            TextView deniedDetails = (TextView)currentView.findViewById(R.id.needed_perms_message);
+            deniedDetails.setText(Localization.get("install.perms.denied.message",
+                    new String[]{attemptCount + ""}));
+        }
+    }
+}

--- a/app/src/org/commcare/android/fragments/InstallPermissionsFragment.java
+++ b/app/src/org/commcare/android/fragments/InstallPermissionsFragment.java
@@ -42,7 +42,7 @@ public class InstallPermissionsFragment extends Fragment {
                         Permissions.ALL_PERMISSIONS_REQUEST);
             }
         });
-        requestPermsButton.setText(Localization.get("install.perms.request"));
+        requestPermsButton.setText(Localization.get("permission.acquire.required"));
 
         return view;
     }

--- a/app/src/org/commcare/dalvik/activities/LoginActivity.java
+++ b/app/src/org/commcare/dalvik/activities/LoginActivity.java
@@ -429,7 +429,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         super.onCreateOptionsMenu(menu);
         menu.add(0, MENU_DEMO, 0, Localization.get("login.menu.demo")).setIcon(android.R.drawable.ic_menu_preferences);
         menu.add(0, MENU_ABOUT, 1, Localization.get("home.menu.about")).setIcon(android.R.drawable.ic_menu_help);
-        menu.add(0, MENU_PERMISSIONS, 1, Localization.get("login.menu.permission")).setIcon(android.R.drawable.ic_menu_manage);
+        menu.add(0, MENU_PERMISSIONS, 1, Localization.get("permission.acquire.required")).setIcon(android.R.drawable.ic_menu_manage);
         menu.add(0, MENU_PASSWORD_MODE, 1, Localization.get("login.menu.password.mode"));
         return true;
     }

--- a/app/src/org/commcare/dalvik/dialogs/DialogCreationHelpers.java
+++ b/app/src/org/commcare/dalvik/dialogs/DialogCreationHelpers.java
@@ -22,11 +22,9 @@ public class DialogCreationHelpers {
         final String commcareVersion = CommCareApplication._().getCurrentVersionString();
 
         LayoutInflater li = LayoutInflater.from(activity);
-        // TODO PLM: remove scroll file
-        //View view = li.inflate(R.layout.scrolling_info_dialog, null);
         View view = li.inflate(R.layout.scrolling_info_dialog, null);
 
-        TextView titleView = (TextView) view.findViewById(R.id.dialog_title).findViewById(R.id.dialog_title_text);
+        TextView titleView = (TextView) view.findViewById(R.id.dialog_title_text);
         titleView.setText(activity.getString(R.string.about_cc));
 
         TextView aboutText = (TextView)view.findViewById(R.id.dialog_text);
@@ -56,14 +54,16 @@ public class DialogCreationHelpers {
                                                            final int requestCode,
                                                            String title,
                                                            String body) {
-        LayoutInflater li = LayoutInflater.from(activity);
-        View view = li.inflate(R.layout.scrolling_info_dialog, null);
-        TextView aboutText = (TextView)view.findViewById(R.id.dialog_text);
+        View view = LayoutInflater.from(activity).inflate(R.layout.scrolling_info_dialog, null);
 
-        aboutText.setText(body);
+        TextView bodyText = (TextView)view.findViewById(R.id.dialog_text);
+        bodyText.setText(body);
+
+        TextView titleText = (TextView) view.findViewById(R.id.dialog_title_text);
+        titleText.setText(title);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        builder.setTitle(title);
+        builder.setCancelable(false);
         builder.setView(view);
         builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
             @Override
@@ -72,8 +72,6 @@ public class DialogCreationHelpers {
                 dialog.dismiss();
             }
         });
-        builder.setCancelable(false);
-
         return builder.create();
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha9'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.google.gms:google-services:2.0.0-alpha7'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0-alpha9'
         classpath 'com.google.gms:google-services:2.0.0-alpha7'
     }
 }


### PR DESCRIPTION
Install screen entered infinite loop if the user selected 'Never show again' for permission request dialog. Break this loop by taking the user to a dedicated screen that allows them to ask for permissions. If they select 'Never show again', then the platform auto-denies subsequent request attempts, so we instruct the user how to enable the perms manually, which is the only way the app will work. Messy UX, but it is a messy, power-user feature of Android...

Fix for http://manage.dimagi.com/default.asp?215782 and http://manage.dimagi.com/default.asp?215779

![screen](https://cloud.githubusercontent.com/assets/94817/12733017/4b8543c6-c906-11e5-8dfe-9b2a2801ec4d.png)


![screen](https://cloud.githubusercontent.com/assets/94817/12732830/6a17b6c6-c905-11e5-894c-8f6c558e7347.png)
