### PR TITLE
Catch arity exceptions in form entry and hierarchy views

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -81,6 +81,7 @@ import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.model.xform.XFormsModule;
+import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.odk.collect.android.activities.components.FormNavigationController;
@@ -1076,7 +1077,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                         break;
                 }
             } while (event != FormEntryController.EVENT_END_OF_FORM);
-            }catch(XPathTypeMismatchException e){
+            }catch(XPathTypeMismatchException | XPathArityException e){
                 UserfacingErrorHandling.logErrorAndShowDialog(this, e, EXIT);
             }
         }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -458,8 +458,12 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 break;
             case HIERARCHY_ACTIVITY:
             case HIERARCHY_ACTIVITY_FIRST_START:
-                // We may have jumped to a new index in hierarchy activity, so refresh
-                refreshCurrentView(false);
+                if (resultCode == FormHierarchyActivity.RESULT_XPATH_ERROR) {
+                    finish();
+                } else {
+                    // We may have jumped to a new index in hierarchy activity, so refresh
+                    refreshCurrentView(false);
+                }
                 break;
         }
     }

--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1261,7 +1261,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         FormNavigationController.NavigationDetails details;
         try {
             details = FormNavigationController.calculateNavigationStatus(mFormController, mCurrentView);
-        } catch (XPathTypeMismatchException e) {
+        } catch (XPathTypeMismatchException | XPathArityException e) {
             UserfacingErrorHandling.logErrorAndShowDialog(this, e, EXIT);
             return;
         }
@@ -1322,7 +1322,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 dialog.dismiss();
                 try {
                     mFormController.newRepeat();
-                } catch (XPathTypeMismatchException e) {
+                } catch (XPathTypeMismatchException | XPathArityException e) {
                     Logger.exception(e);
                     UserfacingErrorHandling.logErrorAndShowDialog(FormEntryActivity.this, e, EXIT);
                     return;
@@ -2310,7 +2310,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public void widgetEntryChanged() {
         try {
             updateFormRelevancies();
-        } catch (XPathTypeMismatchException e) {
+        } catch (XPathTypeMismatchException | XPathArityException e) {
             UserfacingErrorHandling.logErrorAndShowDialog(this, e, EXIT);
             return;
         }

--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -33,6 +33,7 @@ public class FormHierarchyActivity extends ListActivity {
     private List<HierarchyElement> formList;
     private TextView mPath;
     private FormIndex mStartIndex;
+    public final static int RESULT_XPATH_ERROR = RESULT_FIRST_USER + 1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -190,6 +191,7 @@ public class FormHierarchyActivity extends ListActivity {
             // TODO PLM: show blocking dialog with error; requires
             // making this implement DialogController & use Fragments
             Toast.makeText(this, errorMsg, Toast.LENGTH_LONG).show();
+            setResult(RESULT_XPATH_ERROR);
             finish();
             return;
         }

--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -7,11 +7,13 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
+import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.commcare.android.framework.SessionActivityRegistration;
-import org.commcare.android.framework.UserfacingErrorHandling;
+import org.commcare.android.logging.XPathErrorLogger;
 import org.commcare.dalvik.R;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.services.locale.Localization;
@@ -81,14 +83,17 @@ public class FormHierarchyActivity extends ListActivity {
             @Override
             public void run() {
                 int position = 0;
-                for (int i = 0; i < getListAdapter().getCount(); i++) {
-                    HierarchyElement he = (HierarchyElement)getListAdapter().getItem(i);
-                    if (mStartIndex.equals(he.getFormIndex())) {
-                        position = i;
-                        break;
+                ListAdapter adapter = getListAdapter();
+                if (adapter != null) {
+                    for (int i = 0; i < adapter.getCount(); i++) {
+                        HierarchyElement he = (HierarchyElement)getListAdapter().getItem(i);
+                        if (mStartIndex.equals(he.getFormIndex())) {
+                            position = i;
+                            break;
+                        }
                     }
+                    getListView().setSelection(position);
                 }
-                getListView().setSelection(position);
             }
         });
 
@@ -179,7 +184,13 @@ public class FormHierarchyActivity extends ListActivity {
         try {
             hierarchyPath = FormHierarchyBuilder.populateHierarchyList(this, formList);
         } catch (XPathTypeMismatchException | XPathArityException e) {
-            UserfacingErrorHandling.logErrorAndShowDialog(this, e, true);
+            XPathErrorLogger.INSTANCE.logErrorToCurrentApp(e);
+
+            final String errorMsg = "Encounted xpath error: " + e.getMessage();
+            // TODO PLM: show blocking dialog with error; requires
+            // making this implement DialogController & use Fragments
+            Toast.makeText(this, errorMsg, Toast.LENGTH_LONG).show();
+            finish();
             return;
         }
 

--- a/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -11,10 +11,13 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import org.commcare.android.framework.SessionActivityRegistration;
+import org.commcare.android.framework.UserfacingErrorHandling;
 import org.commcare.dalvik.R;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryController;
+import org.javarosa.xpath.XPathArityException;
+import org.javarosa.xpath.XPathTypeMismatchException;
 import org.odk.collect.android.adapters.HierarchyListAdapter;
 import org.odk.collect.android.logic.FormHierarchyBuilder;
 import org.odk.collect.android.logic.HierarchyElement;
@@ -172,7 +175,13 @@ public class FormHierarchyActivity extends ListActivity {
 
         formList = new ArrayList<>();
 
-        String hierarchyPath = FormHierarchyBuilder.populateHierarchyList(this, formList);
+        String hierarchyPath;
+        try {
+            hierarchyPath = FormHierarchyBuilder.populateHierarchyList(this, formList);
+        } catch (XPathTypeMismatchException | XPathArityException e) {
+            UserfacingErrorHandling.logErrorAndShowDialog(this, e, true);
+            return;
+        }
 
         setGoUpButton(hierarchyPath);
 


### PR DESCRIPTION
@esoergel was encountering xpath arity errors that were crashing commcare instead of showing the user the error, which is user addressable.

https://github.com/dimagi/commcare-odk/commit/3a9ad0004f8fb2e33cb505d04e272b6c67d9ce14 adds additional xpath arity exception checks; I'm unsure if they are necessary...

xpath arity checks caught in the form hierarchy activity show a toast message because that activity doesn't extend `CommCareActivity` (it needs to extend the non-Fragment compatible `ListActivity`).

http://manage.dimagi.com/default.asp?217408