### PR TITLE
Show to user that task is cancelling when the press 'stop'

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -315,7 +315,8 @@ notification.logged.in=Logged Into ${0}
 title.datum.wrapper=[${0}]
 
 activity.task.error.generic=Unexpected error! Please try again.
-activity.task.cancelling=Cancelling
+activity.task.cancelling.title=Cancelling: ${0}
+activity.task.cancelling.message=Cancelling...
 
 dialog.ok=OK
 

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -315,6 +315,7 @@ notification.logged.in=Logged Into ${0}
 title.datum.wrapper=[${0}]
 
 activity.task.error.generic=Unexpected error! Please try again.
+activity.task.cancelling=Cancelling
 
 dialog.ok=OK
 

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -1,16 +1,5 @@
 package org.commcare.dalvik.dialogs;
 
-/**
- * @author amstone326
- *
- * Any progress dialog associated with a CommCareTask should use
- * this class to implement the dialog. Any class that launches such a task
- * should implement the generateProgressDialog() method of the DialogController
- * interface, and create the dialog in that method. The rest of the dialog's
- * lifecycle is handled by methods of the DialogController interface that are
- * fully implemented in CommCareActivity
- */
-
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
@@ -27,7 +16,18 @@ import android.widget.TextView;
 
 import org.commcare.android.framework.CommCareActivity;
 import org.commcare.dalvik.R;
+import org.javarosa.core.services.locale.Localization;
 
+/**
+ * Any progress dialog associated with a CommCareTask should use
+ * this class to implement the dialog. Any class that launches such a task
+ * should implement the generateProgressDialog() method of the DialogController
+ * interface, and create the dialog in that method. The rest of the dialog's
+ * lifecycle is handled by methods of the DialogController interface that are
+ * fully implemented in CommCareActivity
+ *
+ * @author amstone326
+ */
 public class CustomProgressDialog extends DialogFragment {
 
     //keys for onSaveInstanceState
@@ -39,9 +39,12 @@ public class CustomProgressDialog extends DialogFragment {
     private final static String KEY_USING_BUTTON = "using_cancel_buton";
     private final static String KEY_TASK_ID = "task_id";
     private final static String KEY_CANCELABLE = "is_cancelable";
+    private final static String KEY_WAS_CANCEL_PRESSED = "was_cancel_pressed";
     private final static String KEY_USING_PROGRESS_BAR = "using_progress_bar";
     private final static String KEY_PROGRESS_BAR_PROGRESS = "progress_bar_progress";
     private final static String KEY_PROGRESS_BAR_MAX = "progress_bar_max";
+
+    private final static String cancellingPrefixText = Localization.get("activity.task.cancelling");
 
     //id of the task that spawned this dialog, -1 if not associated with a CommCareTask
     private int taskId;
@@ -50,6 +53,7 @@ public class CustomProgressDialog extends DialogFragment {
     private String title;
     private String message;
     private boolean isCancelable; //default is false, only set to true if setCancelable() is explicitly called
+    private boolean wasCancelPressed;
 
     //for checkboxes
     private boolean usingCheckbox;
@@ -66,9 +70,9 @@ public class CustomProgressDialog extends DialogFragment {
 
     public static CustomProgressDialog newInstance(String title, String message, int taskId) {
         CustomProgressDialog frag = new CustomProgressDialog();
-        frag.setTitle(title);
-        frag.setMessage(message);
-        frag.setTaskId(taskId);
+        frag.title = title;
+        frag.message = message;
+        frag.taskId = taskId;
         return frag;
     }
 
@@ -92,20 +96,8 @@ public class CustomProgressDialog extends DialogFragment {
         this.progressBarMax = 0;
     }
 
-    private void setTaskId(int id) {
-        this.taskId = id;
-    }
-
     public int getTaskId() {
         return taskId;
-    }
-
-    private void setTitle(String s) {
-        this.title = s;
-    }
-
-    private void setMessage(String s) {
-        this.message = s;
     }
 
     public boolean isChecked() {
@@ -128,6 +120,7 @@ public class CustomProgressDialog extends DialogFragment {
             this.usingCancelButton = savedInstanceState.getBoolean(KEY_USING_BUTTON);
             this.taskId = savedInstanceState.getInt(KEY_TASK_ID);
             this.isCancelable = savedInstanceState.getBoolean(KEY_CANCELABLE);
+            this.wasCancelPressed = savedInstanceState.getBoolean(KEY_WAS_CANCEL_PRESSED);
             this.usingHorizontalProgressBar = savedInstanceState.getBoolean(KEY_USING_PROGRESS_BAR);
             this.progressBarProgress = savedInstanceState.getInt(KEY_PROGRESS_BAR_PROGRESS);
             this.progressBarMax = savedInstanceState.getInt(KEY_PROGRESS_BAR_MAX);
@@ -167,6 +160,9 @@ public class CustomProgressDialog extends DialogFragment {
 
         if (usingCancelButton) {
             setupCancelButton(view);
+            if (wasCancelPressed) {
+                setCancellingText(titleView, messageView);
+            }
         }
 
         builder.setView(view);
@@ -207,10 +203,27 @@ public class CustomProgressDialog extends DialogFragment {
             @Override
             public void onClick(View v) {
                 ((CommCareActivity)getActivity()).cancelCurrentTask();
+                showCancelledState();
             }
 
         });
         b.setVisibility(View.VISIBLE);
+    }
+
+    private void showCancelledState() {
+        wasCancelPressed = true;
+
+        AlertDialog pd = (AlertDialog)getDialog();
+        if (pd != null) {
+            TextView titleView = (TextView)pd.findViewById(R.id.progress_dialog_title).findViewById(R.id.dialog_title_text);
+            TextView messageView = (TextView)pd.findViewById(R.id.progress_dialog_message);
+            setCancellingText(titleView, messageView);
+        }
+    }
+
+    private void setCancellingText(TextView titleTextView, TextView messageTextView) {
+        titleTextView.setText(cancellingPrefixText + " " + title);
+        messageTextView.setText(cancellingPrefixText + "...");
     }
 
     public void updateMessage(String text) {
@@ -233,6 +246,7 @@ public class CustomProgressDialog extends DialogFragment {
         outState.putBoolean(KEY_USING_BUTTON, this.usingCancelButton);
         outState.putInt(KEY_TASK_ID, this.taskId);
         outState.putBoolean(KEY_CANCELABLE, this.isCancelable);
+        outState.putBoolean(KEY_WAS_CANCEL_PRESSED, this.wasCancelPressed);
         outState.putBoolean(KEY_USING_PROGRESS_BAR, this.usingHorizontalProgressBar);
         outState.putInt(KEY_PROGRESS_BAR_PROGRESS, this.progressBarProgress);
         outState.putInt(KEY_PROGRESS_BAR_MAX, this.progressBarMax);

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -222,7 +222,7 @@ public class CustomProgressDialog extends DialogFragment {
     }
 
     private void setCancellingText(TextView titleTextView, TextView messageTextView) {
-        titleTextView.setText(cancellingPrefixText + " " + title);
+        titleTextView.setText(cancellingPrefixText + " '" + title + "'");
         messageTextView.setText(cancellingPrefixText + "...");
     }
 

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -44,8 +44,6 @@ public class CustomProgressDialog extends DialogFragment {
     private final static String KEY_PROGRESS_BAR_PROGRESS = "progress_bar_progress";
     private final static String KEY_PROGRESS_BAR_MAX = "progress_bar_max";
 
-    private final static String cancellingPrefixText = Localization.get("activity.task.cancelling");
-
     //id of the task that spawned this dialog, -1 if not associated with a CommCareTask
     private int taskId;
 
@@ -224,8 +222,8 @@ public class CustomProgressDialog extends DialogFragment {
     }
 
     private void setCancellingText(TextView titleTextView, TextView messageTextView, Button cancelButton) {
-        titleTextView.setText(cancellingPrefixText + " '" + title + "'");
-        messageTextView.setText(cancellingPrefixText + "...");
+        titleTextView.setText(Localization.get("activity.task.cancelling.title", new String[]{title}));
+        messageTextView.setText(Localization.get("activity.task.cancelling.message"));
         cancelButton.setEnabled(false);
     }
 

--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -159,9 +159,9 @@ public class CustomProgressDialog extends DialogFragment {
         messageView.setText(message);
 
         if (usingCancelButton) {
-            setupCancelButton(view);
+            Button cancelButton = setupCancelButton(view);
             if (wasCancelPressed) {
-                setCancellingText(titleView, messageView);
+                setCancellingText(titleView, messageView, cancelButton);
             }
         }
 
@@ -196,7 +196,7 @@ public class CustomProgressDialog extends DialogFragment {
         }
     }
 
-    private void setupCancelButton(View v) {
+    private Button setupCancelButton(View v) {
         Button b = (Button)v.findViewById(R.id.dialog_cancel_button);
         b.setOnClickListener(new OnClickListener() {
 
@@ -208,6 +208,7 @@ public class CustomProgressDialog extends DialogFragment {
 
         });
         b.setVisibility(View.VISIBLE);
+        return b;
     }
 
     private void showCancelledState() {
@@ -217,13 +218,15 @@ public class CustomProgressDialog extends DialogFragment {
         if (pd != null) {
             TextView titleView = (TextView)pd.findViewById(R.id.progress_dialog_title).findViewById(R.id.dialog_title_text);
             TextView messageView = (TextView)pd.findViewById(R.id.progress_dialog_message);
-            setCancellingText(titleView, messageView);
+            Button cancelButton = (Button)pd.findViewById(R.id.dialog_cancel_button);
+            setCancellingText(titleView, messageView, cancelButton);
         }
     }
 
-    private void setCancellingText(TextView titleTextView, TextView messageTextView) {
+    private void setCancellingText(TextView titleTextView, TextView messageTextView, Button cancelButton) {
         titleTextView.setText(cancellingPrefixText + " '" + title + "'");
         messageTextView.setText(cancellingPrefixText + "...");
+        cancelButton.setEnabled(false);
     }
 
     public void updateMessage(String text) {


### PR DESCRIPTION
Sometimes tasks take forever to cancel because we don't actually check the value of  `AsyncTask.isCancelled()` regularly. This is confusing for me, and probably users, because they think that the button is broken.

This PR changes the blocking task dialog text to signify when the task was cancelled.

![screen](https://cloud.githubusercontent.com/assets/94817/13364684/2e070fc2-dc9e-11e5-8862-e811bfc610d1.png)

Eventually we should do a better job of stopping the process when cancel is pressed, but that is sorta hard.

http://manage.dimagi.com/default.asp?217900