### PR TITLE
Prevent reordering of home screen buttons due to text resizing

### DIFF
--- a/app/src/org/commcare/android/view/ResizingTextView.java
+++ b/app/src/org/commcare/android/view/ResizingTextView.java
@@ -70,6 +70,7 @@ public class ResizingTextView extends TextView {
         if (!mHasTriedSmallLayout && this.getLineCount() > 1) {
             setTextSizeToSmall();
         }
+        reset();
     }
 
     private void setTextSizeToSmall() {

--- a/app/src/org/commcare/android/view/ResizingTextView.java
+++ b/app/src/org/commcare/android/view/ResizingTextView.java
@@ -11,12 +11,11 @@ import org.commcare.dalvik.R;
 /**
  * A basic text view that will resize itself to update its text size if text wraps longer than
  * a single line
- * <p/>
+ *
  * Created by ctsims on 3/14/15.
  */
 public class ResizingTextView extends TextView {
-
-    private boolean mIsResizing = false;
+    private boolean isResizable = false;
     private int mSmallTextPixels;
     private float mOriginalTextSize;
 
@@ -24,27 +23,29 @@ public class ResizingTextView extends TextView {
 
     public ResizingTextView(Context context, AttributeSet attrs) {
         super(context, attrs);
+
         setParams(context, attrs);
     }
 
     public ResizingTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+
         setParams(context, attrs);
     }
 
     @Override
     protected void onTextChanged(CharSequence text, int start, int lengthBefore, int lengthAfter) {
-        this.reset();
+        if (!getText().equals(text)) {
+            resetOriginalTextSize();
+        }
         super.onTextChanged(text, start, lengthBefore, lengthAfter);
     }
 
-    private void reset() {
-        if (!mIsResizing) {
-            return;
-        }
-        if (mHasTriedSmallLayout) {
-            this.setTextSize(TypedValue.COMPLEX_UNIT_PX, mOriginalTextSize);
-            this.mHasTriedSmallLayout = false;
+    private void resetOriginalTextSize() {
+        if (isResizable && mHasTriedSmallLayout) {
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, mOriginalTextSize);
+            mHasTriedSmallLayout = false;
+            requestLayout();
         }
     }
 
@@ -53,7 +54,7 @@ public class ResizingTextView extends TextView {
             TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ResizingTextView, 0, 0);
             mSmallTextPixels = typedArray.getDimensionPixelSize(R.styleable.ResizingTextView_text_size_small, -1);
             if (mSmallTextPixels != -1) {
-                mIsResizing = true;
+                isResizable = true;
             }
         }
     }
@@ -63,20 +64,15 @@ public class ResizingTextView extends TextView {
                             int bottom) {
         super.onLayout(changed, left, top, right, bottom);
 
-        if (!mIsResizing) {
-            return;
-        }
-
-        if (!mHasTriedSmallLayout && this.getLineCount() > 1) {
+        if (isResizable && !mHasTriedSmallLayout && this.getLineCount() > 1) {
             setTextSizeToSmall();
         }
-        reset();
     }
 
     private void setTextSizeToSmall() {
-        mOriginalTextSize = this.getTextSize();
-        this.setTextSize(TypedValue.COMPLEX_UNIT_PX, mSmallTextPixels);
+        mOriginalTextSize = getTextSize();
         mHasTriedSmallLayout = true;
-        this.requestLayout();
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, mSmallTextPixels);
+        requestLayout();
     }
 }


### PR DESCRIPTION
Note: doesn't prevent home screen buttons from staggering in a different order when in demo mode, but does prevent button reordering when the home screen is paused and resumed.

Follow up to https://github.com/dimagi/commcare-odk/pull/1040

Issue described in http://manage.dimagi.com/default.asp?215785