### PR TITLE
Graphing: blank screen instead of error message

### DIFF
--- a/app/assets/graphing/graph.js
+++ b/app/assets/graphing/graph.js
@@ -9,8 +9,11 @@ document.addEventListener("DOMContentLoaded", function(event) {
         // Ghastly hack: Occasionally, when the graphing javascript runs, document.body has no
         // dimensions, which causes the graph to not actually display full screen, and it also
         // causes extra points to appear on the y axis. If we wait, dimensions will sometimes get
-        // populated. If they never do, user will see a blank space.
+        // populated. If they never do, give up, and user will see a blank space.
         if (!document.body.offsetWidth || !document.body.offsetHeight) {
+            if (delay > 10000) {
+                clearInterval(intervalID);
+            }
             return;
         }
         clearInterval(intervalID);

--- a/app/assets/graphing/graph.js
+++ b/app/assets/graphing/graph.js
@@ -5,11 +5,12 @@ document.addEventListener("DOMContentLoaded", function(event) {
         delay = 0;
     var intervalID = setInterval(function() {
         delay += retryFrequency;
+
+        // Ghastly hack: Occasionally, when the graphing javascript runs, document.body has no
+        // dimensions, which causes the graph to not actually display full screen, and it also
+        // causes extra points to appear on the y axis. If we wait, dimensions will sometimes get
+        // populated. If they never do, user will see a blank space.
         if (!document.body.offsetWidth || !document.body.offsetHeight) {
-            if (delay > 6000) {
-                displayError("Could not find document body.");
-                clearInterval(intervalID);
-            }
             return;
         }
         clearInterval(intervalID);


### PR DESCRIPTION
See https://github.com/dimagi/commcare-odk/pull/1064 for context.

Don't have a fix for the actual bug yet, but the parto team requested removal of the error message, since it startles users and there's nothing they can do about it.