### PR TITLE
Heed the lint warnings; don't use google data backup feature

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -48,6 +48,7 @@
     </permission>
 
     <application
+        android:allowBackup="false"
         tools:replace="android:label,android:icon"
         android:name="org.commcare.CommCareApplication"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Might be causing strange data restoration issues that occur after uninstalling and reinstalling CommCare on my Android 6 device.

So nice that it defaults to `true` when unset... because we all want to opt into new features that change behavior and weren't advertised on the [Android 6 release page](https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html) 