### PR TITLE
Fix crash logging NPE while gathering ccz app version

### DIFF
--- a/app/src/org/commcare/android/logging/ReportingUtils.java
+++ b/app/src/org/commcare/android/logging/ReportingUtils.java
@@ -18,7 +18,9 @@ public class ReportingUtils {
         CommCareApp app = CommCareApplication._().getCurrentApp();
         if (app != null) {
             Profile profile = app.getCommCarePlatform().getCurrentProfile();
-            return profile.getVersion();
+            if (profile != null) {
+                return profile.getVersion();
+            }
         }
         return -1;
     }


### PR DESCRIPTION
Encountered
```
03-18 11:12:50.109 31299-1089/org.commcare.dalvik E/AndroidRuntime: FATAL EXCEPTION: Thread-1104
                                                                    Process: org.commcare.dalvik, PID: 31299
                                                                    java.lang.NullPointerException: Attempt to invoke virtual method 'int org.commcare.suite.model.Profile.getVersion()' on a null object reference
                                                                        at org.commcare.android.logging.ReportingUtils.getAppBuildNumber(ReportingUtils.java:21)
                                                                        at org.commcare.android.logging.ForceCloseLogEntry.<init>(ForceCloseLogEntry.java:42)
                                                                        at org.commcare.android.logging.ForceCloseLogger.sendToServerOrStore(ForceCloseLogger.java:60)
                                                                        at org.commcare.android.logging.ForceCloseLogger.access$000(ForceCloseLogger.java:34)
                                                                        at org.commcare.android.logging.ForceCloseLogger$1.run(ForceCloseLogger.java:46)
                                                                        at java.lang.Thread.run(Thread.java:818)
```
When an error was found during an app install.
This fixes that