### PR TITLE
Remove > char before testing group label

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1193,7 +1193,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         SpannableStringBuilder groupLabelText = mCurrentView.getGroupLabel();
 
-        if (groupLabelText != null && !groupLabelText.toString().trim().equals("")) {
+        // don't consider '>' char when evaluating whether there's a group label
+        if (groupLabelText != null && !groupLabelText.toString().replace(">","").trim().equals("")) {
             groupLabel.setText(groupLabelText);
             this.mGroupNativeVisibility = true;
             updateGroupViewVisibility();


### PR DESCRIPTION
See http://manage.dimagi.com/default.asp?217534#1092375

We shouldn't be considering the inserted '>' chars as part of the label when evaluating if its null