### PR TITLE
Restore last entered username

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -972,7 +972,14 @@ public class CommCareApplication extends Application {
 
                         //Register that this user was the last to successfully log in if it's a real user
                         if (!User.TYPE_DEMO.equals(user.getUserType())) {
-                            getCurrentApp().getAppPreferences().edit().putString(CommCarePreferences.LAST_LOGGED_IN_USER, record.getUsername()).commit();
+                            getCurrentApp().getAppPreferences().edit().putString(
+                                    CommCarePreferences.LAST_LOGGED_IN_USER, record.getUsername())
+                                    .commit();
+
+                            // Clear this value upon a successful login, so that it does not take
+                            // precedence over the last logged in username
+                            getCurrentApp().getAppPreferences().edit().putString(
+                                    LoginActivity.KEY_LAST_ENTERED_USERNAME, null).commit();
 
                             // clear any files orphaned by file-backed db transaction failures
                             HybridFileBackedSqlHelpers.removeOrphanedFiles(mBoundService.getUserDbHandle());

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -63,7 +63,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     public static final String NOTIFICATION_MESSAGE_LOGIN = "login_message";
     public final static String KEY_LAST_APP = "id_of_last_selected";
-    public final static String KEY_ENTERED_USER = "entered-username";
+    public final static String KEY_LAST_ENTERED_USERNAME = "entered-username";
     public final static String KEY_ENTERED_PW_OR_PIN = "entered-password-or-pin";
 
     private static final int SEAT_APP_ACTIVITY = 0;
@@ -95,7 +95,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         } else {
             // If the screen was rotated with entered text present, we will want to restore it
             // in onResume (can't do it here b/c will get overriden by logic in refreshForNewApp())
-            usernameBeforeRotation = savedInstanceState.getString(KEY_ENTERED_USER);
+            usernameBeforeRotation = savedInstanceState.getString(KEY_LAST_ENTERED_USERNAME);
             passwordOrPinBeforeRotation = savedInstanceState.getString(KEY_ENTERED_PW_OR_PIN);
         }
 
@@ -135,7 +135,14 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         String enteredUsername = uiController.getEnteredUsername();
         if (!"".equals(enteredUsername) && enteredUsername != null) {
-            savedInstanceState.putString(KEY_ENTERED_USER, enteredUsername);
+            savedInstanceState.putString(KEY_LAST_ENTERED_USERNAME, enteredUsername);
+
+            // Only save this to prefs if it's different than the last logged in username
+            SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
+            String lastLoggedInUsername = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
+            if (!enteredUsername.equals(lastLoggedInUsername)) {
+                prefs.edit().putString(KEY_LAST_ENTERED_USERNAME, enteredUsername).commit();
+            }
         }
         String enteredPasswordOrPin = uiController.getEnteredPasswordOrPin();
         if (!"".equals(enteredPasswordOrPin) && enteredPasswordOrPin != null) {

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -277,7 +277,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
         String lastLoggedInUsername = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
         String enteredUsername = uiController.getEnteredUsername();
-        if (!enteredUsername.equals(lastLoggedInUsername)) {
+        if (!enteredUsername.equals(lastLoggedInUsername) && !enteredUsername.equals("")) {
             // Only save this to prefs if it's different than the last logged in username
             prefs.edit().putString(KEY_LAST_ENTERED_USERNAME, enteredUsername).commit();
         }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -277,7 +277,10 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
         String lastLoggedInUsername = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
         String enteredUsername = uiController.getEnteredUsername();
-        if (!enteredUsername.equals(lastLoggedInUsername) && !enteredUsername.equals("")) {
+        if (enteredUsername.equals("")) {
+            // Clear this if there is no username entered
+            prefs.edit().putString(KEY_LAST_ENTERED_USERNAME, null).commit();
+        } else if (!enteredUsername.equals(lastLoggedInUsername)) {
             // Only save this to prefs if it's different than the last logged in username
             prefs.edit().putString(KEY_LAST_ENTERED_USERNAME, enteredUsername).commit();
         }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -91,7 +91,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         if (savedInstanceState == null) {
             // Only restore last user on the initial creation
-            uiController.restoreLastUser();
+            uiController.restoreLastUsername();
         } else {
             // If the screen was rotated with entered text present, we will want to restore it
             // in onResume (can't do it here b/c will get overriden by logic in refreshForNewApp())

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -136,13 +136,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         String enteredUsername = uiController.getEnteredUsername();
         if (!"".equals(enteredUsername) && enteredUsername != null) {
             savedInstanceState.putString(KEY_LAST_ENTERED_USERNAME, enteredUsername);
-
-            // Only save this to prefs if it's different than the last logged in username
-            SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
-            String lastLoggedInUsername = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
-            if (!enteredUsername.equals(lastLoggedInUsername)) {
-                prefs.edit().putString(KEY_LAST_ENTERED_USERNAME, enteredUsername).commit();
-            }
         }
         String enteredPasswordOrPin = uiController.getEnteredPasswordOrPin();
         if (!"".equals(enteredPasswordOrPin) && enteredPasswordOrPin != null) {
@@ -276,6 +269,18 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         // Otherwise, refresh the activity for current conditions
         uiController.refreshView();
+    }
+
+    protected void onPause() {
+        super.onPause();
+
+        SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
+        String lastLoggedInUsername = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
+        String enteredUsername = uiController.getEnteredUsername();
+        if (!enteredUsername.equals(lastLoggedInUsername)) {
+            // Only save this to prefs if it's different than the last logged in username
+            prefs.edit().putString(KEY_LAST_ENTERED_USERNAME, enteredUsername).commit();
+        }
     }
 
     @Override

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -211,14 +211,9 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         // Remove any error content from trying to log into a different app
         setStyleDefault();
 
-        final SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
-        String lastUser = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
-        if (lastUser != null) {
-            // If there was a last user for this app, show it
-            username.setText(lastUser);
-            passwordOrPin.requestFocus();
-        } else {
-            // Otherwise, clear the username text so it does not show a username from a different app
+        if (!restoreLastUser()) {
+            // If we didn't have a username to restore for this app, clear the username text so it
+            // does not show a username from a different app
             username.setText("");
             username.requestFocus();
         }
@@ -441,13 +436,31 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         loginButton.setTextColor(getResources().getColor(R.color.cc_neutral_bg));
     }
 
-    protected void restoreLastUser() {
+    /**
+     *
+     * @return if a username was restored
+     */
+    protected boolean restoreLastUser() {
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
-        String lastUser = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
-        if (lastUser != null) {
-            username.setText(lastUser);
-            passwordOrPin.requestFocus();
+
+        // First try to restore the last username that was entered, but NOT successfully logged in
+        // with (this value gets cleared upon a successful login so that that can take precedence)
+        String lastEnteredUsername = prefs.getString(LoginActivity.KEY_LAST_ENTERED_USERNAME, null);
+        if (lastEnteredUsername != null) {
+            username.setText(lastEnteredUsername);
+            username.requestFocus();
+            username.setSelection(username.getText().length());
+            return true;
         }
+
+        String lastLoggedInUser = prefs.getString(CommCarePreferences.LAST_LOGGED_IN_USER, null);
+        if (lastLoggedInUser != null) {
+            username.setText(lastLoggedInUser);
+            passwordOrPin.requestFocus();
+            return true;
+        }
+
+        return false;
     }
 
     protected boolean isRestoreSessionChecked() {

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -211,7 +211,7 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         // Remove any error content from trying to log into a different app
         setStyleDefault();
 
-        if (!restoreLastUser()) {
+        if (!restoreLastUsername()) {
             // If we didn't have a username to restore for this app, clear the username text so it
             // does not show a username from a different app
             username.setText("");
@@ -440,7 +440,7 @@ public class LoginActivityUIController implements CommCareActivityUIController {
      *
      * @return if a username was restored
      */
-    protected boolean restoreLastUser() {
+    protected boolean restoreLastUsername() {
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
 
         // First try to restore the last username that was entered, but NOT successfully logged in


### PR DESCRIPTION
Problem being addressed: Currently whenever the `LoginActivity` resumes, we load the username entry box with the username of the last logged in user, if there is one. This can produce confusing behavior in a couple of scenarios: 
1) If you attempt to log in with a new username, and that login fails, and then the screen shuts off, when you turn it back on, the username box is populated with the last logged in username instead of the username you just tried.
2) Same as above, but without the login failure part - if you just go away in the middle of entering a username for any reason, and then come back, the box will have been re-populated with something other than what you left there.

The solution I have here: 
-In `LoginActivity.onPause()`, either store the currently entered username to prefs if it differs from the last logged in username, or clear it if it is empty.
-In `restoreLastUsername()`, check for the last entered username BEFORE checking for the last logged in username. By also clearing the last entered username upon the start of a session, this ensures that the last logged in username will take precedence ONLY UNTIL a different username has been tried.