### PR TITLE
Allow multimedia verification to be cancelled if launched voluntarily

### DIFF
--- a/app/src/org/commcare/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/activities/CommCareVerificationActivity.java
@@ -184,6 +184,12 @@ public class CommCareVerificationActivity
         task.execute((String[])null);
     }
 
+    @Override
+    public void taskCancelled() {
+        setResult(RESULT_CANCELED);
+        finish();
+    }
+
     private void handleVerificationProblems(SizeBoundVector<MissingMediaException> problems) {
         String message = Localization.get("verification.fail.message");
 
@@ -276,6 +282,9 @@ public class CommCareVerificationActivity
                             Localization.get("verification.checking"),
                             taskId);
             dialog.addProgressBar();
+            if (fromSettings || fromManager) {
+                dialog.addCancelButton();
+            }
             return dialog;
         }
         Log.w(TAG, "taskId passed to generateProgressDialog does not match "

--- a/app/src/org/commcare/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/activities/CommCareVerificationActivity.java
@@ -186,8 +186,6 @@ public class CommCareVerificationActivity
 
     @Override
     public void taskCancelled() {
-        setResult(RESULT_CANCELED);
-        finish();
     }
 
     private void handleVerificationProblems(SizeBoundVector<MissingMediaException> problems) {


### PR DESCRIPTION
Allow user to cancel multimedia verification process if they launched it voluntarily.
This includes via the settings menu, during app install in the app manager (@amstone326, is this okay behavior, if not I'll add more flags into `CommCareVerificationActivity), or during validation check from the app manager.

![screen](https://cloud.githubusercontent.com/assets/94817/14129062/96197482-f5f4-11e5-9a9e-50ef1236823b.png)

cross-request: https://github.com/dimagi/commcare/pull/276

ticket: http://manage.dimagi.com/default.asp?222474