### PR TITLE
Feature flag for disabling swiping out of case detail tabs

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -96,4 +96,11 @@
         android:defaultValue="yes"
         android:key="cc-form-payload-status"
         android:title="Load form payload status"/>
+    <ListPreference
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:defaultValue="yes"
+        android:key="cc-detail-final-swipe-enabled"
+        android:title="Enable swipe in/out of case detail tabs"/>
 </PreferenceScreen>

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -14,6 +14,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
 import org.commcare.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.models.AndroidSessionWrapper;
+import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.session.CommCareSession;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.CalloutData;
@@ -44,6 +45,9 @@ public class EntityDetailActivity
     private Pair<Detail, TreeReference> mEntityContext;
     private TreeReference mTreeReference;
     private int detailIndex;
+
+    // controls whether swiping can toggle exit from case detail screen
+    private boolean isFinalSwipeActionEnabled = false;
 
     @UiElement(value = R.id.entity_detail)
     private RelativeLayout container;
@@ -126,6 +130,7 @@ public class EntityDetailActivity
         mDetailView.refresh(detail, mTreeReference, detailIndex);
 
         mDetailView.showMenu();
+        isFinalSwipeActionEnabled = DeveloperPreferences.isDetailTabSwipeActionEnabled();
     }
 
     public Pair<Detail, TreeReference> requestEntityContext() {
@@ -192,7 +197,8 @@ public class EntityDetailActivity
     @Override
     protected boolean onForwardSwipe() {
         // Move along, provided we're on the last tab of tabbed case details
-        if (mDetailView.getCurrentTab() >= mDetailView.getTabCount() - 1) {
+        if (isFinalSwipeActionEnabled &&
+                mDetailView.getCurrentTab() >= mDetailView.getTabCount() - 1) {
             select();
             return true;
         }
@@ -202,7 +208,8 @@ public class EntityDetailActivity
     @Override
     protected boolean onBackwardSwipe() {
         // Move back, provided we're on the first screen of tabbed case details
-        if (mDetailView.getCurrentTab() < 1) {
+        if (isFinalSwipeActionEnabled &&
+                mDetailView.getCurrentTab() < 1) {
             finish();
             return true;
         }

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -12,6 +12,7 @@ import android.widget.RelativeLayout;
 
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
+import org.commcare.logging.analytics.GoogleAnalyticsUtils;
 import org.commcare.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.preferences.DeveloperPreferences;
@@ -117,6 +118,7 @@ public class EntityDetailActivity
 
         next.setOnClickListener(new OnClickListener() {
             public void onClick(View v) {
+                GoogleAnalyticsUtils.reportEntityDetailContinue(false);
                 select();
             }
         });
@@ -200,6 +202,7 @@ public class EntityDetailActivity
         if (isFinalSwipeActionEnabled &&
                 mDetailView.getCurrentTab() >= mDetailView.getTabCount() - 1) {
             select();
+            GoogleAnalyticsUtils.reportEntityDetailContinue(true);
             return true;
         }
         return false;
@@ -211,6 +214,7 @@ public class EntityDetailActivity
         if (isFinalSwipeActionEnabled &&
                 mDetailView.getCurrentTab() < 1) {
             finish();
+            GoogleAnalyticsUtils.reportEntityDetailExit(true);
             return true;
         }
         return false;
@@ -224,5 +228,11 @@ public class EntityDetailActivity
         loadOutgoingIntent(i);
         setResult(RESULT_OK, i);
         finish();
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        GoogleAnalyticsUtils.reportEntityDetailExit(false);
     }
 }

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -118,7 +118,7 @@ public class EntityDetailActivity
 
         next.setOnClickListener(new OnClickListener() {
             public void onClick(View v) {
-                GoogleAnalyticsUtils.reportEntityDetailContinue(false, mDetailView.getTabCount() > 1);
+                GoogleAnalyticsUtils.reportEntityDetailContinue(false, mDetailView.getTabCount() == 1);
                 select();
             }
         });
@@ -202,7 +202,7 @@ public class EntityDetailActivity
         if (isFinalSwipeActionEnabled &&
                 mDetailView.getCurrentTab() >= mDetailView.getTabCount() - 1) {
             select();
-            GoogleAnalyticsUtils.reportEntityDetailContinue(true, mDetailView.getTabCount() > 1);
+            GoogleAnalyticsUtils.reportEntityDetailContinue(true, mDetailView.getTabCount() == 1);
             return true;
         }
         return false;
@@ -214,7 +214,7 @@ public class EntityDetailActivity
         if (isFinalSwipeActionEnabled &&
                 mDetailView.getCurrentTab() < 1) {
             finish();
-            GoogleAnalyticsUtils.reportEntityDetailExit(true, mDetailView.getTabCount() > 1);
+            GoogleAnalyticsUtils.reportEntityDetailExit(true, mDetailView.getTabCount() == 1);
             return true;
         }
         return false;
@@ -233,6 +233,6 @@ public class EntityDetailActivity
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        GoogleAnalyticsUtils.reportEntityDetailExit(false, mDetailView.getTabCount() > 1);
+        GoogleAnalyticsUtils.reportEntityDetailExit(false, mDetailView.getTabCount() == 1);
     }
 }

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -118,7 +118,7 @@ public class EntityDetailActivity
 
         next.setOnClickListener(new OnClickListener() {
             public void onClick(View v) {
-                GoogleAnalyticsUtils.reportEntityDetailContinue(false);
+                GoogleAnalyticsUtils.reportEntityDetailContinue(false, mDetailView.getTabCount() > 1);
                 select();
             }
         });
@@ -202,7 +202,7 @@ public class EntityDetailActivity
         if (isFinalSwipeActionEnabled &&
                 mDetailView.getCurrentTab() >= mDetailView.getTabCount() - 1) {
             select();
-            GoogleAnalyticsUtils.reportEntityDetailContinue(true);
+            GoogleAnalyticsUtils.reportEntityDetailContinue(true, mDetailView.getTabCount() > 1);
             return true;
         }
         return false;
@@ -214,7 +214,7 @@ public class EntityDetailActivity
         if (isFinalSwipeActionEnabled &&
                 mDetailView.getCurrentTab() < 1) {
             finish();
-            GoogleAnalyticsUtils.reportEntityDetailExit(true);
+            GoogleAnalyticsUtils.reportEntityDetailExit(true, mDetailView.getTabCount() > 1);
             return true;
         }
         return false;
@@ -233,6 +233,6 @@ public class EntityDetailActivity
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        GoogleAnalyticsUtils.reportEntityDetailExit(false);
+        GoogleAnalyticsUtils.reportEntityDetailExit(false, mDetailView.getTabCount() > 1);
     }
 }

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -169,4 +169,8 @@ public final class GoogleAnalyticsFields {
     // Values for LABEL_ARROW and LABEL_SWIPE
     public static final int VALUE_FORM_NOT_DONE = 0;
     public static final int VALUE_FORM_DONE = 1;
+
+    // Values for ACTION_CONTINUE_FROM_DETAIL/ACTION_EXIT_FROM_DETAIL : LABEL_ARROW/LABEL_SWIPE
+    public static final int VALUE_DOESNT_HAVE_TABS = 0;
+    public static final int VALUE_HAS_TABS = 1;
 }

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -17,6 +17,7 @@ public final class GoogleAnalyticsFields {
     public static final String CATEGORY_ARCHIVED_FORMS = "Archived Forms";
     public static final String CATEGORY_TIMED_EVENTS = "Timed Events";
     public static final String CATEGORY_PRE_LOGIN_STATS = "Pre-Login Stats";
+    public static final String CATEGORY_MODULE_NAVIGATION = "Module Navigation";
 
     // Actions for CATEGORY_HOME_SCREEN only
     public static final String ACTION_BUTTON = "Button Press";
@@ -48,6 +49,10 @@ public final class GoogleAnalyticsFields {
 
     // Actions for CATEGORY_PRE_LOGIN_STATS
     public static final String ACTION_APP_INSTALL = "New App Install";
+
+    // Actions for CATEGORY_MODULE_NAVIGATION
+    public static final String ACTION_CONTINUE_FROM_DETAIL = "Continue Forward from Detail View";
+    public static final String ACTION_EXIT_FROM_DETAIL = "Exit Detail View";
 
     // Labels for ACTION_BUTTON
     public static final String LABEL_START_BUTTON = "Start Button";
@@ -115,6 +120,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_DEVELOPER_OPTIONS = "Developer Options";
 
     // Labels for ACTION_FORWARD and ACTION_BACKWARD (in CATEGORY_FORM_ENTRY)
+    // and also ACTION_CONTINUE_FROM_DETAIL and ACTION_EXIT_FROM_DETAIL (in CATEGORY_MODULE_NAVIGATION)
     public static final String LABEL_ARROW = "Press Arrow";
     public static final String LABEL_SWIPE = "Swipe";
 
@@ -133,7 +139,7 @@ public final class GoogleAnalyticsFields {
     public static String LABEL_SYNC_SUCCESS;
     public static String LABEL_SYNC_FAILURE;
 
-    // Labels for ACTION_VIEW_SAVED_FORMS and ACTION_OPEN_SAVED_FORM
+    // Labels for ACTION_VIEW_FORMS_LIST and ACTION_OPEN_ARCHIVED_FORM
     public static final String LABEL_INCOMPLETE = "Incomplete";
     public static final String LABEL_COMPLETE = "Complete (Saved)";
 

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -88,6 +88,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_REPORT_BUTTON_ENABLED = "Home Report Button enabled";
     public static final String LABEL_AUTO_PURGE = "Auto Purge on Save Enabled";
     public static final String LABEL_LOAD_FORM_PAYLOAD_AS = "Load form payload as";
+    public static final String LABEL_DETAIL_TAB_SWIPE_ACTION = "Detail tab final swipe action enabled";
 
     // Labels for ACTION_OPTIONS_MENU_ITEM in CATEGORY_HOME_SCREEN
     public static final String LABEL_SETTINGS = "Settings";

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
@@ -215,11 +215,9 @@ public class GoogleAnalyticsUtils {
      *
      * @param isSwipe - Toggles user's method of navigation to swipe or arrow press
      */
-    public static void reportEntityDetailExit(boolean isSwipe) {
-        reportEvent(
-                GoogleAnalyticsFields.CATEGORY_MODULE_NAVIGATION,
-                GoogleAnalyticsFields.ACTION_EXIT_FROM_DETAIL,
-                isSwipe ? GoogleAnalyticsFields.LABEL_SWIPE : GoogleAnalyticsFields.LABEL_ARROW);
+    public static void reportEntityDetailExit(boolean isSwipe, boolean isSingleTab) {
+        reportEntityDetailNavigation(
+                GoogleAnalyticsFields.ACTION_EXIT_FROM_DETAIL, isSwipe, isSingleTab);
     }
 
     /**
@@ -227,11 +225,17 @@ public class GoogleAnalyticsUtils {
      *
      * @param isSwipe - Toggles user's method of navigation to swipe or arrow press
      */
-    public static void reportEntityDetailContinue(boolean isSwipe) {
+    public static void reportEntityDetailContinue(boolean isSwipe, boolean isSingleTab) {
+        reportEntityDetailNavigation(
+                GoogleAnalyticsFields.ACTION_CONTINUE_FROM_DETAIL, isSwipe, isSingleTab);
+    }
+
+    private static void reportEntityDetailNavigation(String action, boolean isSwipe, boolean isSingleTab) {
         reportEvent(
                 GoogleAnalyticsFields.CATEGORY_MODULE_NAVIGATION,
-                GoogleAnalyticsFields.ACTION_CONTINUE_FROM_DETAIL,
-                isSwipe ? GoogleAnalyticsFields.LABEL_SWIPE : GoogleAnalyticsFields.LABEL_ARROW);
+                action,
+                isSwipe ? GoogleAnalyticsFields.LABEL_SWIPE : GoogleAnalyticsFields.LABEL_ARROW,
+                isSingleTab ? GoogleAnalyticsFields.VALUE_DOESNT_HAVE_TABS : GoogleAnalyticsFields.VALUE_HAS_TABS);
     }
 
     /**

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
@@ -209,6 +209,31 @@ public class GoogleAnalyticsUtils {
                 CommCareApplication._().getCurrentVersionString());
     }
 
+
+    /**
+     * Report a user event of navigating backward out of the entity detail screen
+     *
+     * @param isSwipe - Toggles user's method of navigation to swipe or arrow press
+     */
+    public static void reportEntityDetailExit(boolean isSwipe) {
+        reportEvent(
+                GoogleAnalyticsFields.CATEGORY_MODULE_NAVIGATION,
+                GoogleAnalyticsFields.ACTION_EXIT_FROM_DETAIL,
+                isSwipe ? GoogleAnalyticsFields.LABEL_SWIPE : GoogleAnalyticsFields.LABEL_ARROW);
+    }
+
+    /**
+     * Report a user event of continuing forward out of the entity detail screen
+     *
+     * @param isSwipe - Toggles user's method of navigation to swipe or arrow press
+     */
+    public static void reportEntityDetailContinue(boolean isSwipe) {
+        reportEvent(
+                GoogleAnalyticsFields.CATEGORY_MODULE_NAVIGATION,
+                GoogleAnalyticsFields.ACTION_CONTINUE_FROM_DETAIL,
+                isSwipe ? GoogleAnalyticsFields.LABEL_SWIPE : GoogleAnalyticsFields.LABEL_ARROW);
+    }
+
     /**
      * Report the length of a certain user event/action/concept
      *

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -27,6 +27,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public final static String HOME_REPORT_ENABLED = "cc-home-report";
     public final static String AUTO_PURGE_ENABLED = "cc-auto-purge";
     public final static String LOAD_FORM_PAYLOAD_AS = "cc-form-payload-status";
+    public final static String DETAIL_TAB_SWIPE_ACTION_ENABLED = "cc-detail-final-swipe-enabled";
     /**
      * Stores last used password and performs auto-login when that password is
      * present
@@ -84,6 +85,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefKeyToAnalyticsEvent.put(HOME_REPORT_ENABLED, GoogleAnalyticsFields.LABEL_REPORT_BUTTON_ENABLED);
         prefKeyToAnalyticsEvent.put(AUTO_PURGE_ENABLED, GoogleAnalyticsFields.LABEL_AUTO_PURGE);
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
+        prefKeyToAnalyticsEvent.put(DETAIL_TAB_SWIPE_ACTION_ENABLED, GoogleAnalyticsFields.LABEL_DETAIL_TAB_SWIPE_ACTION);
     }
 
     @Override
@@ -241,5 +243,13 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static String formLoadPayloadStatus() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
         return properties.getString(LOAD_FORM_PAYLOAD_AS, FormRecord.STATUS_SAVED);
+    }
+
+    /**
+     * Feature flag to control whether swiping in case detail tabs can trigger
+     * exit from the case detail screen
+     */
+    public static boolean isDetailTabSwipeActionEnabled() {
+        return doesPropertyMatch(DETAIL_TAB_SWIPE_ACTION_ENABLED, CommCarePreferences.YES, CommCarePreferences.YES);
     }
 }


### PR DESCRIPTION
Feature flag for preventing swipe actions in the case detail tab view from exiting the case detail view.

Can be enabled at the app level or in the devices developer options

Setting it to target 2.27 because it is a small, contained change that I think some FMs would appreciate. 

End goal is to do some sort of UX testing to determine whether this should be the default. 

![screen](https://cloud.githubusercontent.com/assets/94817/14007743/d506a4a2-f14f-11e5-9226-bffc7f7e262b.png)

Follow-up: add documentation to https://confluence.dimagi.com/display/ccinternal/CommCare+Android+Developer+Options
