### PR TITLE
Parse empty fixtures correctly: don't swallow subsequent fixtures

### DIFF
--- a/unit-tests/resources/odk_level_ipm_restore_with_empty_fixture.xml
+++ b/unit-tests/resources/odk_level_ipm_restore_with_empty_fixture.xml
@@ -1,0 +1,384 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>2837795451fb8620bbffc00fe8c14135</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>sha1$88rUXppT9kj8$7d146054b5bf79fc4ec7f618a1b4aead1ba1d706</password>
+        <uuid>a8f5a98c4ce767c35b9132bc75eb225c</uuid>
+        <date>2014-03-22</date>
+    </Registration>
+    <fixture id="commtrack:locations" user_id="a8f5a98c4ce767c35b9132bc75eb225c"/>
+    <fixture id="user-groups" user_id="a8f5a98c4ce767c35b9132bc75eb225c">
+        <groups/>
+    </fixture>
+    <fixture id="commtrack:products" user_id="a8f5a98c4ce767c35b9132bc75eb225c">
+        <products>
+            <product id="f895be4959f9a8a66f57c340aac461b4">
+                <name>Collier</name>
+                <unit/>
+                <code>col</code>
+                <description>Collier du cycle mensuel</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>152</cost>
+            </product>
+            <product id="a6d16035b98f6f962a6538bd927cefb3">
+                <name>CU</name>
+                <unit/>
+                <code>pd</code>
+                <description>La contraception d'urgence</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>57</cost>
+            </product>
+            <product id="31ab899368d38c2d0207fe80c00fa96c">
+                <name>Depo-Provera</name>
+                <unit/>
+                <code>dp</code>
+                <description>Injectable</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>152</cost>
+            </product>
+            <product id="31ab899368d38c2d0207fe80c00fb8c1">
+                <name>DIU</name>
+                <unit/>
+                <code>diu</code>
+                <description>TCU 380A</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>380</cost>
+            </product>
+            <product id="c7bd1f35a48e1e8daaad6bf61cc2874d">
+                <name>IMPLANON</name>
+                <unit/>
+                <code>implanon</code>
+                <description>Implant contracepif</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>380</cost>
+            </product>
+            <product id="31ab899368d38c2d0207fe80c00fb3ff">
+                <name>Jadelle</name>
+                <unit/>
+                <code>jad</code>
+                <description>Implant contracepif</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>380</cost>
+            </product>
+            <product id="f895be4959f9a8a66f57c340aa795758">
+                <name>Microgynon/Lof.</name>
+                <unit/>
+                <code>ml</code>
+                <description>Pilule</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>76</cost>
+            </product>
+            <product id="a6d16035b98f6f962a6538bd924fed4c">
+                <name>Microlut/Ovrette</name>
+                <unit/>
+                <code>mo</code>
+                <description>Pilule</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>76</cost>
+            </product>
+            <product id="a6d16035b98f6f962a6538bd924fdf4e">
+                <name>Preservatif Feminin</name>
+                <unit/>
+                <code>pf</code>
+                <description>Préservatif</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>0</cost>
+            </product>
+            <product id="57cf5fe4da3c034262099ea418831118">
+                <name>Preservatif Masculin</name>
+                <unit/>
+                <code>pm</code>
+                <description>Préservatif</description>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>0</cost>
+            </product>
+            <product id="a49f5098fe378f2bb0b684e90435a8e6">
+                <name>Sayana Press</name>
+                <unit/>
+                <code>say</code>
+                <description/>
+                <category/>
+                <program_id>31ab899368d38c2d0207fe80c00fc3f3</program_id>
+                <cost>152</cost>
+            </product>
+        </products>
+    </fixture>
+    <fixture id="commtrack:programs" user_id="a8f5a98c4ce767c35b9132bc75eb225c">
+        <programs>
+            <program id="31ab899368d38c2d0207fe80c00fc3f3">
+                <name>Default</name>
+                <code>def</code>
+            </program>
+        </programs>
+    </fixture>
+    <case case_id="289dffbe3a6948048f20d27550b698e1" date_modified="2015-06-25T02:52:03.123000Z"
+          user_id="a8f5a98c4ce767c35b9132bc75eb225c" xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>supply-point</case_type>
+            <case_name>Mr Contes all Italian Leather goods Emporium</case_name>
+            <owner_id>commtrack-system</owner_id>
+        </create>
+        <update>
+            <first_visit>1</first_visit>
+            <location_>['4f79174e22a4ca28c25cf8c74dd56eab', '30586d7da212ba9d7c43fd93cc822deb',
+                '4f8031c0d8ef497f798ad9f2517c7384']
+            </location_>
+            <location_id>4f8031c0d8ef497f798ad9f2517c7384</location_id>
+            <referrals>[]</referrals>
+        </update>
+    </case>
+    <case case_id="3451e61108cc4a5993b856ac9461f006" date_modified="2014-12-10T14:01:32.000000Z"
+          user_id="a8f5a98c4ce767c35b9132bc75eb225c" xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>supply-point</case_type>
+            <case_name>CLINIC GNOCCHI</case_name>
+            <owner_id>commtrack-system</owner_id>
+        </create>
+        <update>
+            <first_visit>1</first_visit>
+            <location_>['4f79174e22a4ca28c25cf8c74dd56eab', '30586d7da212ba9d7c43fd93cc822deb',
+                'b60ccfc8753a654abdc75eb93c87f77b']
+            </location_>
+            <location_id>b60ccfc8753a654abdc75eb93c87f77b</location_id>
+            <referrals>[]</referrals>
+        </update>
+    </case>
+    <case case_id="00d5d8aca0884ac984ab9fa5a6f8683c" date_modified="2015-06-24T22:25:16.532637Z"
+          user_id="commtrack-system" xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>supply-point</case_type>
+            <case_name>Napoli</case_name>
+            <owner_id>commtrack-system</owner_id>
+        </create>
+        <update>
+            <complete>1</complete>
+            <district_a_produit>non</district_a_produit>
+            <location_>['4f79174e22a4ca28c25cf8c74dd56eab', '30586d7da212ba9d7c43fd93cc822deb']</location_>
+            <location_id>30586d7da212ba9d7c43fd93cc822deb</location_id>
+            <quantite_due_au_district>0</quantite_due_au_district>
+            <referrals>[]</referrals>
+        </update>
+    </case>
+    <case case_id="4d8a15eff3404068a671446d7acbc45e" date_modified="2015-02-16T14:45:12.000000Z"
+          user_id="a8f5a98c4ce767c35b9132bc75eb225c" xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>supply-point</case_type>
+            <case_name>CLINIC PASTA</case_name>
+            <owner_id>commtrack-system</owner_id>
+        </create>
+        <update>
+            <first_visit>1</first_visit>
+            <location_>['4f79174e22a4ca28c25cf8c74dd56eab', '30586d7da212ba9d7c43fd93cc822deb',
+                '751f67ca41ce1f46bf9e745f1cee31f5']
+            </location_>
+            <location_id>751f67ca41ce1f46bf9e745f1cee31f5</location_id>
+            <referrals>[]</referrals>
+        </update>
+    </case>
+    <case case_id="3a0ab778a5824755bd28e92cbfe949bb" date_modified="2015-05-20T13:17:01.585000Z"
+          user_id="a8f5a98c4ce767c35b9132bc75eb225c" xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>payment</case_type>
+            <case_name>Napoli janvier 2015</case_name>
+            <owner_id>a8f5a98c4ce767c35b9132bc75eb225c</owner_id>
+        </create>
+        <update>
+            <amount_owed>100</amount_owed>
+            <amount_owed_85>85</amount_owed_85>
+            <amount_paid>oui</amount_paid>
+            <annee>2015</annee>
+            <case_location_id>30586d7da212ba9d7c43fd93cc822deb</case_location_id>
+            <date_du>2015-01-31</date_du>
+            <district_id/>
+            <district_month_year>Napoli Napoli janvier 2015</district_month_year>
+            <district_name>Napoli</district_name>
+            <mois>janvier</mois>
+            <montant_paye>85</montant_paye>
+            <payee>oui</payee>
+            <payee_de_quantite_due>non</payee_de_quantite_due>
+            <payee_trent_jour>1</payee_trent_jour>
+            <payee_trois_mois>1</payee_trois_mois>
+            <payee_un_an>1</payee_un_an>
+            <payment_date>2015-02-11</payment_date>
+            <periode_facture>janvier 2015</periode_facture>
+            <quantite_a_payer_a_changer>0</quantite_a_payer_a_changer>
+            <quantite_due_au_district_nouvelle>0</quantite_due_au_district_nouvelle>
+            <quantite_due_au_district_precedente>0</quantite_due_au_district_precedente>
+            <quantite_reale_a_payer>85</quantite_reale_a_payer>
+        </update>
+        <index>
+            <parent case_type="supply-point">00d5d8aca0884ac984ab9fa5a6f8683c</parent>
+        </index>
+    </case>
+    <case case_id="user-owner-mapping-a8f5a98c4ce767c35b9132bc75eb225c" date_modified="2015-05-12T06:03:47.073379Z"
+          user_id="" xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>user-owner-mapping-case</case_type>
+            <case_name/>
+            <owner_id>a8f5a98c4ce767c35b9132bc75eb225c</owner_id>
+        </create>
+        <update>
+            <location_>[]</location_>
+            <referrals>[]</referrals>
+        </update>
+        <index>
+            <supply_point-00d5d8aca0884ac984ab9fa5a6f8683c case_type="supply-point">00d5d8aca0884ac984ab9fa5a6f8683c
+            </supply_point-00d5d8aca0884ac984ab9fa5a6f8683c>
+            <supply_point-289dffbe3a6948048f20d27550b698e1 case_type="supply-point">289dffbe3a6948048f20d27550b698e1
+            </supply_point-289dffbe3a6948048f20d27550b698e1>
+            <supply_point-3451e61108cc4a5993b856ac9461f006 case_type="supply-point">3451e61108cc4a5993b856ac9461f006
+            </supply_point-3451e61108cc4a5993b856ac9461f006>
+            <supply_point-4d8a15eff3404068a671446d7acbc45e case_type="supply-point">4d8a15eff3404068a671446d7acbc45e
+            </supply_point-4d8a15eff3404068a671446d7acbc45e>
+        </index>
+    </case>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-06-24T13:53:57.154000Z"
+                 entity-id="289dffbe3a6948048f20d27550b698e1" section-id="is-relevant">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="1"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="1"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="1"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="1"/>
+        <ns0:entry id="a49f5098fe378f2bb0b684e90435a8e6" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="1"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="1"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="1"/>
+        <ns0:entry id="c7bd1f35a48e1e8daaad6bf61cc2874d" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="1"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="1"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-06-25T00:00:00.000000Z"
+                 entity-id="289dffbe3a6948048f20d27550b698e1" section-id="stock">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="2"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="2"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="15"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="2"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="53"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="2"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="2"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="8"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="2"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-06-25T00:00:00.000000Z"
+                 entity-id="289dffbe3a6948048f20d27550b698e1" section-id="stock-pps">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="1"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="0"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="10"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="1"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-06-25T00:00:00.000000Z"
+                 entity-id="289dffbe3a6948048f20d27550b698e1" section-id="consumption">
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="1"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="11"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="1"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="5"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="5"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="2"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="8"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="14"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="17"/>
+        <ns0:entry id="a49f5098fe378f2bb0b684e90435a8e6" quantity="2"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2014-12-10T14:01:32.307000Z"
+                 entity-id="3451e61108cc4a5993b856ac9461f006" section-id="is-relevant">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="0"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="1"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="1"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2014-05-15T00:00:00.000000Z"
+                 entity-id="3451e61108cc4a5993b856ac9461f006" section-id="stock">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="0"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="0"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2014-05-15T00:00:00.000000Z"
+                 entity-id="3451e61108cc4a5993b856ac9461f006" section-id="stock-pps">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="0"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="0"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2014-05-15T00:00:00.000000Z"
+                 entity-id="3451e61108cc4a5993b856ac9461f006" section-id="consumption">
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="5"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="18"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="5"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="2"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="2"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="4"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="5"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="3"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="5"/>
+        <ns0:entry id="a49f5098fe378f2bb0b684e90435a8e6" quantity="4"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-02-16T14:44:36.613000Z"
+                 entity-id="4d8a15eff3404068a671446d7acbc45e" section-id="is-relevant">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="0"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="1"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="0"/>
+        <ns0:entry id="a49f5098fe378f2bb0b684e90435a8e6" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="0"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="0"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="1"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-02-16T00:00:00.000000Z"
+                 entity-id="4d8a15eff3404068a671446d7acbc45e" section-id="stock">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="5"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="2"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-02-16T00:00:00.000000Z"
+                 entity-id="4d8a15eff3404068a671446d7acbc45e" section-id="stock-pps">
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="3"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="2"/>
+    </ns0:balance>
+    <ns0:balance xmlns:ns0="http://commcarehq.org/ledger/v1" date="2015-02-16T00:00:00.000000Z"
+                 entity-id="4d8a15eff3404068a671446d7acbc45e" section-id="consumption">
+        <ns0:entry id="f895be4959f9a8a66f57c340aac461b4" quantity="1"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd927cefb3" quantity="23"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fa96c" quantity="1"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb8c1" quantity="2"/>
+        <ns0:entry id="31ab899368d38c2d0207fe80c00fb3ff" quantity="2"/>
+        <ns0:entry id="f895be4959f9a8a66f57c340aa795758" quantity="12"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fed4c" quantity="1"/>
+        <ns0:entry id="a6d16035b98f6f962a6538bd924fdf4e" quantity="3"/>
+        <ns0:entry id="57cf5fe4da3c034262099ea418831118" quantity="1"/>
+        <ns0:entry id="a49f5098fe378f2bb0b684e90435a8e6" quantity="12"/>
+    </ns0:balance>
+</OpenRosaResponse>

--- a/unit-tests/src/org/commcare/android/database/HybridFileBackedSqlStorageTest.java
+++ b/unit-tests/src/org/commcare/android/database/HybridFileBackedSqlStorageTest.java
@@ -31,7 +31,7 @@ public class HybridFileBackedSqlStorageTest {
         UnencryptedHybridFileBackedSqlStorageMock.alwaysPutInFilesystem();
         HybridFileBackedSqlStorageMock.alwaysPutInFilesystem();
 
-        StoreFixturesOnFilesystemTests.installAppWithFixtureData(this.getClass());
+        StoreFixturesOnFilesystemTests.installAppWithFixtureData(this.getClass(), "odk_level_ipm_restore.xml");
     }
 
     /**

--- a/unit-tests/src/org/commcare/android/database/StoreFixturesOnFilesystemTests.java
+++ b/unit-tests/src/org/commcare/android/database/StoreFixturesOnFilesystemTests.java
@@ -48,10 +48,10 @@ public class StoreFixturesOnFilesystemTests {
         UnencryptedHybridFileBackedSqlStorageMock.alwaysPutInFilesystem();
         HybridFileBackedSqlStorageMock.alwaysPutInFilesystem();
 
-        sandbox = installAppWithFixtureData(this.getClass());
+        sandbox = installAppWithFixtureData(this.getClass(), "odk_level_ipm_restore.xml");
     }
 
-    public static AndroidSandbox installAppWithFixtureData(Class testClass) {
+    public static AndroidSandbox installAppWithFixtureData(Class testClass, String fixtureResource) {
         // needed to resolve "jr://resource" type references
         ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
 
@@ -66,7 +66,7 @@ public class StoreFixturesOnFilesystemTests {
         AndroidSandbox sandbox = new AndroidSandbox(CommCareApplication._());
 
         try {
-            parseIntoSandbox(testClass.getClassLoader().getResourceAsStream("odk_level_ipm_restore.xml"), false);
+            parseIntoSandbox(testClass.getClassLoader().getResourceAsStream(fixtureResource), false);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/unit-tests/src/org/commcare/android/tests/processing/FixtureLoadingTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FixtureLoadingTest.java
@@ -1,0 +1,43 @@
+package org.commcare.android.tests.processing;
+
+import org.commcare.android.CommCareTestRunner;
+import org.commcare.android.database.HybridFileBackedSqlStorage;
+import org.commcare.android.database.StoreFixturesOnFilesystemTests;
+import org.commcare.dalvik.BuildConfig;
+import org.commcare.dalvik.application.CommCareApplication;
+import org.javarosa.core.model.instance.FormInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+@Config(application = org.commcare.dalvik.application.CommCareTestApplication.class,
+        constants = BuildConfig.class)
+@RunWith(CommCareTestRunner.class)
+public class FixtureLoadingTest {
+
+    @Before
+    public void setup() {
+        StoreFixturesOnFilesystemTests.installAppWithFixtureData(this.getClass(), "odk_level_ipm_restore_with_empty_fixture.xml");
+    }
+
+    /**
+     * Ensure parsing doesn't stop at empty fixtures, but continues on,
+     * committing subsequent fixtures
+     */
+    @Test
+    public void testEmptyFixtureFollowedByNormalFixture() {
+        HybridFileBackedSqlStorage<FormInstance> userFixtureStorage =
+                CommCareApplication._().getFileBackedUserStorage("fixture", FormInstance.class);
+        FormInstance form = userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
+                new String[]{"commtrack:locations"});
+        form.setName("fake");
+
+        form = userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
+                new String[]{"commtrack:programs"});
+        form.setName("fake");
+    }
+}

--- a/unit-tests/src/org/commcare/android/tests/processing/FixtureLoadingTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FixtureLoadingTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
+import java.util.NoSuchElementException;
+
 /**
  * @author Phillip Mates (pmates@dimagi.com).
  */
@@ -35,12 +37,16 @@ public class FixtureLoadingTest {
     public void testEmptyFixtureFollowedByNormalFixture() {
         HybridFileBackedSqlStorage<FormInstance> userFixtureStorage =
                 CommCareApplication._().getFileBackedUserStorage("fixture", FormInstance.class);
-        FormInstance form = userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
-                new String[]{"commtrack:locations"});
-        Assert.assertTrue(form != null);
+        boolean didntFindEmptyFixture = false;
+        try {
+            userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
+                    new String[]{"commtrack:locations"});
+        } catch (NoSuchElementException e) {
+            didntFindEmptyFixture = true;
+        }
+        Assert.assertTrue(didntFindEmptyFixture);
 
-        form = userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
+        userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
                 new String[]{"commtrack:programs"});
-        Assert.assertTrue(form != null);
     }
 }

--- a/unit-tests/src/org/commcare/android/tests/processing/FixtureLoadingTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FixtureLoadingTest.java
@@ -1,5 +1,7 @@
 package org.commcare.android.tests.processing;
 
+import junit.framework.Assert;
+
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.database.HybridFileBackedSqlStorage;
 import org.commcare.android.database.StoreFixturesOnFilesystemTests;
@@ -21,7 +23,8 @@ public class FixtureLoadingTest {
 
     @Before
     public void setup() {
-        StoreFixturesOnFilesystemTests.installAppWithFixtureData(this.getClass(), "odk_level_ipm_restore_with_empty_fixture.xml");
+        StoreFixturesOnFilesystemTests.installAppWithFixtureData(this.getClass(),
+                "odk_level_ipm_restore_with_empty_fixture.xml");
     }
 
     /**
@@ -34,10 +37,10 @@ public class FixtureLoadingTest {
                 CommCareApplication._().getFileBackedUserStorage("fixture", FormInstance.class);
         FormInstance form = userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
                 new String[]{"commtrack:locations"});
-        form.setName("fake");
+        Assert.assertTrue(form != null);
 
         form = userFixtureStorage.getRecordForValues(new String[]{FormInstance.META_ID},
                 new String[]{"commtrack:programs"});
-        form.setName("fake");
+        Assert.assertTrue(form != null);
     }
 }


### PR DESCRIPTION
ODK-level tests to make sure fixtures were actually loaded from a restore file.

Whenever empty fixtures were encountered they would swallow the rest of the restore file into them.

http://manage.dimagi.com/default.asp?158398

cross-request: https://github.com/dimagi/javarosa/pull/257
cross-request: https://github.com/dimagi/commcare/pull/264