### PR TITLE
Fix home screen button reordering on rotate/scroll

### DIFF
--- a/app/src/org/commcare/dalvik/activities/HomeActivityUIController.java
+++ b/app/src/org/commcare/dalvik/activities/HomeActivityUIController.java
@@ -66,7 +66,7 @@ public class HomeActivityUIController implements CommCareActivityUIController {
 
     private void setupGridView() {
         final RecyclerView grid = (RecyclerView)activity.findViewById(R.id.home_gridview_buttons);
-        grid.setHasFixedSize(true);
+        grid.setHasFixedSize(false);
 
         StaggeredGridLayoutManager gridView =
                 new StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL);


### PR DESCRIPTION
Fix home screen button reordering that occurs on scrolling after rotating from portrait-landscape-portrait.

http://manage.dimagi.com/default.asp?215785