### PR TITLE
Refactor: HorizontalMediaView

### DIFF
--- a/app/src/org/commcare/views/HorizontalMediaView.java
+++ b/app/src/org/commcare/views/HorizontalMediaView.java
@@ -14,7 +14,6 @@ import org.commcare.suite.model.DisplayData;
 import org.commcare.suite.model.DisplayUnit;
 import org.commcare.utils.MediaUtil;
 import org.commcare.views.media.AudioButton;
-import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.locale.Localizer;
@@ -27,55 +26,34 @@ import java.io.File;
  *
  * @author wspride
  */
-
 public class HorizontalMediaView extends RelativeLayout {
     private static final String t = "AVTLayout";
 
-    private TextView mTextView;
     private AudioButton mAudioButton;
     private ImageView mImageView;
-    private final EvaluationContext ec;
     private final int iconDimension;
 
-    public static final int NAVIGATION_NONE = 0;
-    public static final int NAVIGATION_NEXT = 1;
-
-
     public HorizontalMediaView(Context c) {
-        this(c, null);
-    }
-
-    private HorizontalMediaView(Context c, EvaluationContext ec) {
         super(c);
-        mTextView = null;
-        mAudioButton = null;
-        mImageView = null;
-        this.ec = ec;
-        this.iconDimension = (int)getResources().getDimension(R.dimen.menu_icon_size);
+        this.iconDimension = (int) getResources().getDimension(R.dimen.menu_icon_size);
     }
 
     public void setDisplay(DisplayUnit display) {
-        DisplayData mData = display.evaluate(ec);
+        DisplayData mData = display.evaluate(null);
         setAVT(Localizer.processArguments(mData.getName(), new String[]{""}).trim(), mData.getAudioURI(), mData.getImageURI());
     }
 
     public void setAVT(String displayText, String audioURI, String imageURI) {
-        this.setAVT(displayText, audioURI, imageURI, NAVIGATION_NONE);
-    }
+        removeAllViews();
 
-    private void setAVT(String displayText, String audioURI, String imageURI, int navStyle) {
-        this.removeAllViews();
-
-        LayoutInflater inflater = (LayoutInflater)getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        mTextView = (TextView)inflater.inflate(R.layout.menu_list_item, null);
+        LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        TextView mTextView = (TextView) inflater.inflate(R.layout.menu_list_item, null);
         mTextView.setText(displayText);
 
         // Layout configurations for our elements in the relative layout
         RelativeLayout.LayoutParams textParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
         RelativeLayout.LayoutParams audioParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
         RelativeLayout.LayoutParams imageParams = new RelativeLayout.LayoutParams(iconDimension, iconDimension);
-
-        RelativeLayout.LayoutParams iconParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 
         String audioFilename = "";
         if (audioURI != null && !audioURI.equals("")) {
@@ -85,23 +63,6 @@ public class HorizontalMediaView extends RelativeLayout {
                 Log.e(t, "Invalid reference exception");
                 e.printStackTrace();
             }
-        }
-
-
-        if (navStyle != NAVIGATION_NONE) {
-            ImageView iconRight = new ImageView(this.getContext());
-            if (navStyle == NAVIGATION_NEXT) {
-                iconRight.setImageResource(R.drawable.icon_next);
-            } else {
-                iconRight.setImageResource(R.drawable.icon_done);
-            }
-            iconRight.setId(2345345);
-            iconParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-            iconParams.addRule(CENTER_VERTICAL);
-
-            iconParams.rightMargin = 5;
-            //iconRight.setPadding(20, iconRight.getPaddingTop(), iconRight.getPaddingRight(), iconRight.getPaddingBottom());
-            this.addView(iconRight, iconParams);
         }
 
         File audioFile = new File(audioFilename);
@@ -114,11 +75,7 @@ public class HorizontalMediaView extends RelativeLayout {
             // Set not focusable so that list onclick will work
             mAudioButton.setFocusable(false);
             mAudioButton.setFocusableInTouchMode(false);
-            if (navStyle != NAVIGATION_NONE) {
-                audioParams.addRule(RelativeLayout.LEFT_OF, 2345345);
-            } else {
-                audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-            }
+            audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
             audioParams.addRule(CENTER_VERTICAL);
             addView(mAudioButton, audioParams);
         }
@@ -143,9 +100,7 @@ public class HorizontalMediaView extends RelativeLayout {
             textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
         }
 
-        if (navStyle != NAVIGATION_NONE) {
-            textParams.addRule(RelativeLayout.LEFT_OF, 2345345);
-        } else if (mAudioButton != null) {
+        if (mAudioButton != null) {
             textParams.addRule(RelativeLayout.LEFT_OF, mAudioButton.getId());
         }
         addView(mTextView, textParams);

--- a/app/src/org/commcare/views/HorizontalMediaView.java
+++ b/app/src/org/commcare/views/HorizontalMediaView.java
@@ -82,8 +82,8 @@ public class HorizontalMediaView extends RelativeLayout {
                 Log.e(TAG, "Invalid reference exception");
                 e.printStackTrace();
             }
-            return false;
         }
+        return false;
     }
 
     private ImageView setupImageView(String imageURI, RelativeLayout.LayoutParams audioParams) {

--- a/app/src/org/commcare/views/HorizontalMediaView.java
+++ b/app/src/org/commcare/views/HorizontalMediaView.java
@@ -34,7 +34,7 @@ public class HorizontalMediaView extends RelativeLayout {
 
     public HorizontalMediaView(Context c) {
         super(c);
-        this.iconDimension = (int) getResources().getDimension(R.dimen.menu_icon_size);
+        this.iconDimension = (int)getResources().getDimension(R.dimen.menu_icon_size);
     }
 
     public void setDisplay(DisplayUnit display) {
@@ -119,9 +119,9 @@ public class HorizontalMediaView extends RelativeLayout {
             textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
         }
         LayoutInflater inflater =
-                (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+                (LayoutInflater)getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
-        TextView mTextView = (TextView) inflater.inflate(R.layout.menu_list_item, null);
+        TextView mTextView = (TextView)inflater.inflate(R.layout.menu_list_item, null);
         mTextView.setText(displayText);
         addView(mTextView, textParams);
     }

--- a/app/src/org/commcare/views/HorizontalMediaView.java
+++ b/app/src/org/commcare/views/HorizontalMediaView.java
@@ -27,11 +27,10 @@ import java.io.File;
  * @author wspride
  */
 public class HorizontalMediaView extends RelativeLayout {
-    private static final String t = "AVTLayout";
+    private static final String TAG = HorizontalMediaView.class.getSimpleName();
 
-    private AudioButton mAudioButton;
-    private ImageView mImageView;
     private final int iconDimension;
+    private AudioButton audioButton;
 
     public HorizontalMediaView(Context c) {
         super(c);
@@ -39,7 +38,7 @@ public class HorizontalMediaView extends RelativeLayout {
     }
 
     public void setDisplay(DisplayUnit display) {
-        DisplayData mData = display.evaluate(null);
+        DisplayData mData = display.evaluate();
         setAVT(Localizer.processArguments(mData.getName(), new String[]{""}).trim(), mData.getAudioURI(), mData.getImageURI());
     }
 
@@ -60,7 +59,7 @@ public class HorizontalMediaView extends RelativeLayout {
             try {
                 audioFilename = ReferenceManager._().DeriveReference(audioURI).getLocalURI();
             } catch (InvalidReferenceException e) {
-                Log.e(t, "Invalid reference exception");
+                Log.e(TAG, "Invalid reference exception");
                 e.printStackTrace();
             }
         }
@@ -70,38 +69,39 @@ public class HorizontalMediaView extends RelativeLayout {
         // First set up the audio button
         if (!"".equals(audioFilename) && audioFile.exists()) {
             // An audio file is specified
-            mAudioButton = new AudioButton(getContext(), audioURI, true);
-            mAudioButton.setId(3245345); // random ID to be used by the relative layout.
+            audioButton = new AudioButton(getContext(), audioURI, true);
+            audioButton.setId(3245345); // random ID to be used by the relative layout.
             // Set not focusable so that list onclick will work
-            mAudioButton.setFocusable(false);
-            mAudioButton.setFocusableInTouchMode(false);
+            audioButton.setFocusable(false);
+            audioButton.setFocusableInTouchMode(false);
             audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
             audioParams.addRule(CENTER_VERTICAL);
-            addView(mAudioButton, audioParams);
+            addView(audioButton, audioParams);
         }
 
+        ImageView imageView = null;
         Bitmap b = MediaUtil.inflateDisplayImage(getContext(), imageURI, iconDimension, iconDimension);
         if (b != null) {
-            mImageView = new ImageView(getContext());
-            mImageView.setPadding(10, 10, 10, 10);
-            mImageView.setAdjustViewBounds(true);
-            mImageView.setImageBitmap(b);
-            mImageView.setId(23422634);
+            imageView = new ImageView(getContext());
+            imageView.setPadding(10, 10, 10, 10);
+            imageView.setAdjustViewBounds(true);
+            imageView.setImageBitmap(b);
+            imageView.setId(23422634);
             imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
             audioParams.addRule(CENTER_VERTICAL);
-            addView(mImageView, imageParams);
+            addView(imageView, imageParams);
         }
 
         textParams.addRule(RelativeLayout.CENTER_VERTICAL);
         textParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
-        if (imageURI != null && !imageURI.equals("") && mImageView != null) {
-            textParams.addRule(RelativeLayout.RIGHT_OF, mImageView.getId());
+        if (imageURI != null && !imageURI.equals("") && imageView != null) {
+            textParams.addRule(RelativeLayout.RIGHT_OF, imageView.getId());
         } else {
             textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
         }
 
-        if (mAudioButton != null) {
-            textParams.addRule(RelativeLayout.LEFT_OF, mAudioButton.getId());
+        if (audioButton != null) {
+            textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
         }
         addView(mTextView, textParams);
     }
@@ -110,8 +110,8 @@ public class HorizontalMediaView extends RelativeLayout {
     protected void onWindowVisibilityChanged(int visibility) {
         super.onWindowVisibilityChanged(visibility);
         if (visibility != View.VISIBLE) {
-            if (mAudioButton != null) {
-                mAudioButton.endPlaying();
+            if (audioButton != null) {
+                audioButton.endPlaying();
             }
         }
     }

--- a/app/src/org/commcare/views/HorizontalMediaView.java
+++ b/app/src/org/commcare/views/HorizontalMediaView.java
@@ -58,23 +58,9 @@ public class HorizontalMediaView extends RelativeLayout {
     }
 
     private AudioButton setupAudioButton(String audioURI, RelativeLayout.LayoutParams audioParams) {
-        // Layout configurations for our elements in the relative layout
-
-        String audioFilename = "";
-        if (audioURI != null && !audioURI.equals("")) {
-            try {
-                audioFilename = ReferenceManager._().DeriveReference(audioURI).getLocalURI();
-            } catch (InvalidReferenceException e) {
-                Log.e(TAG, "Invalid reference exception");
-                e.printStackTrace();
-            }
-        }
-
-        File audioFile = new File(audioFilename);
-
         AudioButton tmpAudioButton = null;
         // First set up the audio button
-        if (!"".equals(audioFilename) && audioFile.exists()) {
+        if (audioFileExists(audioURI)) {
             // An audio file is specified
             tmpAudioButton = new AudioButton(getContext(), audioURI, true);
             tmpAudioButton.setId(3245345); // random ID to be used by the relative layout.
@@ -86,6 +72,18 @@ public class HorizontalMediaView extends RelativeLayout {
             addView(tmpAudioButton, audioParams);
         }
         return tmpAudioButton;
+    }
+
+    private static boolean audioFileExists(String audioURI) {
+        if (audioURI != null && !audioURI.equals("")) {
+            try {
+                return new File(ReferenceManager._().DeriveReference(audioURI).getLocalURI()).exists();
+            } catch (InvalidReferenceException e) {
+                Log.e(TAG, "Invalid reference exception");
+                e.printStackTrace();
+            }
+            return false;
+        }
     }
 
     private ImageView setupImageView(String imageURI, RelativeLayout.LayoutParams audioParams) {


### PR DESCRIPTION
- Break-up method into smaller helpers
- Remove navigation icon code, which is never executed because `int navStyle` is always set to `NAVIGATION_NONE`

perhaps easiest reviewed commit-by-commit