### PR TITLE
Show PIN explanatory message in primed mode

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -409,7 +409,7 @@ pin.auth.failed.password=Entered password was incorrect. Please try again.
 pin.auth.prompt.pin=Enter your current PIN
 pin.auth.prompt.password=Enter your password
 pin.auth.enter.button=ENTER
-
+pin.primed.mode.message=You will use the PIN you create here to log into CommCare on all future log-ins.
 
 #Put these into their own file
 

--- a/app/res/layout/create_pin_view.xml
+++ b/app/res/layout/create_pin_view.xml
@@ -4,7 +4,18 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-    <include layout="@layout/pin_prompt_text"></include>
+    <include
+        android:id="@+id/pin_prompt_text"
+        layout="@layout/pin_prompt_text"></include>
+
+    <TextView
+        android:id="@+id/extra_msg"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/pin_prompt_text"
+        android:textSize="@dimen/font_size_medium"
+        android:gravity="center"
+        android:visibility="gone" />
 
     <include layout="@layout/pin_text_entry"></include>
 

--- a/app/res/layout/pin_auth_view.xml
+++ b/app/res/layout/pin_auth_view.xml
@@ -4,7 +4,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-    <include layout="@layout/pin_prompt_text"/>
+    <include
+        android:id="@+id/pin_prompt_text"
+        layout="@layout/pin_prompt_text"></include>
 
     <include layout="@layout/pin_text_entry"/>
 

--- a/app/res/layout/pin_prompt_text.xml
+++ b/app/res/layout/pin_prompt_text.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:id="@+id/pin_prompt_text"
-          android:layout_centerHorizontal="true"
-          android:layout_margin="@dimen/standard_spacer_large"
-          android:textSize="@dimen/font_size_xlarge"/>
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_centerHorizontal="true"
+    android:layout_marginLeft="@dimen/standard_spacer_large"
+    android:layout_marginRight="@dimen/standard_spacer_large"
+    android:layout_marginTop="@dimen/standard_spacer_large"
+    android:layout_marginBottom="@dimen/standard_spacer"
+    android:textSize="@dimen/font_size_xlarge"/>

--- a/app/src/org/commcare/activities/CreatePinActivity.java
+++ b/app/src/org/commcare/activities/CreatePinActivity.java
@@ -44,6 +44,9 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
     @UiElement(value = R.id.pin_confirm_button)
     private Button continueButton;
 
+    @UiElement(value = R.id.extra_msg, locale = "pin.primed.mode.message")
+    private TextView primedModeMessage;
+
     public static final String CHOSE_REMEMBER_PASSWORD = "chose-remember-password";
 
     private static final String WAS_IN_CONFIRM_MODE = "was-in-confirm-mode";
@@ -67,6 +70,10 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
         if (loginMode == LoginMode.PRIMED) {
             // Make user unable to cancel this activity if they were brought here by primed login
             cancelButton.setEnabled(false);
+
+            // Show an explanatory message, since the user will have been brought here automatically
+            // after logging in
+            primedModeMessage.setVisibility(View.VISIBLE);
 
             // Clear the primed password
             userRecord.clearPrimedPassword();


### PR DESCRIPTION
When the user was brought to the PIN creation screen by primed mode login (meaning they didn't do anything to get there on their own and are also now forced to create a pin), show a short message explaining what it is they're doing.