### PR TITLE
Update ACRA & gradle android plugin versions

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -59,7 +59,6 @@
 -dontwarn com.google.android.gms.internal.zzhu
 -dontwarn org.jdom2.**
 -dontwarn net.nightwhistler.htmlspanner.**
--dontwarn org.acra.ErrorReporter
 
 -allowaccessmodification
 

--- a/app/src/org/commcare/android/util/ACRAUtil.java
+++ b/app/src/org/commcare/android/util/ACRAUtil.java
@@ -4,8 +4,9 @@ import android.app.Application;
 import android.webkit.URLUtil;
 
 import org.acra.ACRA;
-import org.acra.ACRAConfiguration;
 import org.acra.ErrorReporter;
+import org.acra.config.ACRAConfiguration;
+import org.acra.config.ACRAConfigurationFactory;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.activities.ReportProblemActivity;
 
@@ -35,12 +36,11 @@ public class ACRAUtil {
     public static void initACRA(Application app) {
         String url = BuildConfig.ACRA_URL;
         if (URLUtil.isValidUrl(url)) {
-            ACRA.init(app);
-            ACRAConfiguration acraConfig = ACRA.getConfig();
+            ACRAConfiguration acraConfig = new ACRAConfigurationFactory().create(app);
             acraConfig.setFormUriBasicAuthLogin(BuildConfig.ACRA_USER);
             acraConfig.setFormUriBasicAuthPassword(BuildConfig.ACRA_PASSWORD);
             acraConfig.setFormUri(url);
-            ACRA.setConfig(acraConfig);
+            ACRA.init(app, acraConfig);
             isAcraConfigured = true;
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0-alpha9'
         classpath 'com.google.gms:google-services:2.0.0-alpha7'
     }
 }
@@ -54,7 +54,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-maps:8.4.0'
     compile 'com.google.android.gms:play-services-analytics:8.4.0'
     compile 'com.google.zxing:core:3.0.0'
-    compile 'ch.acra:acra:4.6.2'
+    compile 'ch.acra:acra:4.8.0@aar'
     compile 'joda-time:joda-time:2.3'
     compile 'net.sf.kxml:kxml2:2.3.0'
     compile 'net.zetetic:android-database-sqlcipher:3.3.1-2@aar'


### PR DESCRIPTION
Update versions:

- ACRA 4.6.2 -> 4.8.0 ([changelog](https://github.com/ACRA/acra/wiki/ChangeLog))
- com.android.tools.build:gradle 1.5.0 -> 2.0.0-alpha9

Remove ACRA rules from proguard because ACRA now provides proguard defaults