### PR TITLE
Fix for IText Calculations not properly initializing with the app locale

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1660,21 +1660,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             invalidateOptionsMenu();
         }
 
-        Localizer mLocalizer = Localization.getGlobalLocalizerAdvanced();
-
-        if(mLocalizer != null){
-            String mLocale = mLocalizer.getLocale();
-
-            if (mLocale != null && fc.getLanguages() != null && Arrays.asList(fc.getLanguages()).contains(mLocale)){
-                fc.setLanguage(mLocale);
-            }
-            else{
-                Logger.log("formloader", "The current locale is not set");
-            }
-        } else{
-            Logger.log("formloader", "Could not get the localizer");
-        }
-
         registerSessionFormSaveCallback();
 
         // Set saved answer path

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -31,6 +31,8 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.parse.XFormParseException;
@@ -46,6 +48,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -171,6 +174,17 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
         return fd;
     }
 
+    private String getSystemLocale() {
+        Localizer mLocalizer = Localization.getGlobalLocalizerAdvanced();
+
+        if(mLocalizer != null) {
+            return mLocalizer.getLocale();
+        } else{
+            Logger.log("formloader", "Could not get the localizer");
+        }
+        return null;
+    }
+
     private FormEntryController initFormDef(FormDef formDef) {
         formDef.exprEvalContext.addFunctionHandler(new CalendaredDateFormatHandler((Context)activity));
         // create FormEntryController from formdef
@@ -187,9 +201,9 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
         if (FormEntryActivity.mInstancePath != null) {
             // This order is important. Import data, then initialize.
             importData(FormEntryActivity.mInstancePath, fec);
-            formDef.initialize(false, iif);
+            formDef.initialize(false, iif, getSystemLocale());
         } else {
-            formDef.initialize(true, iif);
+            formDef.initialize(true, iif, getSystemLocale());
         }
         if (mReadOnly) {
             formDef.getInstance().getRoot().setEnabled(false);


### PR DESCRIPTION
Fix for bugs where the itext calculation in xpath was always using the form's default locale, even if the app locale is different.

Needed for ICDS

Fogbugz:
http://manage.dimagi.com/?221785

cross-request: https://github.com/dimagi/javarosa/pull/290
