### PR TITLE
Signature widget changes

### DIFF
--- a/app/res/layout/draw_layout.xml
+++ b/app/res/layout/draw_layout.xml
@@ -12,7 +12,7 @@
         android:layout_alignParentBottom="true">
     </LinearLayout>
 
-    <LinearLayout
+    <RelativeLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true">
@@ -23,17 +23,25 @@
             android:layout_height="wrap_content"
             android:text="@string/save_and_close"/>
 
-        <Button
-            android:id="@+id/btnResetDraw"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/reset_image"/>
+            android:layout_alignParentRight="true">
 
-        <Button
-            android:id="@+id/btnCancelDraw"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/cancel"/>
-    </LinearLayout>
+            <Button
+                android:id="@+id/btnResetDraw"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/reset_image"/>
+
+            <Button
+                android:id="@+id/btnCancelDraw"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/cancel"/>
+
+        </LinearLayout>
+
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -472,7 +472,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 boolean saved = ImageCaptureProcessing.processCaptureResponse(this, getInstanceFolder(), false);
                 if (saved) {
                     ImageButton nextButton = (ImageButton)this.findViewById(R.id.nav_btn_next);
-                    if (nextButton.getTag().equals(NAV_STATE_NEXT)) {
+                    if (nextButton.getTag().equals(NAV_STATE_NEXT) && !questionsView.isQuestionList()) {
                         next();
                     }
                 }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -471,10 +471,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             case SIGNATURE_CAPTURE:
                 boolean saved = ImageCaptureProcessing.processCaptureResponse(this, getInstanceFolder(), false);
                 if (saved) {
-                    ImageButton nextButton = (ImageButton)this.findViewById(R.id.nav_btn_next);
-                    if (nextButton.getTag().equals(NAV_STATE_NEXT) && !questionsView.isQuestionList()) {
-                        next();
-                    }
+                    // attempt to auto-advance if a signature was captured
+                    advance();
                 }
                 break;
             case IMAGE_CHOOSER:
@@ -2037,11 +2035,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     @Override
     protected boolean onForwardSwipe() {
-        //We've already computed the "is there more coming" stuff intensely in the the nav details
-        //and set the forward button tag appropriately, so use that to determine whether we can
-        //swipe forward.
-        ImageButton nextButton = (ImageButton)this.findViewById(R.id.nav_btn_next);
-        if(nextButton.getTag().equals(NAV_STATE_NEXT)) {
+        if (canNavigateForward()) {
             GoogleAnalyticsUtils.reportFormNavForward(
                     GoogleAnalyticsFields.LABEL_SWIPE,
                     GoogleAnalyticsFields.VALUE_FORM_NOT_DONE);
@@ -2068,7 +2062,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     @Override
     public void advance() {
-        next();
+        if (!questionsView.isQuestionList() && canNavigateForward()) {
+            next();
+        }
     }
 
     @Override
@@ -2081,6 +2077,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
 
         FormNavigationUI.updateNavigationCues(this, mFormController, questionsView);
+    }
+
+    private boolean canNavigateForward() {
+        ImageButton nextButton = (ImageButton)this.findViewById(R.id.nav_btn_next);
+        return nextButton.getTag().equals(NAV_STATE_NEXT);
     }
 
     /**

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -469,7 +469,13 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 ImageCaptureProcessing.processCaptureResponse(this, getInstanceFolder(), true);
                 break;
             case SIGNATURE_CAPTURE:
-                ImageCaptureProcessing.processCaptureResponse(this, getInstanceFolder(), false);
+                boolean saved = ImageCaptureProcessing.processCaptureResponse(this, getInstanceFolder(), false);
+                if (saved) {
+                    ImageButton nextButton = (ImageButton)this.findViewById(R.id.nav_btn_next);
+                    if (nextButton.getTag().equals(NAV_STATE_NEXT)) {
+                        next();
+                    }
+                }
                 break;
             case IMAGE_CHOOSER:
                 ImageCaptureProcessing.processImageChooserResponse(this, getInstanceFolder(), intent);

--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -78,8 +78,9 @@ public class ImageCaptureProcessing {
      * SignatureWidget
      *
      * @param isImage true if this was from an ImageWidget, false if it was a SignatureWidget
+     * @return if saving the captured image was successful
      */
-    public static void processCaptureResponse(FormEntryActivity activity,
+    public static boolean processCaptureResponse(FormEntryActivity activity,
                                               String instanceFolder,
                                               boolean isImage) {
         /* We saved the image to the tempfile_path, but we really want it to be in:
@@ -94,9 +95,11 @@ public class ImageCaptureProcessing {
         try {
             File unscaledFinalImage = moveAndScaleImage(originalImage, isImage, instanceFolder, activity);
             activity.saveImageWidgetAnswer(buildImageFileContentValues(unscaledFinalImage));
+            return true;
         } catch (IOException e) {
             e.printStackTrace();
             activity.showCustomToast(Localization.get("image.capture.not.saved"), Toast.LENGTH_LONG);
+            return false;
         }
     }
 

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -365,6 +365,10 @@ public class QuestionsView extends ScrollView
         return widgets;
     }
 
+    public boolean isQuestionList() {
+        return widgets.size() > 1;
+    }
+
     @Override
     public void setOnFocusChangeListener(OnFocusChangeListener l) {
         for (QuestionWidget qw : widgets) {

--- a/app/src/org/commcare/views/widgets/SignatureWidget.java
+++ b/app/src/org/commcare/views/widgets/SignatureWidget.java
@@ -152,7 +152,6 @@ public class SignatureWidget extends QuestionWidget {
             i.putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(f));
         }
 
-        // Path to output the signature file to
         i.putExtra(DrawActivity.EXTRA_OUTPUT,
                 Uri.fromFile(new File(ODKStorage.TMPFILE_PATH)));
 

--- a/app/src/org/commcare/views/widgets/SignatureWidget.java
+++ b/app/src/org/commcare/views/widgets/SignatureWidget.java
@@ -145,19 +145,18 @@ public class SignatureWidget extends QuestionWidget {
         mErrorTextView.setVisibility(View.GONE);
         Intent i = new Intent(getContext(), DrawActivity.class);
         i.putExtra(DrawActivity.OPTION, DrawActivity.OPTION_SIGNATURE);
-        // copy...
-        //mBinaryName would be a preexisting signature that is getting displayed when the activity starts
+
+        // If a signature has already been captured for this question, will want to display it
         if (mBinaryName != null) {
             File f = new File(mInstanceFolder + File.separator + mBinaryName);
             i.putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(f));
         }
-        //path to output the signature file to
+
+        // Path to output the signature file to
         i.putExtra(DrawActivity.EXTRA_OUTPUT,
                 Uri.fromFile(new File(ODKStorage.TMPFILE_PATH)));
 
         try {
-            //tells the form controller that when onActivityResult is called (when the DrawActivity)
-            //finishes, the requestCode is SIGNATURE_CAPTURE
             ((Activity)getContext()).startActivityForResult(i, FormEntryActivity.SIGNATURE_CAPTURE);
             pendingCalloutInterface.setPendingCalloutFormIndex(questionIndex);
         } catch (ActivityNotFoundException e) {


### PR DESCRIPTION
-Move the 'Reset' and 'Cancel' buttons to the right side of the screen, so that the 'Save and Close' button stands alone

-Automatically navigate forward after signature capture ONLY if: a) a signature was actually captured (e.g. they pressed 'Save and Close' as opposed to cancel), b) the signature question is not on the  last screen, and c) the signature widget isn't in a question list
*(Having now done this and realized all of the conditions I needed to add in order to have this make sense, I'm open to being told that it's not a good idea to have the widget behave differently under different conditions. But wanted to share it and see what others think)*

-Remove some of the more embarrassing comments left in the `SignatureWidget` code from when I worked on it as an intern...