### PR TITLE
Add OK button to 'About CommCare' dialog

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="url_prompt">Choose a URL</string>
 
     <string name="aboutdialog">%s\n\n
-_Copyright 2015, Dimagi inc, All rights reserved_ \n\n
+_Copyright 2016, Dimagi inc, All rights reserved_ \n\n
 
 ---------------- \n\n
 __Acknowledgements:__ \n\n

--- a/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
+++ b/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
@@ -13,6 +13,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
 import org.commcare.interfaces.RuntimePermissionRequester;
 import org.commcare.utils.MarkupUtil;
+import org.javarosa.core.services.locale.Localization;
 
 /**
  * @author Phillip Mates (pmates@dimagi.com)
@@ -38,6 +39,12 @@ public class DialogCreationHelpers {
 
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
         builder.setView(view);
+        builder.setPositiveButton(Localization.get("dialog.ok"), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                });
         return builder.create();
     }
 


### PR DESCRIPTION
Used a phone with a broken 'back' button the other day and got stuck on the 'About CommCare' button because it didn't have an exit button.
 
![screen](https://cloud.githubusercontent.com/assets/94817/13978499/ebdcf012-f0a7-11e5-9fc0-e0e7adc82c3c.png)