### PR TITLE
Fix for NSD Attachment blocking

### DIFF
--- a/app/src/org/commcare/android/nsd/NSDDiscoveryTools.java
+++ b/app/src/org/commcare/android/nsd/NSDDiscoveryTools.java
@@ -130,6 +130,7 @@ public class NSDDiscoveryTools {
                     manager = (NsdManager)context.getSystemService(Context.NSD_SERVICE);
                 }
 
+                @Override
                 public void commit() {
                     mNsdManager = manager;
                 }

--- a/app/src/org/commcare/android/nsd/NSDDiscoveryTools.java
+++ b/app/src/org/commcare/android/nsd/NSDDiscoveryTools.java
@@ -7,6 +7,10 @@ import android.net.nsd.NsdServiceInfo;
 import android.os.Build;
 import android.util.Log;
 
+import org.commcare.logging.AndroidLogger;
+import org.commcare.utils.TimeBoundOperation;
+import org.javarosa.core.services.Logger;
+
 import java.net.InetAddress;
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,7 +41,8 @@ public class NSDDiscoveryTools {
     public enum NsdState {
         Init,
         Discovery,
-        Idle
+        Idle,
+        Unsupported
     }
 
     private static NsdState state = NsdState.Init;
@@ -93,7 +98,9 @@ public class NSDDiscoveryTools {
     private static void doDiscovery(Context context) {
         synchronized (nsdToolsLock) {
             if (mNsdManager == null) {
-                mNsdManager = (NsdManager)context.getSystemService(Context.NSD_SERVICE);
+                if(!connectNsdManager(context)) {
+                    return;
+                }
             }
 
             if (state == NsdState.Init || state == NsdState.Idle) {
@@ -102,6 +109,41 @@ public class NSDDiscoveryTools {
                 mNsdManager.discoverServices(SERVICE_TYPE,
                         NsdManager.PROTOCOL_DNS_SD, mDiscoveryListener);
             }
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    private static boolean connectNsdManager(final Context context) {
+        synchronized (nsdToolsLock) {
+            //sometimes the service fetch  basically times out forever, thanks for the clear
+            //workaround steps google. Only give this half a second to fire, and then ignore the
+            //service as broken.
+            //Apparently NSDManager is a disaster before Android 5 and we should consider using
+            //a different NSD stack. Ugh.
+            //https://code.google.com/p/android/issues/detail?id=70778
+
+            boolean connected = new TimeBoundOperation(500) {
+                NsdManager manager;
+
+                @Override
+                public void run() {
+                    manager = (NsdManager)context.getSystemService(Context.NSD_SERVICE);
+                }
+
+                public void commit() {
+                    mNsdManager = manager;
+                }
+
+            }.execute();
+
+            if(!connected) {
+                Logger.log(AndroidLogger.TYPE_MAINTENANCE, "NSD Service Failed to connect");
+            }
+            if(mNsdManager == null) {
+                Log.d(TAG, "NSD Service Unavailable on device");
+                state = NsdState.Unsupported;
+            }
+            return connected;
         }
     }
 

--- a/app/src/org/commcare/utils/TimeBoundOperation.java
+++ b/app/src/org/commcare/utils/TimeBoundOperation.java
@@ -1,0 +1,76 @@
+package org.commcare.utils;
+
+/**
+ * A time bound operation will run a synchronized operation in the background, with the confidence
+ * that it will either execute within the time frame provided, or it will not fire its resolution
+ * method, and will return control to the main thead after the timeout has expired.
+ *
+ * The operation should consist of two steps: A first step that should have no side effects
+ * (run), and an optional second step (commit) that executes after the first is
+ * completed. The second step will not be bounded, but is guaranteed to not execute if the first
+ * step did not complete in time.
+ *
+ * A time bound operation can only be executed once.
+ *
+ * Created by ctsims on 4/4/2016.
+ */
+public abstract class TimeBoundOperation {
+
+    final private long timeout;
+
+    private Thread thread;
+    private boolean hasExecuted;
+
+    public TimeBoundOperation(long timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * The operation which will be executed within the timeout limit. Should not contain side
+     * effects which will effect runtime if they execute indefinitely
+     */
+    protected abstract void run();
+
+    /**
+     * The optional commit step after the run executes which isn't bounded, and can have
+     * side effects that will be guaranteed to run if the execution succeeds
+     */
+    protected void commit() {
+
+    }
+
+    /**
+     * Executes the operation and optionally the commit step if the run step succeeds in time
+     *
+     * @return true if both phases of the timed operation succeeded. False if the operaiton
+     * timed out and the commit step did not run.
+     *
+     * @throws IllegalStateException If the operation has already been executed
+     */
+    public synchronized boolean execute() throws IllegalStateException {
+        if(hasExecuted) {
+            throw new IllegalStateException("time bound operation has already executed");
+        }
+        hasExecuted = true;
+
+        thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                TimeBoundOperation.this.run();
+            }
+        });
+
+        thread.start();
+        try {
+            thread.join(timeout);
+        }catch (InterruptedException e) {
+            //Execution failed
+            return false;
+        };
+
+        commit();
+        return true;
+
+    }
+
+}

--- a/app/src/org/commcare/utils/TimeBoundOperation.java
+++ b/app/src/org/commcare/utils/TimeBoundOperation.java
@@ -1,7 +1,7 @@
 package org.commcare.utils;
 
 /**
- * A time bound operation will run a synchronized operation in the background, with the confidence
+ * A time bound operation will run a synchronized operation on a blocking thread with the confidence
  * that it will either execute within the time frame provided, or it will not fire its resolution
  * method, and will return control to the main thead after the timeout has expired.
  *
@@ -18,7 +18,6 @@ public abstract class TimeBoundOperation {
 
     final private long timeout;
 
-    private Thread thread;
     private boolean hasExecuted;
 
     public TimeBoundOperation(long timeout) {
@@ -53,7 +52,7 @@ public abstract class TimeBoundOperation {
         }
         hasExecuted = true;
 
-        thread = new Thread(new Runnable() {
+        Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {
                 TimeBoundOperation.this.run();
@@ -66,7 +65,7 @@ public abstract class TimeBoundOperation {
         }catch (InterruptedException e) {
             //Execution failed
             return false;
-        };
+        }
 
         commit();
         return true;


### PR DESCRIPTION
Workaround for NSD Services being a disaster and resulting in many-second blocking calls. Now will abandon the search after a brief window (it won't succeed after it's gotten into the bugged state anyway)

Ticket:
http://manage.dimagi.com/default.asp?222766#1120157