### PR TITLE
Fix for HQ not being able to distinguish demo data

### DIFF
--- a/app/src/org/commcare/android/logging/ForceCloseLogger.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogger.java
@@ -108,11 +108,7 @@ public class ForceCloseLogger {
         HttpRequestGenerator generator;
         try {
             User user = CommCareApplication._().getSession().getLoggedInUser();
-            if (user.getUserType().equals(User.TYPE_DEMO)) {
-                generator = new HttpRequestGenerator();
-            } else {
-                generator = new HttpRequestGenerator(user);
-            }
+            generator = new HttpRequestGenerator(user);
         } catch (Exception e) {
             generator = new HttpRequestGenerator();
         }

--- a/app/src/org/commcare/network/HttpRequestGenerator.java
+++ b/app/src/org/commcare/network/HttpRequestGenerator.java
@@ -68,15 +68,25 @@ public class HttpRequestGenerator {
      */
     public static final String AUTH_REQUEST_TYPE_NO_AUTH = "noauth";
 
+    private static final String SUBMIT_MODE = "submit_mode";
+
+    private static final String SUBMIT_MODE_DEMO = "demo";
+
     private Credentials credentials;
     PasswordAuthentication passwordAuthentication;
     private String username;
+    private String userType;
 
     public HttpRequestGenerator(User user) {
-        this(user.getUsername(), user.getCachedPwd());
+        this(user.getUsername(), user.getCachedPwd(), user.getUserType());
     }
 
+
     public HttpRequestGenerator(String username, String password) {
+        this(username, password, null);
+    }
+
+    public HttpRequestGenerator(String username, String password, String userType) {
         String domainedUsername = username;
 
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
@@ -86,11 +96,13 @@ public class HttpRequestGenerator {
             domainedUsername += "@" + prefs.getString(USER_DOMAIN_SUFFIX, null);
         }
 
+        if (!User.TYPE_DEMO.equals(userType)) {
+            this.credentials = new UsernamePasswordCredentials(domainedUsername, password);
+            passwordAuthentication = new PasswordAuthentication(domainedUsername, password.toCharArray());
+            this.username = username;
+        }
 
-        this.credentials = new UsernamePasswordCredentials(domainedUsername, password);
-
-        passwordAuthentication = new PasswordAuthentication(domainedUsername, password.toCharArray());
-        this.username = username;
+        this.userType = userType;
     }
 
     public HttpRequestGenerator() {
@@ -204,6 +216,10 @@ public class HttpRequestGenerator {
         //not ready 
         if (credentials == null) {
             url = Uri.parse(url).buildUpon().appendQueryParameter(AUTH_REQUEST_TYPE, AUTH_REQUEST_TYPE_NO_AUTH).build().toString();
+        }
+
+        if (User.TYPE_DEMO.equals(userType)) {
+            url = Uri.parse(url).buildUpon().appendQueryParameter(SUBMIT_MODE, SUBMIT_MODE_DEMO).build().toString();
         }
 
         HttpPost httppost = new HttpPost(url);

--- a/app/src/org/commcare/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/tasks/LogSubmissionTask.java
@@ -250,11 +250,7 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
             return false;
         }
 
-        if (User.TYPE_DEMO.equals(user.getUserType())) {
-            generator = new HttpRequestGenerator();
-        } else {
-            generator = new HttpRequestGenerator(user);
-        }
+        generator = new HttpRequestGenerator(user);
 
         MultipartEntity entity = new DataSubmissionEntity(listener, index);
 

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -155,12 +155,7 @@ public class FormUploadUtil {
             return RECORD_FAILURE;
         }
 
-        HttpRequestGenerator generator;
-        if (user.getUserType().equals(User.TYPE_DEMO)) {
-            generator = new HttpRequestGenerator();
-        } else {
-            generator = new HttpRequestGenerator(user);
-        }
+        HttpRequestGenerator generator = new HttpRequestGenerator(user);
         return submitEntity(entity, url, generator);
     }
 


### PR DESCRIPTION
HQ couldn't previously identify what data in the system was coming from demo users, simply that some submissions were forced to be sent without authentication, preventing it from handling them properly.

Also unifies redundant logic around not using authentication when demo users are logged in.