### PR TITLE
Fix user notifications for localization exceptions

### DIFF
--- a/app/src/org/commcare/utils/CommCareExceptionHandler.java
+++ b/app/src/org/commcare/utils/CommCareExceptionHandler.java
@@ -47,7 +47,7 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
      * they can fix.
      */
     private boolean warnUserAndExit(Throwable ex) {
-        if (ex instanceof NoLocalizedTextException) {
+        if (causedByLocalizationException(ex)) {
             Intent i = new Intent(ctx, CrashWarningActivity.class);
             i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
@@ -56,5 +56,15 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
             return true;
         }
         return false;
+    }
+
+    private static boolean causedByLocalizationException(Throwable ex) {
+        if (ex == null) {
+            return false;
+        }
+        if (ex instanceof NoLocalizedTextException) {
+            return true;
+        }
+        return causedByLocalizationException(ex.getCause());
     }
 }

--- a/app/src/org/commcare/utils/CommCareExceptionHandler.java
+++ b/app/src/org/commcare/utils/CommCareExceptionHandler.java
@@ -59,12 +59,7 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
     }
 
     private static boolean causedByLocalizationException(Throwable ex) {
-        if (ex == null) {
-            return false;
-        }
-        if (ex instanceof NoLocalizedTextException) {
-            return true;
-        }
-        return causedByLocalizationException(ex.getCause());
+        return ex != null &&
+                (ex instanceof NoLocalizedTextException || causedByLocalizationException(ex.getCause()));
     }
 }


### PR DESCRIPTION
The user-facing error activity was not always being displayed when a crash was caused by a NoLocalizedTextException, because we weren't checking the Throwable's cause(s).

@phillipm Seems like something that could be worth sneaking into 2.27?