### PR TITLE
Fix overriding of the last-entered username

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -283,6 +283,13 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         tryAutoLogin();
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        if (requestCode == SEAT_APP_ACTIVITY) {
+            uiController.refreshForNewApp();
+        }
+    }
+
     private void tryAutoLogin() {
         Pair<String, String> userAndPass =
                 DevSessionRestorer.getAutoLoginCreds();

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -285,7 +285,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
-        if (requestCode == SEAT_APP_ACTIVITY) {
+        if (requestCode == SEAT_APP_ACTIVITY && resultCode == RESULT_OK) {
             uiController.refreshForNewApp();
         }
     }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -288,6 +288,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         if (requestCode == SEAT_APP_ACTIVITY && resultCode == RESULT_OK) {
             uiController.refreshForNewApp();
         }
+        super.onActivityResult(requestCode, resultCode, intent);
     }
 
     private void tryAutoLogin() {

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -182,8 +182,6 @@ public class LoginActivityUIController implements CommCareActivityUIController {
 
     @Override
     public void refreshView() {
-        refreshForNewApp(); // In case the seated app has changed
-
         updateBanner();
 
         activity.restoreEnteredTextFromRotation();
@@ -207,7 +205,7 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         //refreshUsernamesAdapter();
     }
 
-    private void refreshForNewApp() {
+    protected void refreshForNewApp() {
         // Remove any error content from trying to log into a different app
         setStyleDefault();
 


### PR DESCRIPTION
Finally realized that this was a regression caused by multiple apps. For no clear reason, I was calling `refreshForNewApp()` (which calls `restoreLastUsername()`) in `onResume()`, instead of just upon successful completion of a call to `SeatAppActivity`, which was causing the last-entered username to be overridden by the last logged in username whenever `onResume()` was called. Sorry for not catching this sooner!