### PR TITLE
Dismiss dialogs before finishing form entry activity

### DIFF
--- a/app/src/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/app/src/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1466,6 +1466,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             public void onClick(View v) {
                 GoogleAnalyticsUtils.reportFormExit(GoogleAnalyticsFields.LABEL_EXIT_NO_SAVE);
                 discardChangesAndExit();
+                dialog.dismiss();
             }
         };
         DialogChoiceItem quitFormItem = new DialogChoiceItem(
@@ -1480,6 +1481,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 public void onClick(View v) {
                     GoogleAnalyticsUtils.reportFormExit(GoogleAnalyticsFields.LABEL_SAVE_AND_EXIT);
                     saveFormToDisk(EXIT);
+                    dialog.dismiss();
                 }
             };
             DialogChoiceItem saveIncompleteItem = new DialogChoiceItem(


### PR DESCRIPTION
Prevent the following stack trace from showing in logcat:

```
02-18 17:16:49.150 28264-28264/org.commcare.dalvik E/WindowManager: android.view.WindowLeaked: Activity org.odk.collect.android.activities.FormEntryActivity has leaked window com.android.internal.policy.PhoneWindow$DecorView{4eaa4b5 V.E...... R....... 0,0-1026,573} that was originally added here
...
```