### PR TITLE
Revert to allowing auto-advance selects to trigger form submission

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -481,7 +481,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 boolean saved = ImageCaptureProcessing.processCaptureResponse(this, getInstanceFolder(), false);
                 if (saved) {
                     // attempt to auto-advance if a signature was captured
-                    advance();
+                    advance(false);
                 }
                 break;
             case IMAGE_CHOOSER:
@@ -2070,8 +2070,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     @Override
-    public void advance() {
-        if (!questionsView.isQuestionList() && canNavigateForward()) {
+    public void advance(boolean allowAutoSubmission) {
+        if (!questionsView.isQuestionList() && (allowAutoSubmission || canNavigateForward())) {
             next();
         }
     }

--- a/app/src/org/commcare/interfaces/AdvanceToNextListener.java
+++ b/app/src/org/commcare/interfaces/AdvanceToNextListener.java
@@ -2,5 +2,5 @@ package org.commcare.interfaces;
 
 public interface AdvanceToNextListener {
 
-    void advance(); //Move on to the next question
+    void advance(boolean allowAutoSubmission); //Move on to the next question
 }

--- a/app/src/org/commcare/views/widgets/GridWidget.java
+++ b/app/src/org/commcare/views/widgets/GridWidget.java
@@ -142,7 +142,7 @@ public class GridWidget extends QuestionWidget {
                 imageViews[position].setBackgroundColor(Color.rgb(orangeRedVal, orangeGreenVal,
                         orangeBlueVal));
                 if (quickAdvance) {
-                    listener.advance();
+                    listener.advance(true);
                 }
             }
         });

--- a/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
@@ -186,7 +186,7 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
         }
         widgetEntryChanged();
 
-        listener.advance();
+        listener.advance(true);
     }
 
 


### PR DESCRIPTION
In this PR https://github.com/dimagi/commcare-odk/pull/1126, I changed the behavior of auto-advance widgets to NOT perform an auto-advance if it is the last question in the form, so that auto-advancing would no longer trigger an automatic form submission. My thinking being that nothing should trigger a form submission other than a user explicitly pressing the submit button. However, @phillipm brought up the issue that some existing users (namely Ray it sounds like) are currently relying on this functionality in their apps, and would be upset to discover it has changed. 

On principle, I think my reasoning is technically correct, but given the reality that app builders are very unlikely to use the auto-advance setting on a question unless they know what they're doing and are going to explicitly train their users accordingly, it also seems fine to leave the old functionality. Just wanted to check if anyone else has strong opinions on what the right thing to do here is, before I revert the change (cc: @ctsims @wpride @amsagoff).