### PR TITLE
Improve unsent forms subtext + fix subtext coloring

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -79,7 +79,7 @@ home.forms.incomplete=Incomplete
 home.forms.incomplete.indicator=${1} (${0})  
 home.forms.saved=Saved
 home.sync=Sync with Server
-home.sync.indicator=Unsent Forms: ${0}
+home.unsent.forms.indicator=Unsent Forms: ${0}
 home.logout=Log out of CommCare
 home.report=Report an Issue
 

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -79,7 +79,7 @@ home.forms.incomplete=Incomplete
 home.forms.incomplete.indicator=${1} (${0})  
 home.forms.saved=Saved
 home.sync=Sync with Server
-home.sync.indicator=${1} (${0})
+home.sync.indicator=Unsent Forms: ${0}
 home.logout=Log out of CommCare
 home.report=Report an Issue
 

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -37,7 +37,7 @@ public class SyncDetailCalculations {
         Pair<Long, String> lastSyncTimeAndMessage = getLastSyncTimeAndMessage();
 
         if (numUnsentForms > 0) {
-            Spannable syncIndicator = (activity.localize("home.sync.indicator",
+            Spannable syncIndicator = (activity.localize("home.unsent.forms.indicator",
                     new String[]{String.valueOf(numUnsentForms)}));
             squareButtonViewHolder.subTextView.setText(syncIndicator);
         } else {

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -12,6 +12,7 @@ import org.commcare.adapters.SquareButtonViewHolder;
 import org.commcare.dalvik.R;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.user.models.FormRecord;
+import org.commcare.modern.util.Pair;
 import org.javarosa.core.services.locale.Localization;
 
 import java.text.DateFormat;
@@ -29,22 +30,26 @@ public class SyncDetailCalculations {
     public static void updateSubText(final CommCareHomeActivity activity,
                                      SquareButtonViewHolder squareButtonViewHolder,
                                      HomeCardDisplayData cardDisplayData) {
+
         SqlStorage<FormRecord> formsStorage = CommCareApplication._().getUserStorage(FormRecord.class);
         int numUnsentForms = formsStorage.getIDsForValue(FormRecord.META_STATUS, FormRecord.STATUS_UNSENT).size();
+
+        Pair<Long, String> lastSyncTimeAndMessage = getLastSyncTimeAndMessage();
+
         if (numUnsentForms > 0) {
             Spannable syncIndicator = (activity.localize("home.sync.indicator",
                     new String[]{String.valueOf(numUnsentForms)}));
             squareButtonViewHolder.subTextView.setText(syncIndicator);
-            squareButtonViewHolder.subTextView.setTextColor(activity.getResources().getColor(cardDisplayData.subTextColor));
         } else {
-            showSyncMessage(squareButtonViewHolder.subTextView,
-                    activity.getResources().getColor(cardDisplayData.subTextColor),
-                    activity.getResources().getColor(R.color.cc_attention_negative_text),
-                    numUnsentForms);
+            squareButtonViewHolder.subTextView.setText(lastSyncTimeAndMessage.second);
         }
+        setSyncSubtextColor(
+                squareButtonViewHolder.subTextView, numUnsentForms, lastSyncTimeAndMessage.first,
+                activity.getResources().getColor(cardDisplayData.subTextColor),
+                activity.getResources().getColor(R.color.cc_attention_negative_text));
     }
 
-    private static void showSyncMessage(TextView subTextView, int normalColor, int warningColor, int numUnsentForms) {
+    private static Pair<Long, String> getLastSyncTimeAndMessage() {
         CharSequence syncTimeMessage;
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
         long lastSyncTime = prefs.getLong("last-succesful-sync", 0);
@@ -53,20 +58,15 @@ public class SyncDetailCalculations {
         } else {
             syncTimeMessage = DateUtils.formatSameDayTime(lastSyncTime, new Date().getTime(), DateFormat.DEFAULT, DateFormat.DEFAULT);
         }
+        return new Pair<>(lastSyncTime, Localization.get("home.sync.message.last", new String[]{syncTimeMessage.toString()}));
+    }
 
-        String message = "";
-        if (numUnsentForms == 1) {
-            message += Localization.get("home.sync.message.unsent.singular") + "\n";
-        } else if (numUnsentForms > 1) {
-            message += Localization.get("home.sync.message.unsent.plural", new String[]{String.valueOf(numUnsentForms)}) + "\n";
-        }
-
-        message += Localization.get("home.sync.message.last", new String[]{syncTimeMessage.toString()});
-        subTextView.setText(message);
+    private static void setSyncSubtextColor(TextView subtext, int numUnsentForms, long lastSyncTime,
+                                            int normalColor, int warningColor) {
         if (isSyncStronglyNeeded(numUnsentForms, lastSyncTime)) {
-            subTextView.setTextColor(warningColor);
+            subtext.setTextColor(warningColor);
         } else {
-            subTextView.setTextColor(normalColor);
+            subtext.setTextColor(normalColor);
         }
     }
 

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -33,7 +33,7 @@ public class SyncDetailCalculations {
         int numUnsentForms = formsStorage.getIDsForValue(FormRecord.META_STATUS, FormRecord.STATUS_UNSENT).size();
         if (numUnsentForms > 0) {
             Spannable syncIndicator = (activity.localize("home.sync.indicator",
-                    new String[]{String.valueOf(numUnsentForms), cardDisplayData.text}));
+                    new String[]{String.valueOf(numUnsentForms)}));
             squareButtonViewHolder.subTextView.setText(syncIndicator);
             squareButtonViewHolder.subTextView.setTextColor(activity.getResources().getColor(cardDisplayData.subTextColor));
         } else {


### PR DESCRIPTION
Chatted with Sheel about this ticket http://manage.dimagi.com/default.asp?211211 and determined that the only lingering change necessary was to make the Sync button subtext clearer. That subtext previously read "Sync with Server (x)", where x is the number of unsent forms. It seems silly to duplicate the main text that's already on the button, and not give a good description of what that number actually represents, so changing it to instead read "Unsent Forms: x".

(The other concern on this ticket -- the error text persisting and therefore obfuscating the unsent forms count -- appears to have been resolved at some point since the version the partner was on).

I also noticed while working on this that that somewhere in the process of this code getting refactored, some unreachable code was left in, and the subtext color was not always getting set to warning when it should be. Comments inline as to what I changed there.
