### PR TITLE
Localize safely during app install

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -705,7 +705,13 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     @Override
     public void updateResourceProgress(int done, int total, int phase) {
-        updateProgress(Localization.get("profile.found", new String[]{"" + done, "" + total}), DIALOG_INSTALL_PROGRESS);
+        // perform safe localization because the localization dictionary might
+        // be the resource currently being installed.
+        String installProgressText =
+                Localization.getWithDefault("profile.found",
+                        new String[]{"" + done, "" + total},
+                        "Application found. Loading resources...");
+        updateProgress(installProgressText, DIALOG_INSTALL_PROGRESS);
         updateProgressBar(done, total, DIALOG_INSTALL_PROGRESS);
     }
 


### PR DESCRIPTION
Every once in a while CommCare crashes during an app install with the following stack trace.
Pretty sure the issue is that we are trying to localize some text while the localization dictionary is being installed, which causes the crash because localization setting/getting isn't synchronized. Saw similar issues during app updating.

Sorta embarrassing that I'm only now taking the time to fix this...

```
org.javarosa.core.util.NoLocalizedTextException: The Localizer could not find a definition for ID: profile.found in the 'default' locale.
  at org.javarosa.core.services.locale.Localizer.getText(Localizer.java:457)
  at org.javarosa.core.services.locale.Localization.get(Localization.java:22)
  at org.commcare.activities.CommCareSetupActivity.updateResourceProgress(CommCareSetupActivity.java:708)
  at org.commcare.activities.CommCareSetupActivity$1.deliverUpdate(CommCareSetupActivity.java:459)
  at org.commcare.activities.CommCareSetupActivity$1.deliverUpdate(CommCareSetupActivity.java:421)
  at org.commcare.tasks.templates.CommCareTask.onProgressUpdate(CommCareTask.java:116)
```