### PR TITLE
Don't show form save error when constraints aren't satisfied

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1292,14 +1292,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
         // save current answer; if headless, don't evaluate the constraints
         // before doing so.
-        if (headless &&
-                (!saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS, complete, headless))) {
-            return;
-        } else if (!headless &&
-                !saveAnswersForCurrentScreen(EVALUATE_CONSTRAINTS, complete, headless)) {
-            Toast.makeText(this,
-                    Localization.get("form.entry.save.error"),
-                    Toast.LENGTH_SHORT).show();
+        boolean wasScreenSaved =
+                saveAnswersForCurrentScreen(headless ? DO_NOT_EVALUATE_CONSTRAINTS : EVALUATE_CONSTRAINTS,
+                        complete, headless);
+        if (!wasScreenSaved) {
             return;
         }
 


### PR DESCRIPTION
Don't show form save warning message at end-of-form when the only issue was that a constraint wasn't satisfied.

![image](https://cloud.githubusercontent.com/assets/94817/13484364/1be97d94-e0cb-11e5-9558-5645a7825667.png)

http://manage.dimagi.com/default.asp?219803