### PR TITLE
Check if CallOutActivity.onCreate bundle is null before referencing it

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -66,7 +66,7 @@ public class CallOutActivity extends FragmentActivity
     }
 
     private void loadStateFromInstance(Bundle savedInstanceState) {
-        if (savedInstanceState.containsKey(CALLOUT_ACTION_KEY)) {
+        if (savedInstanceState != null && savedInstanceState.containsKey(CALLOUT_ACTION_KEY)) {
             calloutAction = savedInstanceState.getString(CALLOUT_ACTION_KEY);
         }
     }


### PR DESCRIPTION
fix for https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/941a986da24b6c57417032737cfd4be9

might need to go into a 2.26 hotfix