### PR TITLE
Minor changes to forceclose/xpatherror log entries

### DIFF
--- a/app/src/org/commcare/android/logging/ForceCloseLogEntry.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogEntry.java
@@ -2,6 +2,7 @@ package org.commcare.android.logging;
 
 import android.os.Build;
 
+import org.commcare.CommCareApplication;
 import org.commcare.logging.AndroidLogEntry;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.preferences.DevSessionRestorer;
@@ -29,6 +30,8 @@ public class ForceCloseLogEntry extends AndroidLogEntry {
     private String deviceModel;
     private String readableSessionString;
     private String serializedSessionString;
+    private String appId;
+    private String userId;
 
     /**
      * Serialization only
@@ -44,6 +47,8 @@ public class ForceCloseLogEntry extends AndroidLogEntry {
         deviceModel = Build.MODEL;
         readableSessionString = ReportingUtils.getCurrentSession();
         serializedSessionString = DevSessionRestorer.getSerializedSessionString();
+        appId = ReportingUtils.getAppId();
+        userId = CommCareApplication._().getCurrentUserId();
     }
 
     public int getAppBuildNumber() {
@@ -66,6 +71,14 @@ public class ForceCloseLogEntry extends AndroidLogEntry {
         return serializedSessionString;
     }
 
+    public String getAppId() {
+        return appId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
@@ -75,6 +88,8 @@ public class ForceCloseLogEntry extends AndroidLogEntry {
         deviceModel = ExtUtil.readString(in);
         readableSessionString = ExtUtil.readString(in);
         serializedSessionString = ExtUtil.readString(in);
+        appId = ExtUtil.readString(in);
+        userId = ExtUtil.readString(in);
     }
 
     @Override
@@ -85,6 +100,8 @@ public class ForceCloseLogEntry extends AndroidLogEntry {
         ExtUtil.writeString(out, deviceModel);
         ExtUtil.writeString(out, readableSessionString);
         ExtUtil.writeString(out, serializedSessionString);
+        ExtUtil.writeString(out, appId);
+        ExtUtil.writeString(out, userId);
     }
 
 }

--- a/app/src/org/commcare/android/logging/ForceCloseLogSerializer.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogSerializer.java
@@ -66,7 +66,7 @@ public class ForceCloseLogSerializer extends StreamLogSerializer implements Devi
                     forceCloseEntry.getType(), serializer);
             AndroidLogSerializer.writeText("msg",
                     forceCloseEntry.getMessage(), serializer);
-            AndroidLogSerializer.writeText("build_number",
+            AndroidLogSerializer.writeText("app_build",
                     forceCloseEntry.getAppBuildNumber() + "", serializer);
             AndroidLogSerializer.writeText("android_version",
                     forceCloseEntry.getAndroidVersion(), serializer);
@@ -76,6 +76,8 @@ public class ForceCloseLogSerializer extends StreamLogSerializer implements Devi
                     forceCloseEntry.getReadableSession(), serializer);
             AndroidLogSerializer.writeText("session_serialized",
                     forceCloseEntry.getSerializedSessionString(), serializer);
+            AndroidLogSerializer.writeText("app_id", forceCloseEntry.getAppId(), serializer);
+            AndroidLogSerializer.writeText("user_id", forceCloseEntry.getUserId(), serializer);
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/app/src/org/commcare/logging/XPathErrorSerializer.java
+++ b/app/src/org/commcare/logging/XPathErrorSerializer.java
@@ -61,7 +61,7 @@ public class XPathErrorSerializer
             AndroidLogSerializer.writeText("msg", errorEntry.getMessage(), serializer);
             AndroidLogSerializer.writeText("user_id", errorEntry.getUserId(), serializer);
             AndroidLogSerializer.writeText("session", errorEntry.getSessionPath(), serializer);
-            AndroidLogSerializer.writeText("version", errorEntry.getAppVersion() + "", serializer);
+            AndroidLogSerializer.writeText("app_build", errorEntry.getAppVersion() + "", serializer);
             AndroidLogSerializer.writeText("app_id", errorEntry.getAppId(), serializer);
             AndroidLogSerializer.writeText("expr", errorEntry.getExpression(), serializer);
         } catch (Exception e) {


### PR DESCRIPTION
Just chatted with Ethan about the HQ handling of our new log subreports, and he asked me to change the name of 1 field to make it less ambiguous, as well as add a couple of useful fields that were missing from force closes. 