### PR TITLE
Fix NPE on multiple apps Multimedia Validation

### DIFF
--- a/app/src/org/commcare/activities/AppManagerActivity.java
+++ b/app/src/org/commcare/activities/AppManagerActivity.java
@@ -122,7 +122,7 @@ public class AppManagerActivity extends Activity implements OnItemClickListener 
                     Toast.makeText(this, R.string.no_installation,
                             Toast.LENGTH_LONG).show();
                 }
-                break;
+                return;
             case DispatchActivity.MISSING_MEDIA_ACTIVITY:
                 if (resultCode == RESULT_CANCELED) {
                     String title = getString(R.string.media_not_verified);
@@ -138,8 +138,9 @@ public class AppManagerActivity extends Activity implements OnItemClickListener 
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }
-                break;
+                return;
         }
+        super.onActivityResult(requestCode, resultCode, intent);
     }
 
     /**

--- a/app/src/org/commcare/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/activities/CommCareVerificationActivity.java
@@ -225,6 +225,7 @@ public class CommCareVerificationActivity
             // we found some media, so try validating it
             newMediaToValidate = true;
         }
+        super.onActivityResult(requestCode, resultCode, intent);
     }
 
     private void handleVerificationSuccess() {
@@ -290,8 +291,8 @@ public class CommCareVerificationActivity
                 break;
             case R.id.screen_multimedia_retry:
                 verifyResourceInstall();
+                break;
         }
-
     }
 
     private String prettyString(String rawString) {

--- a/app/src/org/commcare/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/activities/CommCareVerificationActivity.java
@@ -224,7 +224,9 @@ public class CommCareVerificationActivity
         if (requestCode == GET_MULTIMEDIA && resultCode == Activity.RESULT_OK) {
             // we found some media, so try validating it
             newMediaToValidate = true;
+            return;
         }
+
         super.onActivityResult(requestCode, resultCode, intent);
     }
 

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -320,12 +320,12 @@ public class DispatchActivity extends FragmentActivity {
                 waitingForActivityResultFromLogin = false;
                 if (resultCode == RESULT_CANCELED) {
                     shouldFinish = true;
-                    return;
+                } else if (intent != null) {
+                    lastLoginMode = (LoginMode)intent.getSerializableExtra(LoginActivity.LOGIN_MODE);
+                    userManuallyEnteredPasswordMode =
+                            intent.getBooleanExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, false);
+                    startFromLogin = true;
                 }
-                lastLoginMode = (LoginMode)intent.getSerializableExtra(LoginActivity.LOGIN_MODE);
-                userManuallyEnteredPasswordMode =
-                        intent.getBooleanExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, false);
-                startFromLogin = true;
                 break;
             case HOME_SCREEN:
                 if (resultCode == RESULT_CANCELED) {

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -303,19 +303,17 @@ public class DispatchActivity extends FragmentActivity {
                 if (resultCode == RESULT_CANCELED) {
                     // User pressed back button from install screen, so take them out of CommCare
                     shouldFinish = true;
-                    return;
                 }
-                break;
+                return;
             case MISSING_MEDIA_ACTIVITY:
                 if (resultCode == RESULT_CANCELED) {
                     // exit the app if media wasn't validated on automatic
                     // validation check.
                     shouldFinish = true;
-                    return;
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, "Media Validated!", Toast.LENGTH_LONG).show();
-                    return;
                 }
+                return;
             case LOGIN_USER:
                 waitingForActivityResultFromLogin = false;
                 if (resultCode == RESULT_CANCELED) {
@@ -326,7 +324,7 @@ public class DispatchActivity extends FragmentActivity {
                             intent.getBooleanExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, false);
                     startFromLogin = true;
                 }
-                break;
+                return;
             case HOME_SCREEN:
                 if (resultCode == RESULT_CANCELED) {
                     shouldFinish = true;
@@ -334,7 +332,7 @@ public class DispatchActivity extends FragmentActivity {
                 } else {
                     userTriggeredLogout = true;
                 }
-                break;
+                return;
         }
         super.onActivityResult(requestCode, resultCode, intent);
     }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -288,6 +288,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         if (requestCode == SEAT_APP_ACTIVITY && resultCode == RESULT_OK) {
             uiController.refreshForNewApp();
         }
+
         super.onActivityResult(requestCode, resultCode, intent);
     }
 

--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -124,7 +124,7 @@ public class SingleAppManagerActivity extends Activity {
                         task.cancel(true);
                     }
                 }
-                break;
+                return;
             case DispatchActivity.MISSING_MEDIA_ACTIVITY:
                 refresh();
                 if (resultCode == RESULT_CANCELED) {
@@ -134,7 +134,9 @@ public class SingleAppManagerActivity extends Activity {
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }
+                return;
         }
+        super.onActivityResult(requestCode, resultCode, intent);
     }
 
     /**


### PR DESCRIPTION
If you:
- install an app w/o multimedia via multiple apps
- try to validate its multimedia
- select 'skip' when it fails
- switch to the normal CommCare app

Then you get a crash due to the intent passed to `DispatchActivity.onActivityResult` being `null`.

Also make sure to call `super.onActivityResult` in a few methods when no the result code isn't processed in the current `onActivityResult` implementation. This isn't necessary, but is the 'right thing' to do.