### PR TITLE
Reset height before animating shrinking question hint text

### DIFF
--- a/app/src/org/odk/collect/android/views/ShrinkingTextView.java
+++ b/app/src/org/odk/collect/android/views/ShrinkingTextView.java
@@ -125,6 +125,9 @@ public class ShrinkingTextView extends TextView {
             }
 
             if (mExpanded) {
+                if (mFullHeight == -1) {
+                    mFullHeight = ShrinkingTextView.this.getMeasuredHeight();
+                }
                 mCurrentAnimation = new ExpandAnimation(mFullHeight, mMaxHeight);
             } else {
                 mCurrentAnimation = new ExpandAnimation(mMaxHeight, mFullHeight);


### PR DESCRIPTION
Long question text hints are semi-collapsed such that when you click them they animate open. 

There was a glitch where when you click them to collapse them, the text height animates up from 0 to the collapsed height instead of animating down from the full text height to the collapsed text height.

This was due to the `mFullHeight` being reset to `-1` and not reset to the correct value before collapsing.