### PR TITLE
Fix form entry callout return

### DIFF
--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -164,9 +164,7 @@ public class CommCareHomeActivity
     protected void onCreateSessionSafe(Bundle savedInstanceState) throws SessionUnavailableException {
         super.onCreateSessionSafe(savedInstanceState);
 
-        if (savedInstanceState != null) {
-            loginExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
-        }
+        loadInstanceState(savedInstanceState);
 
         ACRAUtil.registerAppData();
         uiController.setupUI();
@@ -178,17 +176,20 @@ public class CommCareHomeActivity
         processFromLoginLaunch();
     }
 
+    private void loadInstanceState(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            loginExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
+            wasExternal = savedInstanceState.getBoolean(WAS_EXTERNAL_KEY);
+        }
+    }
+
     /**
      * Set state that signifies activity was launch from external app.
      */
     private void processFromExternalLaunch(Bundle savedInstanceState) {
-        if (savedInstanceState != null) {
-            wasExternal = savedInstanceState.getBoolean(WAS_EXTERNAL_KEY);
-        } else {
-            if (getIntent().hasExtra(DispatchActivity.WAS_EXTERNAL)) {
-                wasExternal = true;
-                sessionNavigator.startNextSessionStep();
-            }
+        if (savedInstanceState == null && getIntent().hasExtra(DispatchActivity.WAS_EXTERNAL)) {
+            wasExternal = true;
+            sessionNavigator.startNextSessionStep();
         }
     }
 

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -619,6 +619,7 @@ public class CommCareHomeActivity
             // regardless of the exit code
             currentState.reset();
             if (wasExternal) {
+                setResult(RESULT_CANCELED);
                 this.finish();
             } else {
                 // Return to where we started
@@ -669,6 +670,7 @@ public class CommCareHomeActivity
                 uiController.refreshView();
 
                 if (wasExternal) {
+                    setResult(RESULT_CANCELED);
                     this.finish();
                     return false;
                 }
@@ -707,6 +709,7 @@ public class CommCareHomeActivity
 
             if (wasExternal) {
                 currentState.reset();
+                setResult(RESULT_CANCELED);
                 this.finish();
                 return false;
             } else if (current.getStatus().equals(FormRecord.STATUS_INCOMPLETE)) {
@@ -728,6 +731,7 @@ public class CommCareHomeActivity
     private void clearSessionAndExit(AndroidSessionWrapper currentState, boolean shouldWarnUser) {
         currentState.reset();
         if (wasExternal) {
+            setResult(RESULT_CANCELED);
             this.finish();
         }
         uiController.refreshView();

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -265,7 +265,7 @@ public class DispatchActivity extends FragmentActivity {
         CommCareApplication._().getCurrentSessionWrapper().loadFromStateDescription(ssd);
         Intent i = new Intent(this, CommCareHomeActivity.class);
         i.putExtra(WAS_EXTERNAL, true);
-        startActivity(i);
+        startActivityForResult(i, HOME_SCREEN);
     }
 
     private void handleShortcutLaunch() {


### PR DESCRIPTION
Callouts from external apps that launch form entry weren't being returned to correctly upon form completion/exit. The dispatch activity was erroneously relaunching the form entry action instead of finishing.
 
First commit is the fix
Second commit is some aux cleanup

Fix for http://manage.dimagi.com/default.asp?221691