### PR TITLE
Fix check for finish() conditions in LoginActivity

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -87,6 +87,12 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        if (shouldFinish()) {
+            // If we're going to finish in onResume() because there is no usable seated app,
+            // don't bother with all of the setup here
+            return;
+        }
+
         uiController.setupUI();
 
         if (savedInstanceState == null) {
@@ -262,11 +268,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         // It is possible that we left off at the LoginActivity last time we were on the main CC
         // screen, but have since done something in the app manager to either leave no seated app
-        // at all, or to render the seated app unusable. Redirect to CCHomeActivity if we encounter
-        // either case
-        CommCareApp currentApp = CommCareApplication._().getCurrentApp();
-        if (currentApp == null || !currentApp.getAppRecord().isUsable()) {
-            // send back to dispatch activity
+        // at all, or to render the seated app unusable. Redirect to dispatch activity if we
+        // encounter either case
+        if (shouldFinish()) {
             setResult(RESULT_OK);
             this.finish();
             return;
@@ -285,6 +289,11 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             return true;
         }
         return false;
+    }
+
+    private static boolean shouldFinish() {
+        CommCareApp currentApp = CommCareApplication._().getCurrentApp();
+        return currentApp == null || !currentApp.getAppRecord().isUsable();
     }
 
     @Override

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -266,13 +266,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     protected void onResume() {
         super.onResume();
 
-        // It is possible that we left off at the LoginActivity last time we were on the main CC
-        // screen, but have since done something in the app manager to either leave no seated app
-        // at all, or to render the seated app unusable. Redirect to dispatch activity if we
-        // encounter either case
         if (shouldFinish()) {
-            setResult(RESULT_OK);
-            this.finish();
             return;
         }
 
@@ -299,6 +293,16 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     @Override
     protected void onResumeFragments() {
         super.onResumeFragments();
+
+        // It is possible that we left off at the LoginActivity last time we were on the main CC
+        // screen, but have since done something in the app manager to either leave no seated app
+        // at all, or to render the seated app unusable. Redirect to dispatch activity if we
+        // encounter either case
+        if (shouldFinish()) {
+            setResult(RESULT_OK);
+            this.finish();
+            return;
+        }
 
         tryAutoLogin();
     }


### PR DESCRIPTION
Fix crash that occurs when the following steps are performed (this used to work; I'm guessing the regression has been around since `onResumeFragments()` got added to LoginActivity):
1) User is on the login screen with 1 app installed
2) User navigates to the app manager and uninstalls that 1 app
3) User navigates back to the normal CommCare screen, at which point CommCare crashes for 1 of 2 reasons (when I fixed the first the 2nd manifested itself):
--a) `onCreate()` tries to do something with the seated app (which is actually null) before reaching the code in `onResume()` that finishes the activity
--b) Since `onResumeFragments()` comes after `onResume()` in the activity lifecycle, it seemed like it was actually still getting called after `onResume()` called finish(), resulting in a weird interstitial state with a blank screen. 
