### PR TITLE
Check for empty password on login

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -419,6 +419,9 @@ login.attempt.fail.auth.detail=Your username or password was not recognized, ple
 login.attempt.fail.pin.title=Invalid PIN
 login.attempt.fail.pin.detail=You entered an incorrect PIN for the given username.
 
+login.attempt.fail.empty.pw.title=Empty Password
+login.attempt.fail.empty.pw.detail=You did not enter a password.
+
 login.attempt.fail.changed.title=Password Changed since Last Login
 login.attempt.fail.changed.detail=You've logged in with a new password since you're last login. You may need to log in with your old credentials to ensure you have no unsent data.
 login.attempt.fail.changed.action=If you had unsent data or incomplete forms on the phone before you logged in with your new password you should log out, and log in with your old password. Make sure all your unsent forms are sent and incomplete forms are submitted, then log in again with your new password and sync. 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -148,6 +148,11 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
      *                       upon successful login
      */
     protected void initiateLoginAttempt(boolean restoreSession) {
+        if (uiController.getEnteredPasswordOrPin().equals("")) {
+            raiseLoginMessage(StockMessages.Auth_EmptyPassword, false);
+            return;
+        }
+
         uiController.clearErrorMessage();
         ViewUtil.hideVirtualKeyboard(LoginActivity.this);
 

--- a/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
@@ -44,6 +44,11 @@ public class NotificationMessageFactory {
         Auth_InvalidPin("login.attempt.fail.pin"),
 
         /**
+         * No password was entered
+         */
+        Auth_EmptyPassword("login.attempt.fail.empty.pw"),
+
+        /**
          * Server 500 when retrieving data.
          */
         Restore_RemoteError("notification.restore.remote.error"),


### PR DESCRIPTION
If a login is attempted with an empty password, immediately fail and show a specified error message, instead of going through a whole login attempt.