### PR TITLE
Fix images in detail view

### DIFF
--- a/app/res/layout/component_entity_detail_item.xml
+++ b/app/res/layout/component_entity_detail_item.xml
@@ -61,7 +61,7 @@
 
         <ImageView
             android:id="@+id/detail_value_image"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_gravity="right|center_vertical"
             android:gravity="left|center_vertical"

--- a/app/src/org/commcare/android/view/EntityDetailView.java
+++ b/app/src/org/commcare/android/view/EntityDetailView.java
@@ -23,6 +23,7 @@ import org.commcare.android.util.FileUtil;
 import org.commcare.android.util.InvalidStateException;
 import org.commcare.android.util.MediaUtil;
 import org.commcare.dalvik.R;
+import org.commcare.dalvik.preferences.CommCarePreferences;
 import org.commcare.suite.model.CalloutData;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.graph.GraphData;
@@ -111,7 +112,20 @@ public class EntityDetailView extends FrameLayout {
         addressView = detailRow.findViewById(R.id.detail_address_view);
         addressText = (TextView)addressView.findViewById(R.id.detail_address_text);
         addressButton = (Button)addressView.findViewById(R.id.detail_address_button);
+
         imageView = (ImageView)detailRow.findViewById(R.id.detail_value_image);
+        int height;
+        if (CommCarePreferences.isSmartInflationEnabled()) {
+            // If using smart inflation, we don't want to do any other artificial resizing of images
+            height = LayoutParams.WRAP_CONTENT;
+        } else {
+            // otherwise, should let the image view stretch to fill the height of the row
+            height = LayoutParams.MATCH_PARENT;
+        }
+        FrameLayout.LayoutParams imageViewParams =
+                new FrameLayout.LayoutParams(LayoutParams.WRAP_CONTENT, height);
+        imageView.setLayoutParams(imageViewParams);
+
         graphLayout = (AspectRatioLayout)detailRow.findViewById(R.id.graph);
         calloutView = detailRow.findViewById(R.id.callout_view);
         calloutText = (TextView)detailRow.findViewById(R.id.callout_text);


### PR DESCRIPTION
Fix for: http://manage.dimagi.com/default.asp?216179

Previously, we had both the height and width of image views on an entity detail screen set to `match_parent`. This, in conjunction with `setAdjustViewBounds`, was allowing some images to expand the row height (like in the ticket above). This would occur if the combination of matching the parent's width and maintaining the aspect ratio meant needing to increase the image's height to greater than the row height. 

Changes made to resolve this:
-Set the image view's width to always be `wrap_content`; there is no reason we should ever be stretching to fill the image view's width here
-In normal contexts, leave the image view's height set to `match_parent`; there are likely a lot of people who rely on us sizing up these images to fill that row height. However, if the app has our new image inflation feature turned on, make the height `match_parent` as well, since the whole point of that feature is for the image to come out _exactly_ the size of the original file.