### PR TITLE
Purge on Commit for Relevant Cases

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -88,4 +88,11 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-offer-pin-for-login"
         android:title="Give option to use PIN for login"/>
+
+    <ListPreference
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-auto-purge"
+        android:title="Detect and Trigger Purge on Form Save"/>
 </PreferenceScreen>

--- a/app/src/org/commcare/android/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/android/analytics/GoogleAnalyticsFields.java
@@ -86,6 +86,7 @@ public final class GoogleAnalyticsFields {
     public static String LABEL_IMAGE_ABOVE_TEXT = "Image Above Question Text Enabled";
     public static String LABEL_TRIGGERS_ON_SAVE = "Fire triggers on form save";
     public static String LABEL_REPORT_BUTTON_ENABLED = "Home Report Button enabled";
+    public static String LABEL_AUTO_PURGE = "Auto Purge on Save Enabled";
 
     // Labels for ACTION_OPTIONS_MENU_ITEM in CATEGORY_HOME_SCREEN
     public static String LABEL_SETTINGS = "Settings";
@@ -160,5 +161,4 @@ public final class GoogleAnalyticsFields {
     // Values for LABEL_ARROW and LABEL_SWIPE
     public static int VALUE_FORM_NOT_DONE = 0;
     public static int VALUE_FORM_DONE = 1;
-
 }

--- a/app/src/org/commcare/android/cases/CaseUtils.java
+++ b/app/src/org/commcare/android/cases/CaseUtils.java
@@ -1,0 +1,82 @@
+package org.commcare.android.cases;
+
+import org.commcare.android.database.SqlStorage;
+import org.commcare.android.database.user.models.ACase;
+import org.commcare.android.logging.AndroidLogger;
+import org.commcare.android.util.CommCareUtil;
+import org.commcare.cases.ledger.Ledger;
+import org.commcare.cases.ledger.LedgerPurgeFilter;
+import org.commcare.cases.util.CasePurgeFilter;
+import org.commcare.dalvik.application.CommCareApplication;
+import org.javarosa.core.model.User;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.AbstractTreeElement;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.storage.IStorageIterator;
+import org.javarosa.model.xform.XPathReference;
+
+import java.util.Vector;
+
+/**
+ * Utilities for performing complex operations on the case database.
+ *
+ * Created by ctsims on 2/25/2016.
+ */
+public class CaseUtils {
+    /**
+     * Perform a case purge against the logged in user with the logged in app in local storage.
+     *
+     * Will fail if the app is not ready for DB operations at the user level.
+     */
+    public static void purgeCases() {
+        long start = System.currentTimeMillis();
+        //We need to determine if we're using ownership for purging. For right now, only in sync mode
+        Vector<String> owners = new Vector<>();
+        Vector<String> users = new Vector<>();
+        for (IStorageIterator<User> userIterator = CommCareApplication._()
+                .getUserStorage(User.STORAGE_KEY, User.class).iterate(); userIterator.hasMore(); ) {
+            String id = userIterator.nextRecord().getUniqueId();
+            owners.addElement(id);
+            users.addElement(id);
+        }
+
+        //Now add all of the relevant groups
+        //TODO: Wow. This is.... kind of megasketch
+        for (String userId : users) {
+            DataInstance instance = CommCareUtil.loadFixture("user-groups", userId);
+            if (instance == null) {
+                continue;
+            }
+            EvaluationContext ec = new EvaluationContext(instance);
+            for (TreeReference ref : ec.expandReference(XPathReference.getPathExpr("/groups/group/@id").getReference())) {
+                AbstractTreeElement<AbstractTreeElement> idelement = ec.resolveReference(ref);
+                if (idelement.getValue() != null) {
+                    owners.addElement(idelement.getValue().uncast().getString());
+                }
+            }
+        }
+
+        SqlStorage<ACase> storage = CommCareApplication._().getUserStorage(ACase.STORAGE_KEY, ACase.class);
+        CasePurgeFilter filter = new CasePurgeFilter(storage, owners);
+        if (filter.invalidEdgesWereRemoved()) {
+            Logger.log(AndroidLogger.SOFT_ASSERT, "An invalid edge was created in the internal " +
+                    "case DAG of a case purge filter, meaning that at least 1 case on the " +
+                    "device had an index into another case that no longer exists on the device");
+            Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, "Case lists on the server and device" +
+                    " were out of sync. The following cases were expected to be on the device, " +
+                    "but were missing: " + filter.getMissingCasesString() + ". As a result, the " +
+                    "following cases were also removed from the device: " + filter.getRemovedCasesString());
+        }
+        int removedCases = storage.removeAll(filter).size();
+
+        SqlStorage<Ledger> stockStorage = CommCareApplication._().getUserStorage(Ledger.STORAGE_KEY, Ledger.class);
+        LedgerPurgeFilter stockFilter = new LedgerPurgeFilter(stockStorage, storage);
+        int removedLedgers = stockStorage.removeAll(stockFilter).size();
+
+        long taken = System.currentTimeMillis() - start;
+
+        Logger.log(AndroidLogger.TYPE_MAINTENANCE, String.format("Purged [%d Case, %d Ledger] records in %dms", removedCases, removedLedgers, taken));
+    }
+}

--- a/app/src/org/commcare/android/models/logic/FormRecordProcessor.java
+++ b/app/src/org/commcare/android/models/logic/FormRecordProcessor.java
@@ -4,12 +4,16 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Pair;
 
+import org.commcare.android.cases.CaseUtils;
 import org.commcare.android.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.tasks.ExceptionReporting;
 import org.commcare.android.util.FormUploadUtil;
 import org.commcare.core.process.XmlFormRecordProcessor;
+import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
+import org.commcare.dalvik.preferences.CommCarePreferences;
+import org.commcare.dalvik.preferences.DeveloperPreferences;
 import org.commcare.data.xml.TransactionParser;
 import org.commcare.xml.AndroidTransactionParserFactory;
 import org.commcare.xml.LedgerXmlParsers;
@@ -114,7 +118,9 @@ public class FormRecordProcessor {
     }
 
     private void performPurge() {
-
+        if(DeveloperPreferences.isAutoPurgeEnabled()) {
+            CaseUtils.purgeCases();
+        }
     }
 
     public void beginBulkSubmit() {

--- a/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/android/tasks/ProcessAndSendTask.java
@@ -158,6 +158,7 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
     private boolean checkFormRecordStatus(FormRecord[] records)
             throws FileNotFoundException, TaskCancelledException {
         boolean needToSendLogs = false;
+        processor.beginBulkSubmit();
         for (int i = 0; i < records.length; ++i) {
             if (isCancelled()) {
                 throw new TaskCancelledException();
@@ -198,6 +199,7 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                 }
             }
         }
+        processor.closeBulkSubmit();
         return needToSendLogs;
     }
 

--- a/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/dalvik/preferences/DeveloperPreferences.java
@@ -26,6 +26,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public final static String ACTION_BAR_ENABLED = "cc-action-nav-enabled";
     public final static String LIST_REFRESH_ENABLED = "cc-list-refresh";
     public final static String HOME_REPORT_ENABLED = "cc-home-report";
+    public final static String AUTO_PURGE_ENABLED = "cc-auto-purge";
     /**
      * Stores last used password and performs auto-login when that password is
      * present
@@ -82,6 +83,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefKeyToAnalyticsEvent.put(ALTERNATE_QUESTION_LAYOUT_ENABLED, GoogleAnalyticsFields.LABEL_IMAGE_ABOVE_TEXT);
         prefKeyToAnalyticsEvent.put(FIRE_TRIGGERS_ON_SAVE, GoogleAnalyticsFields.LABEL_TRIGGERS_ON_SAVE);
         prefKeyToAnalyticsEvent.put(HOME_REPORT_ENABLED, GoogleAnalyticsFields.LABEL_REPORT_BUTTON_ENABLED);
+        prefKeyToAnalyticsEvent.put(AUTO_PURGE_ENABLED, GoogleAnalyticsFields.LABEL_AUTO_PURGE);
     }
 
     @Override
@@ -225,6 +227,11 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
 
     public static boolean shouldOfferPinForLogin() {
         return doesPropertyMatch(OFFER_PIN_FOR_LOGIN, CommCarePreferences.NO,
+                CommCarePreferences.YES);
+    }
+
+    public static boolean isAutoPurgeEnabled() {
+        return doesPropertyMatch(AUTO_PURGE_ENABLED, CommCarePreferences.NO,
                 CommCarePreferences.YES);
     }
 

--- a/app/src/org/commcare/xml/AndroidTransactionParserFactory.java
+++ b/app/src/org/commcare/xml/AndroidTransactionParserFactory.java
@@ -38,6 +38,7 @@ public class AndroidTransactionParserFactory extends CommCareTransactionParserFa
     final private HttpRequestGenerator generator;
 
     private TransactionParserFactory formInstanceParser;
+    private boolean caseIndexesWereDisrupted = false;
 
     /**
      * A mapping from an installed form's namespace its install path.
@@ -87,7 +88,13 @@ public class AndroidTransactionParserFactory extends CommCareTransactionParserFa
             @Override
             public TransactionParser<Case> getParser(KXmlParser parser) {
                 if (created == null) {
-                    created = new AndroidCaseXmlParser(parser, tallies, true, sandbox.getCaseStorage(), generator);
+                    created = new AndroidCaseXmlParser(parser, tallies, true, sandbox.getCaseStorage(), generator) {
+
+                        @Override
+                        public void onIndexDisrupted(String caseId) {
+                            caseIndexesWereDisrupted = true;
+                        }
+                    };
                 }
 
                 return created;
@@ -119,5 +126,9 @@ public class AndroidTransactionParserFactory extends CommCareTransactionParserFa
                 return created;
             }
         };
+    }
+
+    public boolean wereCaseIndexesDisrupted() {
+        return caseIndexesWereDisrupted;
     }
 }


### PR DESCRIPTION
Adds (as a feature flag for now) the ability to trigger a purge whenever the case xml processor detects that the casedb now has stale cases.

CommCare Field/Dev Announce:

Adds a feature flag (cc-auto-purge: yes) for triggering casedb purges when a form is completed that might result in cases needing to leave the device, for instance because their owner ID was changed.

cross-request: https://github.com/dimagi/commcare/pull/265