### PR TITLE
CommCare 2.26.4 Hotfix Candidate - Resends forms which are likely to have lost data

### DIFF
--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -192,8 +192,8 @@ public class FormRecord extends Persisted implements EncryptedModel {
         return String.format("Form Record[%s][Status: %s]\n[Form: %s]\n[Last Modified: %s]", this.recordId, this.status, this.xmlns, this.lastModified.toString());
     }
 
-    public void setCompleteFormToUnsent() {
-        if(STATUS_COMPLETE.equals(this.getStatus())) {
+    public void setArchivedFormToUnsent() {
+        if(STATUS_SAVED.equals(this.getStatus())) {
             this.status = STATUS_UNSENT;
         }
     }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -191,4 +191,10 @@ public class FormRecord extends Persisted implements EncryptedModel {
     public String toString() {
         return String.format("Form Record[%s][Status: %s]\n[Form: %s]\n[Last Modified: %s]", this.recordId, this.status, this.xmlns, this.lastModified.toString());
     }
+
+    public void setCompleteFormToUnsent() {
+        if(STATUS_COMPLETE.equals(this.getStatus())) {
+            this.status = STATUS_UNSENT;
+        }
+    }
 }

--- a/app/src/org/commcare/android/tasks/PurgeStaleArchivedFormsTask.java
+++ b/app/src/org/commcare/android/tasks/PurgeStaleArchivedFormsTask.java
@@ -9,6 +9,8 @@ import org.commcare.dalvik.application.CommCareApp;
 import org.commcare.dalvik.application.CommCareApplication;
 import org.javarosa.core.services.Logger;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -182,8 +184,9 @@ public class PurgeStaleArchivedFormsTask
             return;
         }
 
-        DateTime timeWindowBegin = DateTime.parse("2016-02-22T06:00:00-05:00");
-        DateTime timeWindowEnd = DateTime.parse("2016-03-04T06:00:00-05:00");
+        DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+        DateTime timeWindowBegin = parser.parseDateTime("2016-02-22T06:00:00-05:00");
+        DateTime timeWindowEnd = parser.parseDateTime("2016-03-04T06:00:00-05:00");
 
         Vector<Integer> toResend = evaluateSavedFormsToResend(timeWindowBegin, timeWindowEnd);
 
@@ -259,7 +262,7 @@ public class PurgeStaleArchivedFormsTask
 
         for(int formRecordId : toResend) {
             FormRecord r = formStorage.read(formRecordId);
-            r.setCompleteFormToUnsent();
+            r.setArchivedFormToUnsent();
             formStorage.write(r);
         }
     }

--- a/app/src/org/commcare/android/tasks/PurgeStaleArchivedFormsTask.java
+++ b/app/src/org/commcare/android/tasks/PurgeStaleArchivedFormsTask.java
@@ -192,6 +192,10 @@ public class PurgeStaleArchivedFormsTask
 
         markFormsAsUnsent(toResend);
 
+        if(toResend.size() > 0) {
+            Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Succesfully recovered " + toResend.size() +
+                    " forms for resubmission");
+        }
         app.getAppPreferences().edit().putBoolean(KEY_HAS_PERFORMED_HOTFIX_CHECK, true).commit();
     }
 


### PR DESCRIPTION
Retroactively tags data for re-submission which was missed as a result of the 2.26.0-2 bug. 