### PR TITLE
Finalize product-level analytics for 2.27

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -345,7 +345,11 @@ public class CommCareApplication extends Application {
     synchronized public Tracker getDefaultTracker() {
         if (analyticsTracker == null) {
             // TODO: AMS - Will want to set this conditionally after test release
-            analyticsTracker = analyticsInstance.newTracker(DEV_TRACKING_ID);
+            if (BuildConfig.DEBUG) {
+                analyticsTracker = analyticsInstance.newTracker(DEV_TRACKING_ID);
+            } else {
+                analyticsTracker = analyticsInstance.newTracker(LIVE_TRACKING_ID);
+            }
             analyticsTracker.enableAutoActivityTracking(true);
         }
         String userId = getCurrentUserId();

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -131,7 +131,6 @@ public class CommCareHomeActivity
     private static final int MENU_SAVED_FORMS = Menu.FIRST + 7;
     private static final int MENU_ABOUT = Menu.FIRST + 8;
     private static final int MENU_PIN = Menu.FIRST + 9;
-    private static final int MENU_DISABLE_ANALYTICS = Menu.FIRST + 10;
 
     /**
      * Restart is a special CommCare return code which means that the session was invalidated in the
@@ -1156,7 +1155,6 @@ public class CommCareHomeActivity
         menu.add(0, MENU_ABOUT, 0, Localization.get("home.menu.about")).setIcon(
                 android.R.drawable.ic_menu_help);
         menu.add(0, MENU_PIN, 0, Localization.get("home.menu.pin.set"));
-        menu.add(0, MENU_DISABLE_ANALYTICS, 0, Localization.get("home.menu.disable.analytics"));
         return true;
     }
 
@@ -1177,7 +1175,6 @@ public class CommCareHomeActivity
             menu.findItem(MENU_CONNECTION_DIAGNOSTIC).setVisible(enableMenus);
             menu.findItem(MENU_SAVED_FORMS).setVisible(enableMenus);
             menu.findItem(MENU_ABOUT).setVisible(enableMenus);
-            menu.findItem(MENU_DISABLE_ANALYTICS).setVisible(CommCarePreferences.isAnalyticsEnabled());
             if (CommCareApplication._().getRecordForCurrentUser().hasPinSet()) {
                 menu.findItem(MENU_PIN).setTitle(Localization.get("home.menu.pin.change"));
             } else {
@@ -1228,9 +1225,6 @@ public class CommCareHomeActivity
             case MENU_PIN:
                 launchPinAuthentication();
                 return true;
-            case MENU_DISABLE_ANALYTICS:
-                showAnalyticsOptOutDialog();
-                return true;
         }
         return super.onOptionsItemSelected(item);
     }
@@ -1247,33 +1241,6 @@ public class CommCareHomeActivity
         menuIdToAnalyticsEvent.put(MENU_SAVED_FORMS, GoogleAnalyticsFields.LABEL_SAVED_FORMS);
         menuIdToAnalyticsEvent.put(MENU_ABOUT, GoogleAnalyticsFields.LABEL_ABOUT_CC);
         return menuIdToAnalyticsEvent;
-    }
-
-    private void showAnalyticsOptOutDialog() {
-        AlertDialogFactory f = new AlertDialogFactory(this,
-                Localization.get("analytics.opt.out.title"),
-                Localization.get("analytics.opt.out.message"));
-
-        f.setPositiveButton(Localization.get("analytics.disable.button"),
-                new DialogInterface.OnClickListener() {
-
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                        CommCarePreferences.disableAnalytics();
-                    }
-                });
-
-        f.setNegativeButton(Localization.get("option.cancel"),
-                new DialogInterface.OnClickListener() {
-
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
-                });
-
-        f.showDialog();
     }
 
     public static void createPreferencesMenu(Activity activity) {

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
@@ -257,9 +257,4 @@ public class GoogleAnalyticsUtils {
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD;
     }
 
-    // Currently unused, should remove later if it doesn't get used
-    private static void dispatchQueuedEvents() {
-        CommCareApplication._().getAnalyticsInstance().dispatchLocalHits();
-    }
-
 }

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -1,6 +1,7 @@
 package org.commcare.preferences;
 
 import android.content.ActivityNotFoundException;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
@@ -27,6 +28,7 @@ import org.commcare.utils.CommCareUtil;
 import org.commcare.utils.FileUtils;
 import org.commcare.utils.TemplatePrinterUtils;
 import org.commcare.utils.UriToFilePath;
+import org.commcare.views.dialogs.AlertDialogFactory;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 
@@ -88,8 +90,10 @@ public class CommCarePreferences
     private static final int CLEAR_USER_DATA = Menu.FIRST;
     private static final int FORCE_LOG_SUBMIT = Menu.FIRST + 1;
     private static final int RECOVERY_MODE = Menu.FIRST + 2;
-    private static final int SUPERUSER_PREFS = Menu.FIRST + 3;
-    private static final int MENU_CLEAR_SAVED_SESSION = Menu.FIRST + 4;
+    private static final int MENU_DISABLE_ANALYTICS = Menu.FIRST + 3;
+    private static final int SUPERUSER_PREFS = Menu.FIRST + 4;
+    private static final int MENU_CLEAR_SAVED_SESSION = Menu.FIRST + 5;
+
 
     public static final int RESULT_DATA_RESET = RESULT_FIRST_USER + 1;
 
@@ -200,6 +204,7 @@ public class CommCarePreferences
                 android.R.drawable.ic_menu_upload);
         menu.add(0, RECOVERY_MODE, 3, "Recovery Mode").setIcon(android.R.drawable.ic_menu_report_image);
         menu.add(0, SUPERUSER_PREFS, 4, "Developer Options").setIcon(android.R.drawable.ic_menu_edit);
+        menu.add(0, MENU_DISABLE_ANALYTICS, 5, Localization.get("home.menu.disable.analytics"));
 
         return true;
     }
@@ -209,6 +214,7 @@ public class CommCarePreferences
         GoogleAnalyticsUtils.reportOptionsMenuEntry(GoogleAnalyticsFields.CATEGORY_CC_PREFS);
         menu.findItem(SUPERUSER_PREFS).setVisible(DeveloperPreferences.isSuperuserEnabled());
         menu.findItem(MENU_CLEAR_SAVED_SESSION).setVisible(DevSessionRestorer.savedSessionPresent());
+        menu.findItem(MENU_DISABLE_ANALYTICS).setVisible(CommCarePreferences.isAnalyticsEnabled());
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -238,9 +244,40 @@ public class CommCarePreferences
             case MENU_CLEAR_SAVED_SESSION:
                 DevSessionRestorer.clearSession();
                 return true;
+            case MENU_DISABLE_ANALYTICS:
+                showAnalyticsOptOutDialog();
+                return true;
         }
         return super.onOptionsItemSelected(item);
     }
+
+    private void showAnalyticsOptOutDialog() {
+        AlertDialogFactory f = new AlertDialogFactory(this,
+                Localization.get("analytics.opt.out.title"),
+                Localization.get("analytics.opt.out.message"));
+
+        f.setPositiveButton(Localization.get("analytics.disable.button"),
+                new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                        CommCarePreferences.disableAnalytics();
+                    }
+                });
+
+        f.setNegativeButton(Localization.get("option.cancel"),
+                new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                });
+
+        f.showDialog();
+    }
+
 
     private static Map<Integer, String> createMenuItemToEventMapping() {
         Map<Integer, String> menuIdToAnalyticsEvent = new HashMap<>();


### PR DESCRIPTION
Kevin said all of the data that's been coming into the test dashboard from 2.26 looks sound, so we're going ahead with moving to the live dashboard (but continuing to use the test dashboard for debug builds). Also makes the opt out button more hidden (per request from @jjackson).