### PR TITLE
Hotfix: revert mime library version bump

### DIFF
--- a/app/src/org/commcare/android/util/FormUploadUtil.java
+++ b/app/src/org/commcare/android/util/FormUploadUtil.java
@@ -12,19 +12,20 @@ import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.ContentBody;
 import org.apache.http.entity.mime.content.FileBody;
 import org.commcare.android.database.UserStorageClosedException;
-import org.javarosa.core.model.User;
 import org.commcare.android.io.DataSubmissionEntity;
 import org.commcare.android.javarosa.AndroidLogger;
 import org.commcare.android.mime.EncryptedFileBody;
 import org.commcare.android.net.HttpRequestGenerator;
 import org.commcare.android.tasks.DataSubmissionListener;
 import org.javarosa.core.io.StreamsUtil.InputIOException;
+import org.javarosa.core.model.User;
 import org.javarosa.core.services.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
@@ -297,7 +298,7 @@ public class FormUploadUtil {
                 }
                 entity.addPart("xml_submission_file", fb);
             } else if (f.getName().endsWith(".jpg")) {
-                fb = new FileBody(f, "image/jpeg");
+                fb = new FileBody(f, ContentType.create("image/jpeg", (Charset) null), f.getName());
                 if (fb.getContentLength() <= MAX_BYTES) {
                     entity.addPart(f.getName(), fb);
                     Log.i(TAG, "added image file " + f.getName());
@@ -305,7 +306,7 @@ public class FormUploadUtil {
                     Log.i(TAG, "file " + f.getName() + " is too big");
                 }
             } else if (f.getName().endsWith(".3gpp")) {
-                fb = new FileBody(f, "audio/3gpp");
+                fb = new FileBody(f, ContentType.create("audio/3gpp", (Charset) null), f.getName());
                 if (fb.getContentLength() <= MAX_BYTES) {
                     entity.addPart(f.getName(), fb);
                     Log.i(TAG, "added audio file " + f.getName());
@@ -313,7 +314,7 @@ public class FormUploadUtil {
                     Log.i(TAG, "file " + f.getName() + " is too big");
                 }
             } else if (f.getName().endsWith(".3gp")) {
-                fb = new FileBody(f, "video/3gpp");
+                fb = new FileBody(f, ContentType.create("video/3gpp", (Charset) null), f.getName());
                 if (fb.getContentLength() <= MAX_BYTES) {
                     entity.addPart(f.getName(), fb);
                     Log.i(TAG, "added video file " + f.getName());
@@ -321,7 +322,7 @@ public class FormUploadUtil {
                     Log.i(TAG, "file " + f.getName() + " is too big");
                 }
             } else if (isSupportedMultimediaFile(f.getName())) {
-                fb = new FileBody(f, "application/octet-stream");
+                fb = new FileBody(f, ContentType.DEFAULT_BINARY, f.getName());
                 if (fb.getContentLength() <= MAX_BYTES) {
                     entity.addPart(f.getName(), fb);
                     Log.i(TAG, "added unknown file " + f.getName());

--- a/app/src/org/commcare/android/util/FormUploadUtil.java
+++ b/app/src/org/commcare/android/util/FormUploadUtil.java
@@ -322,7 +322,7 @@ public class FormUploadUtil {
                     Log.i(TAG, "file " + f.getName() + " is too big");
                 }
             } else if (isSupportedMultimediaFile(f.getName())) {
-                fb = new FileBody(f, ContentType.DEFAULT_BINARY, f.getName());
+                fb = new FileBody(f, ContentType.APPLICATION_OCTET_STREAM, f.getName());
                 if (fb.getContentLength() <= MAX_BYTES) {
                     entity.addPart(f.getName(), fb);
                     Log.i(TAG, "added unknown file " + f.getName());


### PR DESCRIPTION
revert bump from mime 4.0 to 4.5.1 version bump from https://github.com/dimagi/commcare-odk/pull/934

That version bump caused form attachments to be sent to HQ in a format that HQ can't handle, causing data loss for form attachments.