### PR TITLE
Prevent double loading of form list

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -182,6 +182,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
                 incompleteMode = true;
                 //special case, no special filtering options
                 adapter.setFormFilter(FormRecordFilter.Incomplete);
+                adapter.resetRecords();
             }
         } else {
             FormRecordFilter[] filters = FormRecordFilter.values();
@@ -307,7 +308,6 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
      */
     public void refreshView() {
         disableSearch();
-        adapter.resetRecords();
         listView.setAdapter(adapter);
     }
 


### PR DESCRIPTION
Form list loading gets called twice for 'saved' forms activity. This is due to it happening [here](https://github.com/dimagi/commcare-odk/blob/master/app/src/org/commcare/activities/FormRecordListActivity.java#L198-L201) and then again in the place that I removed it in this PR

Ticket: http://manage.dimagi.com/default.asp?222620