### PR TITLE
Fix case detail phone callout & add localizations

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -305,6 +305,9 @@ select.menu.map=View on Map
 
 select.detail.title=Details
 select.list.title=Select
+select.detail.callout.title=Select phone number action
+select.detail.callout.call=Call
+select.detail.callout.sms=Send SMS
 
 home.logged.in.message=Logged In: ${0}
 notification.logged.in=Logged Into ${0}
@@ -642,6 +645,7 @@ permission.all.message=CommCare needs permissions to read/write forms to memory,
 permission.all.denial.message=CommCare doesn't have the necessary permissions. Please enable via 'Settings -> Apps'
 permission.case.callout.title=Permissions for calling & messaging
 permission.case.callout.message=CommCare needs call & messaging permissions to enable communication with cases.
+permission.case.callout.denied=Permissions denied for calling & messaging from case detail screen.
 permission.sms.install.title=Permission for obtaining SMS app code
 permission.sms.install.message=CommCare would like to scan your recent messages for an app install code.
 permission.form.gps.title=Permission to capture location during form entry

--- a/app/src/org/commcare/dalvik/activities/CallOutActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CallOutActivity.java
@@ -69,7 +69,7 @@ public class CallOutActivity extends FragmentActivity
     }
 
     private void loadStateFromInstance(Bundle savedInstanceState) {
-        if (savedInstanceState.containsKey(CALLOUT_ACTION_KEY)) {
+        if (savedInstanceState != null && savedInstanceState.containsKey(CALLOUT_ACTION_KEY)) {
             calloutAction = savedInstanceState.getString(CALLOUT_ACTION_KEY);
         }
     }
@@ -97,25 +97,27 @@ public class CallOutActivity extends FragmentActivity
     }
     
     private void showChoiceDialog() {
-        PaneledChoiceDialog dialog = new PaneledChoiceDialog(this, "Select Action");
+        final PaneledChoiceDialog dialog = new PaneledChoiceDialog(this, Localization.get("select.detail.callout.title"));
 
         View.OnClickListener callListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 calloutAction = Intent.ACTION_CALL;
                 dispatchActionWithPermissions();
+                dialog.dismiss();
             }
         };
-        DialogChoiceItem item1 = new DialogChoiceItem("Call", -1, callListener);
+        DialogChoiceItem item1 = new DialogChoiceItem(Localization.get("select.detail.callout.call"), -1, callListener);
 
         View.OnClickListener smsListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 calloutAction = Intent.ACTION_SENDTO;
                 dispatchActionWithPermissions();
+                dialog.dismiss();
             }
         };
-        DialogChoiceItem item2 = new DialogChoiceItem("Send SMS", -1, smsListener);
+        DialogChoiceItem item2 = new DialogChoiceItem(Localization.get("select.detail.callout.sms"), -1, smsListener);
 
         dialog.setChoiceItems(new DialogChoiceItem[]{item1, item2});
         dialog.setOnCancelListener(new OnCancelListener() {
@@ -131,6 +133,7 @@ public class CallOutActivity extends FragmentActivity
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+
         outState.putString(CALLOUT_ACTION_KEY, calloutAction);
     }
 
@@ -151,28 +154,20 @@ public class CallOutActivity extends FragmentActivity
         }
     }
 
-    private String getPermissionForAction() {
-        if (calloutAction.equals(Intent.ACTION_CALL)) {
-            return Manifest.permission.CALL_PHONE;
-        } else if (calloutAction.equals(Intent.ACTION_SENDTO)) {
-            return Manifest.permission.RECEIVE_SMS;
-        }
-        return "";
-    }
-
     private boolean missingPhonePermission() {
-        return ContextCompat.checkSelfPermission(this, getPermissionForAction()) != PackageManager.PERMISSION_GRANTED;
+        return calloutAction.equals(Intent.ACTION_CALL) &&
+                ContextCompat.checkSelfPermission(this, Manifest.permission.CALL_PHONE) != PackageManager.PERMISSION_GRANTED;
     }
 
     private boolean shouldShowPhonePermissionRationale() {
         return ActivityCompat.shouldShowRequestPermissionRationale(this,
-                getPermissionForAction());
+                Manifest.permission.CALL_PHONE);
     }
 
     @Override
     public void requestNeededPermissions(int requestCode) {
         ActivityCompat.requestPermissions(this,
-                new String[]{getPermissionForAction()},
+                new String[]{Manifest.permission.CALL_PHONE},
                 requestCode);
     }
 
@@ -182,17 +177,19 @@ public class CallOutActivity extends FragmentActivity
                                            @NonNull int[] grantResults) {
         if (requestCode == CALL_OR_SMS_PERMISSION_REQUEST) {
             for (int i = 0; i < permissions.length; i++) {
-                if (getPermissionForAction().equals(permissions[i]) &&
+                if (Manifest.permission.CALL_PHONE.equals(permissions[i]) &&
                         grantResults[i] == PackageManager.PERMISSION_GRANTED) {
                     dispatchAction();
+                    return;
                 }
             }
         }
+        Toast.makeText(this, Localization.get("permission.case.callout.denied"), Toast.LENGTH_LONG).show();
+        finish();
     }
 
     private void dispatchAction() {
-        // using createChooser to handle any errors gracefully
-        if(Intent.ACTION_CALL.equals(calloutAction) ) {
+        if (Intent.ACTION_CALL.equals(calloutAction)) {
             tManager.listen(listener, PhoneStateListener.LISTEN_CALL_STATE);
 
             Intent call = new Intent(Intent.ACTION_CALL);


### PR DESCRIPTION
 - Stop case detail phone number callout from crashing when launched
 - Fix permission checking to all the 'Send SMS' option to work. Sending an sms via the messenger doesn't actually require permissions
 - Fix failure mode when permissions are denied.
 - Add localization texts to allow app builders to localize phone number callout text

fix for https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/941a986da24b6c57417032737cfd4be9