### PR TITLE
Fix last username spill-over to newly installed app

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -62,7 +62,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     private static final int MENU_PASSWORD_MODE = Menu.FIRST + 3;
 
     public static final String NOTIFICATION_MESSAGE_LOGIN = "login_message";
-    public final static String KEY_LAST_APP = "id_of_last_selected";
+    public final static String KEY_LAST_APP = "id-last-seated-app";
     public final static String KEY_ENTERED_USER = "entered-username";
     public final static String KEY_ENTERED_PW_OR_PIN = "entered-password-or-pin";
 
@@ -274,6 +274,17 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         // Otherwise, refresh the activity for current conditions
         uiController.refreshView();
+    }
+
+    protected boolean checkForSeatedAppChange() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        String lastSeatedId = prefs.getString(KEY_LAST_APP, "");
+        String currentSeatedId = CommCareApplication._().getCurrentApp().getUniqueId();
+        if (!lastSeatedId.equals(currentSeatedId)) {
+            prefs.edit().putString(KEY_LAST_APP, currentSeatedId).commit();
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -490,8 +501,8 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         // Retrieve the app record corresponding to the app selected
         String appId = appIdDropdownList.get(position);
 
-        boolean appChanged = !appId.equals(CommCareApplication._().getCurrentApp().getUniqueId());
-        if (appChanged) {
+        boolean selectedNewApp = !appId.equals(CommCareApplication._().getCurrentApp().getUniqueId());
+        if (selectedNewApp) {
             // Set the id of the last selected app
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
             prefs.edit().putString(KEY_LAST_APP, appId).commit();

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -210,6 +210,10 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         } else {
             restoreSessionCheckbox.setVisibility(View.GONE);
         }
+
+        if (activity.checkForSeatedAppChange()) {
+            refreshForNewApp();
+        }
     }
 
     protected void refreshForNewApp() {


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?221630#1113023, which was introduced in https://github.com/dimagi/commcare-odk/pull/1138. 

Turns out there was one reason for calling `refreshForNewApp()` in `onResume()` that I had forgotten about: if you install an app from the app manager and then return to the login screen, the seated app has changed. This PR introduces a check for that case.