### PR TITLE
Report CommCareTask exceptions to ACRA

### DIFF
--- a/app/src/org/commcare/android/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/android/tasks/templates/CommCareTask.java
@@ -3,6 +3,7 @@ package org.commcare.android.tasks.templates;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import org.acra.ACRA;
 import org.javarosa.core.services.Logger;
 
 /**
@@ -36,6 +37,9 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver> extends M
         } catch (Exception e) {
             Logger.log(TAG, e.getMessage());
             e.printStackTrace();
+
+            // Report to unified crash report dashboard
+            ACRA.getErrorReporter().handleException(e);
 
             // Save error for reporting during post-execute
             unknownError = e;


### PR DESCRIPTION
Seeing [some](https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/ba6ff7a32e1a4544ec305bd24954d5dc) [crashes](https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/ac631cd32058b56b78e308299c2f3eb8) that imply that instances of `CommCareTask` are failing. Realized that the only why for us to access those failures is via HQ logs, which are super hard to track down.

This PR ensures we report task failures, such as form save or load failures to our unified crash dashboard for easier triaging and response.