### PR TITLE
Fix incorrect scale-up of images

### DIFF
--- a/unit-tests/src/org/commcare/android/tests/ImageInflationTest.java
+++ b/unit-tests/src/org/commcare/android/tests/ImageInflationTest.java
@@ -34,10 +34,18 @@ public class ImageInflationTest {
         return metrics;
     }
 
-    private void testCorrectInflation(int targetDensity, DisplayMetrics mockDevice,
-                                      int[] boundingDimens, int expectedNewDimen) {
+    private void testCorrectInflationWithoutDensity(int[] boundingDimens, int expectedNewDimen) {
+        Bitmap b = MediaUtil.getBitmapScaledToContainer(imageFilepath, boundingDimens[0],
+                boundingDimens[1]);
+        Assert.assertNotNull(b);
+        Assert.assertEquals(expectedNewDimen, b.getWidth());
+        Assert.assertEquals(expectedNewDimen, b.getHeight());
+    }
+
+    private void testCorrectInflationWithDensity(int targetDensity, DisplayMetrics mockDevice,
+                                                 int[] boundingDimens, int expectedNewDimen) {
         Bitmap b = MediaUtil.getBitmapScaledForNativeDensity(mockDevice, imageFilepath,
-               boundingDimens[0], boundingDimens[1], targetDensity);
+                boundingDimens[0], boundingDimens[1], targetDensity);
         Assert.assertNotNull(b);
         Assert.assertEquals(expectedNewDimen, b.getWidth());
         Assert.assertEquals(expectedNewDimen, b.getHeight());
@@ -78,10 +86,20 @@ public class ImageInflationTest {
     }
 
     @Test
+    public void testInflationWithoutDensity_noChange() {
+        testCorrectInflationWithoutDensity(boundingDimens_UNRESTRICTIVE, 100);
+    }
+
+    @Test
+    public void testInflationWithoutDensity_shouldChange() {
+        testCorrectInflationWithoutDensity(boundingDimens_RESTRICTIVE, 50);
+    }
+
+    @Test
     public void testDoNoScaling() {
         // Low density device with low density target should result in no size change
         int targetDensity = DisplayMetrics.DENSITY_LOW;
-        testCorrectInflation(targetDensity, lowDensityDevice, boundingDimens_UNRESTRICTIVE, 100);
+        testCorrectInflationWithDensity(targetDensity, lowDensityDevice, boundingDimens_UNRESTRICTIVE, 100);
     }
 
     @Test
@@ -89,7 +107,7 @@ public class ImageInflationTest {
         // Medium density device with low density target should result in image being scaled up
         // by a factor of 160/120 = 1.33
         int targetDensity = DisplayMetrics.DENSITY_LOW;
-        testCorrectInflation(targetDensity, mediumDensityDevice, boundingDimens_UNRESTRICTIVE, 133);
+        testCorrectInflationWithDensity(targetDensity, mediumDensityDevice, boundingDimens_UNRESTRICTIVE, 133);
     }
 
     @Test
@@ -97,7 +115,7 @@ public class ImageInflationTest {
         // Low density device with medium density target should result in image being scaled down
         // by a factor of 120/160 = .75
         int targetDensity = DisplayMetrics.DENSITY_MEDIUM;
-        testCorrectInflation(targetDensity, lowDensityDevice, boundingDimens_UNRESTRICTIVE, 75);
+        testCorrectInflationWithDensity(targetDensity, lowDensityDevice, boundingDimens_UNRESTRICTIVE, 75);
     }
 
     @Test
@@ -106,15 +124,15 @@ public class ImageInflationTest {
         // factor of 240 / 120 = 2, which would mean a final size of 200. However, the actual
         // scale-up should be bounded to 150 by the container
         int targetDensity = DisplayMetrics.DENSITY_LOW;
-        testCorrectInflation(targetDensity, highDensityDevice, boundingDimens_LESS_UNRESTRICTIVE, 150);
+        testCorrectInflationWithDensity(targetDensity, highDensityDevice, boundingDimens_LESS_UNRESTRICTIVE, 150);
     }
 
     @Test
-    public void testScaleDownDueToContainer_noDensityAffect() {
+    public void testScaleDownDueToContainer_noDensityEffect() {
         // Low density device with low density target means no change based on density, but
         // restrictive container causes scale down
         int targetDensity = DisplayMetrics.DENSITY_MEDIUM;
-        testCorrectInflation(targetDensity, mediumDensityDevice, boundingDimens_RESTRICTIVE, 50);
+        testCorrectInflationWithDensity(targetDensity, mediumDensityDevice, boundingDimens_RESTRICTIVE, 50);
     }
 
     @Test
@@ -122,7 +140,7 @@ public class ImageInflationTest {
         // Medium density device with low density target would cause an upscale based on density,
         // but the scale down imposed by a restrictive container should be what actual takes effect
         int targetDensity = DisplayMetrics.DENSITY_LOW;
-        testCorrectInflation(targetDensity, mediumDensityDevice, boundingDimens_RESTRICTIVE, 50);
+        testCorrectInflationWithDensity(targetDensity, mediumDensityDevice, boundingDimens_RESTRICTIVE, 50);
     }
 
     @Test
@@ -130,7 +148,7 @@ public class ImageInflationTest {
         // Both the container size and the relative densities impose scale down requirements,
         // but the density factor imposes a larger scale down, so we scale to those dimens
         int targetDensity = DisplayMetrics.DENSITY_MEDIUM;
-        testCorrectInflation(targetDensity, lowDensityDevice, boundingDimens_LESS_RESTRICTIVE, 75);
+        testCorrectInflationWithDensity(targetDensity, lowDensityDevice, boundingDimens_LESS_RESTRICTIVE, 75);
     }
 
     @Test
@@ -138,7 +156,7 @@ public class ImageInflationTest {
         // Both the container size and the relative densities impose scale down requirements,
         // but the container restrictions impose a larger scale down, so we scale to those dimens
         int targetDensity = DisplayMetrics.DENSITY_MEDIUM;
-        testCorrectInflation(targetDensity, lowDensityDevice, boundingDimens_RESTRICTIVE, 50);
+        testCorrectInflationWithDensity(targetDensity, lowDensityDevice, boundingDimens_RESTRICTIVE, 50);
     }
 
 }


### PR DESCRIPTION
Decided to write this up in hotfix format because it probably should have been one. Since at this point we're releasing 2.26 in a few days, I don't think it makes sense to hotfix 2.25, especially since this has been around since 2.24 and we didn't get any bug reports.. But I am really confused how this didn't cause problems for people.

What is the bug?: If the original size of an image is smaller than its bounding container, the image will in some circumstances get scaled up to fill the container.

How did it get introduced?: Basically, I was using 1 method for 2 very different use cases that I somehow convinced myself were the same thing. In one case - `attemptBoundedScaleUp` - we want to be increasing the original image size as much as possible, without exceeding the bounding dimensions. In the other case - `getBitmapScaledToContainer` - the only thing we want to be doing is scaling _down_ the original image if it exceeds its container dimens, and otherwise do nothing.

What is the fix?: Write 2 separate helper methods that do the correct things...

Why wasn't it caught?: The tests I wrote to go along with this feature only tested the strictly new code path that was added - `getBitmapScaledForNativeDensity` - and not the existing code path that was tweaked/refactored in the process - `getBitmapScaledToContainer`. Regressions for `getBitmapScaledToContainer` have now been added to `ImageInflationTest`.

Lesson learned: When you introduce new functionality that also changes existing code paths, make sure your tests for the new feature also include regressions for the existing functionality that it touched, if tests for that code don't already exist. 