### PR TITLE
Use normal PrototypeFactory in Robolectric tests

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -61,6 +61,7 @@ import org.commcare.logging.analytics.TimedStatsTracker;
 import org.commcare.models.AndroidClassHasher;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.models.database.AndroidDbHelper;
+import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.HybridFileBackedSqlHelpers;
 import org.commcare.models.database.HybridFileBackedSqlStorage;
 import org.commcare.models.database.MigrationException;
@@ -105,6 +106,7 @@ import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.storage.EntityFilter;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.PropertyUtils;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
@@ -1476,4 +1478,7 @@ public class CommCareApplication extends Application {
         return false;
     }
 
+    public PrototypeFactory getPrototypeFactory(Context c) {
+        return DbUtil.getPrototypeFactory(c);
+    }
 }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -2206,7 +2206,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             formEntryRestoreSession = new FormEntrySession();
             DataInputStream objectInputStream = new DataInputStream(new ByteArrayInputStream(serializedObject));
             try {
-                formEntryRestoreSession.readExternal(objectInputStream, DbUtil.getPrototypeFactory(this));
+                formEntryRestoreSession.readExternal(objectInputStream, CommCareApplication._().getPrototypeFactory(this));
             } catch (IOException | DeserializationException e) {
                 Log.e(TAG, "failed to deserialize form entry session during saved instance restore");
             } finally {

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -72,10 +72,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
 
     @Override
     protected int customInstall(Resource r, Reference local, boolean upgrade) throws IOException, UnresolvedResourceException {
-        //Ugh. Really need to sync up the Xform libs between ccodk and odk.
-        XFormParser.registerHandler("intent", new IntentExtensionParser());
-        XFormParser.registerActionHandler(PollSensorAction.ELEMENT_NAME, new PollSensorExtensionParser());
-
+        registerAndroidLevelFormParsers();
         FormDef formDef;
         try {
             formDef = XFormExtensionUtils.getFormFromInputStream(local.getStream());
@@ -146,6 +143,12 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         }
 
         return upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED;
+    }
+
+    public static void registerAndroidLevelFormParsers() {
+        //Ugh. Really need to sync up the Xform libs between ccodk and odk.
+        XFormParser.registerHandler("intent", new IntentExtensionParser());
+        XFormParser.registerActionHandler(PollSensorAction.ELEMENT_NAME, new PollSensorExtensionParser());
     }
 
     @Override

--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -1,5 +1,6 @@
 package org.commcare.engine.references;
 
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.network.HttpRequestGenerator;
 import org.javarosa.core.reference.Reference;
 
@@ -14,7 +15,7 @@ import java.net.URL;
 public class JavaHttpReference implements Reference {
 
     private final String uri;
-    private HttpRequestGenerator generator;
+    private HttpRequestEndpoints generator;
 
     public JavaHttpReference(String uri, HttpRequestGenerator generator) {
         this.uri = uri;
@@ -66,7 +67,7 @@ public class JavaHttpReference implements Reference {
 
     //TODO: This should get changed to be set from the root, don't assume this will
     //still be here indefinitely
-    public void setHttpRequestor(HttpRequestGenerator generator) {
+    public void setHttpRequestor(HttpRequestEndpoints generator) {
         this.generator = generator;
     }
 }

--- a/app/src/org/commcare/interfaces/HttpRequestEndpoints.java
+++ b/app/src/org/commcare/interfaces/HttpRequestEndpoints.java
@@ -1,0 +1,27 @@
+package org.commcare.interfaces;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.entity.mime.MultipartEntity;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
+
+/**
+ * Types of http requests made by CommCare mobile to server
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public interface HttpRequestEndpoints {
+    HttpResponse makeCaseFetchRequest(String baseUri, boolean includeStateFlags) throws ClientProtocolException, IOException;
+
+    HttpResponse makeKeyFetchRequest(String baseUri, Date lastRequest) throws ClientProtocolException, IOException;
+
+    HttpResponse postData(String url, MultipartEntity entity) throws ClientProtocolException, IOException;
+
+    InputStream simpleGet(URL url) throws IOException;
+
+    void abortCurrentRequest();
+}

--- a/app/src/org/commcare/models/database/AndroidDbHelper.java
+++ b/app/src/org/commcare/models/database/AndroidDbHelper.java
@@ -7,6 +7,7 @@ import android.util.Pair;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
+import org.commcare.CommCareApplication;
 import org.commcare.modern.database.DatabaseHelper;
 import org.commcare.modern.models.EncryptedModel;
 import org.commcare.utils.SessionUnavailableException;
@@ -91,6 +92,6 @@ public abstract class AndroidDbHelper extends DatabaseHelper {
     }
 
     public PrototypeFactory getPrototypeFactory() {
-        return DbUtil.getPrototypeFactory(c);
+        return CommCareApplication._().getPrototypeFactory(c);
     }
 }

--- a/app/src/org/commcare/models/database/DbUtil.java
+++ b/app/src/org/commcare/models/database/DbUtil.java
@@ -54,13 +54,11 @@ public class DbUtil {
 
         factory = new AndroidPrototypeFactory(tree);
         return factory;
-
     }
 
     /**
      * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
      */
-    @SuppressWarnings("unchecked")
     private static List<String> getClasses(String[] packageNames, Context c)
             throws IOException {
         ArrayList<String> classNames = new ArrayList<>();

--- a/app/src/org/commcare/models/database/DbUtil.java
+++ b/app/src/org/commcare/models/database/DbUtil.java
@@ -28,6 +28,7 @@ public class DbUtil {
     public final static String orphanFileTableName = "OrphanedFiles";
 
     private static PrototypeFactory factory;
+    private static final String[] packageNames = new String[]{"org.javarosa", "org.commcare", "org.odk.collect"};
 
     public static void setDBUtilsPrototypeFactory(PrototypeFactory factory) {
         DbUtil.factory = factory;
@@ -44,7 +45,7 @@ public class DbUtil {
         PrefixTree tree = new PrefixTree();
 
         try {
-            List<String> classes = getClasses(new String[]{"org.javarosa", "org.commcare", "org.odk.collect"}, c);
+            List<String> classes = getClasses(c);
             for (String cl : classes) {
                 tree.addString(cl);
             }
@@ -59,7 +60,7 @@ public class DbUtil {
     /**
      * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
      */
-    private static List<String> getClasses(String[] packageNames, Context c)
+    private static List<String> getClasses(Context c)
             throws IOException {
         ArrayList<String> classNames = new ArrayList<>();
 
@@ -73,13 +74,13 @@ public class DbUtil {
         DexFile df = new DexFile(new File(zpath));
         for (Enumeration<String> en = df.entries(); en.hasMoreElements(); ) {
             String cn = en.nextElement();
-            loadClass(cn, packageNames, classNames);
+            loadClass(cn, classNames);
         }
 
         return classNames;
     }
 
-    private static void loadClass(String cn, String[] packageNames, ArrayList<String> classNames) {
+    public static void loadClass(String cn, List<String> classNames) {
         try {
             for (String packageName : packageNames) {
                 if (cn.startsWith(packageName) && !cn.contains(".test.") && !cn.contains("readystatesoftware")) {

--- a/app/src/org/commcare/models/database/DbUtil.java
+++ b/app/src/org/commcare/models/database/DbUtil.java
@@ -75,35 +75,39 @@ public class DbUtil {
         DexFile df = new DexFile(new File(zpath));
         for (Enumeration<String> en = df.entries(); en.hasMoreElements(); ) {
             String cn = en.nextElement();
-            try {
-                for (String packageName : packageNames) {
-                    if (cn.startsWith(packageName) && !cn.contains(".test.") && !cn.contains("readystatesoftware")) {
-                        //TODO: These optimize by preventing us from statically loading classes we don't need, but they take a _long_ time to run.
-                        //Maybe we should skip this and/or roll it into initializing the factory itself.
-                        Class prototype = Class.forName(cn);
-                        if (prototype.isInterface()) {
-                            continue;
-                        }
-                        boolean emptyc = false;
-                        for (Constructor<?> cons : prototype.getConstructors()) {
-                            if (cons.getParameterTypes().length == 0) {
-                                emptyc = true;
-                            }
-                        }
-                        if (!emptyc) {
-                            continue;
-                        }
-                        if (Externalizable.class.isAssignableFrom(prototype)) {
-                            classNames.add(cn);
-                        }
-                    }
-                }
-            } catch (Error | Exception e) {
-
-            }
+            loadClass(cn, packageNames, classNames);
         }
 
         return classNames;
+    }
+
+    private static void loadClass(String cn, String[] packageNames, ArrayList<String> classNames) {
+        try {
+            for (String packageName : packageNames) {
+                if (cn.startsWith(packageName) && !cn.contains(".test.") && !cn.contains("readystatesoftware")) {
+                    //TODO: These optimize by preventing us from statically loading classes we don't need, but they take a _long_ time to run.
+                    //Maybe we should skip this and/or roll it into initializing the factory itself.
+                    Class prototype = Class.forName(cn);
+                    if (prototype.isInterface()) {
+                        continue;
+                    }
+                    boolean emptyc = false;
+                    for (Constructor<?> cons : prototype.getConstructors()) {
+                        if (cons.getParameterTypes().length == 0) {
+                            emptyc = true;
+                        }
+                    }
+                    if (!emptyc) {
+                        continue;
+                    }
+                    if (Externalizable.class.isAssignableFrom(prototype)) {
+                        classNames.add(cn);
+                    }
+                }
+            }
+        } catch (Error | Exception e) {
+
+        }
     }
 
     /**

--- a/app/src/org/commcare/network/DataPullRequester.java
+++ b/app/src/org/commcare/network/DataPullRequester.java
@@ -1,5 +1,6 @@
 package org.commcare.network;
 
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.tasks.DataPullTask;
 
 import java.io.IOException;
@@ -14,12 +15,16 @@ public interface DataPullRequester {
      * Makes a data pulling request and returns an object for locally caching
      * the response data.
      *
-     * @param task      For reporting data download progress
-     * @param requestor For making the data pulling request
+     * @param task             For reporting data download progress
+     * @param requestor        For making the data pulling request
+     * @param server           Address of the request target
+     * @param includeSyncToken Add sync token to the request
      * @return Instance to handle the response data
      */
     RemoteDataPullResponse makeDataPullRequest(DataPullTask task,
-                                               HttpRequestGenerator requestor,
+                                               HttpRequestEndpoints requestor,
                                                String server,
                                                boolean includeSyncToken) throws IOException;
+
+    HttpRequestEndpoints getHttpGenerator(String username, String password);
 }

--- a/app/src/org/commcare/network/DataPullResponseFactory.java
+++ b/app/src/org/commcare/network/DataPullResponseFactory.java
@@ -1,5 +1,7 @@
 package org.commcare.network;
 
+import org.apache.http.HttpResponse;
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.tasks.DataPullTask;
 
 import java.io.IOException;
@@ -14,7 +16,16 @@ public class DataPullResponseFactory implements DataPullRequester {
     }
 
     @Override
-    public RemoteDataPullResponse makeDataPullRequest(DataPullTask task, HttpRequestGenerator requestor, String server, boolean includeSyncToken) throws IOException {
-        return new RemoteDataPullResponse(task, requestor, server, includeSyncToken);
+    public RemoteDataPullResponse makeDataPullRequest(DataPullTask task,
+                                                      HttpRequestEndpoints requestor,
+                                                      String server,
+                                                      boolean includeSyncToken) throws IOException {
+        HttpResponse response = requestor.makeCaseFetchRequest(server, includeSyncToken);
+        return new RemoteDataPullResponse(task, response);
+    }
+
+    @Override
+    public HttpRequestGenerator getHttpGenerator(String username, String password) {
+        return new HttpRequestGenerator(username, password);
     }
 }

--- a/app/src/org/commcare/network/HttpRequestGenerator.java
+++ b/app/src/org/commcare/network/HttpRequestGenerator.java
@@ -28,6 +28,7 @@ import org.apache.http.protocol.HttpContext;
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.cases.util.CaseDBUtils;
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.utils.GlobalConstants;
@@ -48,7 +49,7 @@ import java.util.Vector;
 /**
  * @author ctsims
  */
-public class HttpRequestGenerator {
+public class HttpRequestGenerator implements HttpRequestEndpoints {
     private static final String TAG = HttpRequestGenerator.class.getSimpleName();
 
     /**
@@ -138,6 +139,7 @@ public class HttpRequestGenerator {
 
     }
 
+    @Override
     public HttpResponse makeCaseFetchRequest(String baseUri, boolean includeStateFlags) throws ClientProtocolException, IOException {
         HttpClient client = client();
 
@@ -173,6 +175,7 @@ public class HttpRequestGenerator {
         return response;
     }
 
+    @Override
     public HttpResponse makeKeyFetchRequest(String baseUri, Date lastRequest) throws ClientProtocolException, IOException {
         HttpClient client = client();
 
@@ -215,6 +218,7 @@ public class HttpRequestGenerator {
         return CaseDBUtils.computeHash(CommCareApplication._().getUserStorage(ACase.STORAGE_KEY, ACase.class));
     }
 
+    @Override
     public HttpResponse postData(String url, MultipartEntity entity) throws ClientProtocolException, IOException {
         // setup client
         HttpClient httpclient = client();
@@ -288,6 +292,7 @@ public class HttpRequestGenerator {
         return url.getHost().equals(newUrl.getHost());
     }
 
+    @Override
     public InputStream simpleGet(URL url) throws IOException {
         if (android.os.Build.VERSION.SDK_INT > 11) {
             InputStream requestResult = makeModernRequest(url);
@@ -366,6 +371,7 @@ public class HttpRequestGenerator {
         con.setInstanceFollowRedirects(true);
     }
 
+    @Override
     public void abortCurrentRequest() {
         if (currentRequest != null) {
             try {

--- a/app/src/org/commcare/network/RemoteDataPullResponse.java
+++ b/app/src/org/commcare/network/RemoteDataPullResponse.java
@@ -5,6 +5,7 @@ import android.net.http.AndroidHttpClient;
 import android.util.Log;
 
 import org.apache.http.HttpResponse;
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.utils.AndroidStreamUtil;
 import org.commcare.utils.bitcache.BitCache;
@@ -27,27 +28,14 @@ public class RemoteDataPullResponse {
     private final HttpResponse response;
 
     /**
-     * Testing constructor used when overriding server dependent behavior
-     */
-    protected RemoteDataPullResponse(int responseCode) {
-        this.responseCode = responseCode;
-        this.task = null;
-        this.response = null;
-    }
-
-    /**
      * Makes data pulling request and keeps response for local caching
      *
-     * @param task             For progress reporting
-     * @param requestor        Handles making the http request
-     * @param server           Address of the request target
-     * @param includeSyncToken Add sync token to the request
+     * @param task     For progress reporting
+     * @param response Contains data pull response stream and status code
      */
     protected RemoteDataPullResponse(DataPullTask task,
-                                     HttpRequestGenerator requestor,
-                                     String server,
-                                     boolean includeSyncToken) throws IOException {
-        this.response = requestor.makeCaseFetchRequest(server, includeSyncToken);
+                                     HttpResponse response) throws IOException {
+        this.response = response;
         this.responseCode = response.getStatusLine().getStatusCode();
         this.task = task;
     }

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -16,11 +16,12 @@ import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.engine.cases.CaseUtils;
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.logging.analytics.GoogleAnalyticsFields;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.models.encryption.CryptUtil;
 import org.commcare.models.encryption.ByteEncrypter;
+import org.commcare.models.encryption.CryptUtil;
 import org.commcare.modern.models.RecordTooLargeException;
 import org.commcare.network.DataPullRequester;
 import org.commcare.network.DataPullResponseFactory;
@@ -104,7 +105,7 @@ public abstract class DataPullTask<R>
         this(username, password, server, context, false);
     }
 
-    private DataPullTask(String username, String password,
+    public DataPullTask(String username, String password,
                          String server, Context context,
                          DataPullRequester dataPullRequester) {
         this(username, password, server, context);
@@ -118,7 +119,7 @@ public abstract class DataPullTask<R>
             CommCareApplication._().releaseUserResourcesAndServices();
         }
     }
-    private HttpRequestGenerator requestor;
+    private HttpRequestEndpoints requestor;
 
     @Override
     protected ResultAndError<PullTaskResult> doTaskBackground(Void... params) {
@@ -158,7 +159,7 @@ public abstract class DataPullTask<R>
             //This should be per _user_, not per app
             prefs.edit().putLong("last-ota-restore", new Date().getTime()).commit();
 
-            requestor = new HttpRequestGenerator(username, password);
+            requestor = dataPullRequester.getHttpGenerator(username, password);
 
             AndroidTransactionParserFactory factory = new AndroidTransactionParserFactory(context, requestor) {
                 boolean publishedAuth = false;
@@ -386,7 +387,7 @@ public abstract class DataPullTask<R>
     }
 
     //TODO: This and the normal sync share a ton of code. It's hard to really... figure out the right way to 
-    private Pair<Integer, String> recover(HttpRequestGenerator requestor, AndroidTransactionParserFactory factory) {
+    private Pair<Integer, String> recover(HttpRequestEndpoints requestor, AndroidTransactionParserFactory factory) {
         this.publishProgress(PROGRESS_RECOVERY_NEEDED);
 
         Logger.log(AndroidLogger.TYPE_USER, "Sync Recovery Triggered");

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.logging.ForceCloseLogger;
+import org.commcare.android.resource.installers.XFormAndroidInstaller;
 import org.commcare.engine.extensions.CalendaredDateFormatHandler;
 import org.commcare.engine.extensions.IntentExtensionParser;
 import org.odk.collect.android.jr.extensions.PollSensorAction;
@@ -164,8 +165,7 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
         } catch (FileNotFoundException e) {
             throw new RuntimeException("Error reading XForm file");
         }
-        XFormParser.registerHandler("intent", new IntentExtensionParser());
-        XFormParser.registerActionHandler(PollSensorAction.ELEMENT_NAME, new PollSensorExtensionParser());
+        XFormAndroidInstaller.registerAndroidLevelFormParsers();
         FormDef fd = XFormExtensionUtils.getFormFromInputStream(fis);
         if (fd == null) {
             throw new RuntimeException("Error reading XForm file");

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -297,7 +297,7 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
             DataInputStream dis = new DataInputStream(new BufferedInputStream(fis));
 
             // read serialized formdef into new formdef
-            fd.readExternal(dis, DbUtil.getPrototypeFactory(context));
+            fd.readExternal(dis, CommCareApplication._().getPrototypeFactory(context));
             dis.close();
         } catch (Throwable e) {
             e.printStackTrace();

--- a/app/src/org/commcare/utils/SerializationUtil.java
+++ b/app/src/org/commcare/utils/SerializationUtil.java
@@ -33,7 +33,7 @@ public class SerializationUtil {
         T t;
         try {
             t = type.newInstance();
-            t.readExternal(new DataInputStream(new ByteArrayInputStream(bytes)), DbUtil.getPrototypeFactory(CommCareApplication._()));
+            t.readExternal(new DataInputStream(new ByteArrayInputStream(bytes)), CommCareApplication._().getPrototypeFactory(CommCareApplication._()));
         } catch (IOException | InstantiationException
                 | DeserializationException | IllegalAccessException e1) {
             e1.printStackTrace();

--- a/app/src/org/commcare/xml/AndroidCaseXmlParser.java
+++ b/app/src/org/commcare/xml/AndroidCaseXmlParser.java
@@ -9,6 +9,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 import org.commcare.CommCareApplication;
 import org.commcare.cases.model.Case;
 import org.commcare.engine.references.JavaHttpReference;
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.UserStorageClosedException;
 import org.commcare.android.database.user.models.ACase;
@@ -37,7 +38,7 @@ import java.io.IOException;
 public class AndroidCaseXmlParser extends CaseXmlParser {
     private File folder;
     private final boolean processAttachments = true;
-    private HttpRequestGenerator generator;
+    private HttpRequestEndpoints generator;
     private final EntityStorageCache mEntityCache;
     private final CaseIndexTable mCaseIndexTable;
 
@@ -54,7 +55,7 @@ public class AndroidCaseXmlParser extends CaseXmlParser {
 
     public AndroidCaseXmlParser(KXmlParser parser, int[] tallies,
                                 boolean b, IStorageUtilityIndexed<Case> storage,
-                                HttpRequestGenerator generator) {
+                                HttpRequestEndpoints generator) {
         super(parser, tallies, b, storage);
         this.generator = generator;
         mEntityCache = new EntityStorageCache("case");

--- a/app/src/org/commcare/xml/AndroidTransactionParserFactory.java
+++ b/app/src/org/commcare/xml/AndroidTransactionParserFactory.java
@@ -7,8 +7,8 @@ import org.commcare.cases.model.Case;
 import org.commcare.core.parse.CommCareTransactionParserFactory;
 import org.commcare.data.xml.TransactionParser;
 import org.commcare.data.xml.TransactionParserFactory;
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.models.database.AndroidSandbox;
-import org.commcare.network.HttpRequestGenerator;
 import org.commcare.utils.GlobalConstants;
 import org.kxml2.io.KXmlParser;
 
@@ -35,7 +35,7 @@ import java.util.Hashtable;
 public class AndroidTransactionParserFactory extends CommCareTransactionParserFactory {
 
     final private Context context;
-    final private HttpRequestGenerator generator;
+    final private HttpRequestEndpoints generator;
 
     private TransactionParserFactory formInstanceParser;
     private boolean caseIndexesWereDisrupted = false;
@@ -45,7 +45,7 @@ public class AndroidTransactionParserFactory extends CommCareTransactionParserFa
      */
     private Hashtable<String, String> formInstanceNamespaces;
 
-    public AndroidTransactionParserFactory(Context context, HttpRequestGenerator generator) {
+    public AndroidTransactionParserFactory(Context context, HttpRequestEndpoints generator) {
         super(new AndroidSandbox(CommCareApplication._()));
         this.context = context;
         this.generator = generator;

--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,9 @@ android {
             minifyEnabled true
             debuggable true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'app/proguard.cfg'
+            // used in test suite to build the prototype factory; otherwise unneeded
+            buildConfigField "String", "BUILD_DIR", "\"${buildDir}\""
+            buildConfigField "String", "PROJECT_DIR", "\"${projectDir}\""
         }
 
         release {

--- a/unit-tests/resources/commcare-apps/form_nav_tests/bad_xml_data_restore.xml
+++ b/unit-tests/resources/commcare-apps/form_nav_tests/bad_xml_data_restore.xml
@@ -1,0 +1,22 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account fp!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>fdb7c703321ce4c36e5d2c40f2b99621</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>
+            sha1$RTBRzfAJgfZN$dc8cfd249de9d52db04de48a8a8d251aaf3e9ace
+        </password>
+        <uuid>test</uuid>
+        <date>2015-07-22</date>
+        <user_data>
+            <data key="commcare_first_name"/>
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
+        </user_data>
+    </Registration>
+    <fixture id="user-groups" user_id="2ebaf997aecf7e6fcbb4c6f62e8c1648">
+        <groups/>
+    </asdfaasdsdfasdfassfixture>
+</OpenRosaResponse>

--- a/unit-tests/resources/commcare-apps/form_nav_tests/self_indexing_case_data_restore.xml
+++ b/unit-tests/resources/commcare-apps/form_nav_tests/self_indexing_case_data_restore.xml
@@ -1,0 +1,32 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account fp!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>fdb7c703321ce4c36e5d2c40f2b99621</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>
+            sha1$RTBRzfAJgfZN$dc8cfd249de9d52db04de48a8a8d251aaf3e9ace
+        </password>
+        <uuid>test</uuid>
+        <date>2015-07-22</date>
+        <user_data>
+            <data key="commcare_first_name"/>
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
+        </user_data>
+    </Registration>
+
+    <case case_id="the_parent_case"
+          date_modified="2016-02-03T16:20:49.734000Z" user_id="2ebaf997aecf7e6fcbb4c6f62e8c1648"
+          xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>pregnancy</case_type>
+            <case_name>helia</case_name>
+            <owner_id>2ebaf997aecf7e6fcbb4c6f62e8c1648</owner_id>
+        </create>
+        <index>
+            <parent case_type="test_case" relationship="child">the_parent_case</parent>
+        </index>
+    </case>
+</OpenRosaResponse>

--- a/unit-tests/resources/commcare-apps/form_nav_tests/simple_data_restore.xml
+++ b/unit-tests/resources/commcare-apps/form_nav_tests/simple_data_restore.xml
@@ -1,0 +1,46 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account fp!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>fdb7c703321ce4c36e5d2c40f2b99621</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>
+            sha1$RTBRzfAJgfZN$dc8cfd249de9d52db04de48a8a8d251aaf3e9ace
+        </password>
+        <uuid>test</uuid>
+        <date>2015-07-22</date>
+        <user_data>
+            <data key="commcare_first_name"/>
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
+        </user_data>
+    </Registration>
+    <fixture id="user-groups" user_id="2ebaf997aecf7e6fcbb4c6f62e8c1648">
+        <groups/>
+    </fixture>
+    <fixture id="item-list:name" user_id="2ebaf997aecf7e6fcbb4c6f62e8c1648">
+        <name_list/>
+    </fixture>
+    <fixture id="item-list:state" user_id="2ebaf997aecf7e6fcbb4c6f62e8c1648">
+        <state_list/>
+    </fixture>
+
+    <!-- Simple case transaction that doesn't correspond to anything in the app -->
+    <case case_id="679e34a6-ccd7-48bf-81f4-0decadd958f8"
+          date_modified="2016-02-03T16:20:49.734000Z" user_id="2ebaf997aecf7e6fcbb4c6f62e8c1648"
+          xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>pregnancy</case_type>
+            <case_name>helia</case_name>
+            <owner_id>2ebaf997aecf7e6fcbb4c6f62e8c1648</owner_id>
+        </create>
+        <update>
+            <feeling_sick>no</feeling_sick>
+            <living_children>yes</living_children>
+            <lmp>2015-12-03</lmp>
+            <total_children/>
+            <village_name>s</village_name>
+        </update>
+    </case>
+</OpenRosaResponse>

--- a/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -1,14 +1,28 @@
 package org.commcare;
 
+import android.content.Context;
+import android.util.Log;
+
+import org.commcare.models.AndroidPrototypeFactory;
+import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.HybridFileBackedSqlStorage;
 import org.commcare.models.database.HybridFileBackedSqlStorageMock;
 import org.javarosa.core.services.storage.Persistable;
+import org.javarosa.core.util.PrefixTree;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.junit.Assert;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class CommCareTestApplication extends CommCareApplication {
+    private static final String TAG = CommCareTestApplication.class.getSimpleName();
+    private static PrototypeFactory testPrototypeFactor;
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -35,4 +49,66 @@ public class CommCareTestApplication extends CommCareApplication {
     public CommCareApp getCurrentApp() {
         return new CommCareTestApp(super.getCurrentApp());
     }
+
+    @Override
+    public PrototypeFactory getPrototypeFactory(Context c) {
+        if (testPrototypeFactor != null) {
+            return testPrototypeFactor;
+        }
+
+        ArrayList<String> classNames = new ArrayList<>();
+        String baseODK = "/home/mates/dimagi/commcare-odk/build/intermediates/classes/commcare/debug/";
+        String baseJR = "/home/mates/dimagi/javarosa/build/classes/main/";
+        String baseCC = "/home/mates/dimagi/commcare/build/classes/main/";
+        processTest(baseODK, classNames);
+        processTest(baseCC, classNames);
+        processTest(baseJR, classNames);
+        PrefixTree tree = new PrefixTree();
+
+        try {
+            for (String cl : classNames) {
+                tree.addString(cl);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        testPrototypeFactor = new AndroidPrototypeFactory(tree);
+        return testPrototypeFactor;
+    }
+
+
+    private static void processTest(String baseClassPath, List<String> list) {
+        ArrayList<String> classNames = new ArrayList<>();
+        try {
+            File f = new File(baseClassPath);
+            ArrayList<File> files = new ArrayList<>();
+            getFilesInDir(f, files);
+            for (File file : files) {
+                String fullName = file.getAbsolutePath();
+                String className1 = fullName.replace(baseClassPath, "");
+                String className2 = className1.replace("/", ".").replace(".class", "");
+                String className3 = className2.replace(".class", "");
+                classNames.add(className3);
+            }
+        } catch (Exception e) {
+            Log.w(TAG, e.getMessage());
+        }
+
+        for (String className : classNames) {
+            DbUtil.loadClass(className, list);
+        }
+        Log.w(TAG, classNames.get(0));
+    }
+
+    private static void getFilesInDir(File currentFile, ArrayList<File> acc) {
+        for (File f : currentFile.listFiles()) {
+            if (f.isFile()) {
+                acc.add(f);
+            } else {
+                getFilesInDir(f, acc);
+            }
+        }
+    }
+
 }

--- a/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -3,10 +3,12 @@ package org.commcare;
 import android.content.Context;
 import android.util.Log;
 
+import org.commcare.android.util.TestUtils;
 import org.commcare.models.AndroidPrototypeFactory;
 import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.HybridFileBackedSqlStorage;
 import org.commcare.models.database.HybridFileBackedSqlStorageMock;
+import org.commcare.models.database.SqlStorage;
 import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.PrefixTree;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -52,6 +54,8 @@ public class CommCareTestApplication extends CommCareApplication {
 
     @Override
     public PrototypeFactory getPrototypeFactory(Context c) {
+        TestUtils.disableSqlOptimizations();
+
         if (testPrototypeFactor != null) {
             return testPrototypeFactor;
         }

--- a/unit-tests/src/org/commcare/android/mocks/HttpRequestEndpointsMock.java
+++ b/unit-tests/src/org/commcare/android/mocks/HttpRequestEndpointsMock.java
@@ -1,0 +1,56 @@
+package org.commcare.android.mocks;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.entity.mime.MultipartEntity;
+import org.commcare.interfaces.HttpRequestEndpoints;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Mocks for different types of http requests commcare mobile makes to the server
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class HttpRequestEndpointsMock implements HttpRequestEndpoints {
+    private static List<Integer> caseFetchResponseCodeStack = new ArrayList<>();
+
+    /**
+     * Set the response code for the next N requests
+     */
+    public static void setCaseFetchResponseCodes(Integer[] responseCodes) {
+        caseFetchResponseCodeStack.clear();
+        Collections.addAll(caseFetchResponseCodeStack, responseCodes);
+    }
+
+    @Override
+    public HttpResponse makeCaseFetchRequest(String baseUri, boolean includeStateFlags) throws ClientProtocolException, IOException {
+        return HttpResponseMock.buildHttpResponseMock(caseFetchResponseCodeStack.remove(0));
+    }
+
+    @Override
+    public HttpResponse makeKeyFetchRequest(String baseUri, Date lastRequest) throws ClientProtocolException, IOException {
+        throw new RuntimeException("Not yet mocked");
+    }
+
+    @Override
+    public HttpResponse postData(String url, MultipartEntity entity) throws ClientProtocolException, IOException {
+        throw new RuntimeException("Not yet mocked");
+    }
+
+    @Override
+    public InputStream simpleGet(URL url) throws IOException {
+        throw new RuntimeException("Not yet mocked");
+    }
+
+    @Override
+    public void abortCurrentRequest() {
+        throw new RuntimeException("Not yet mocked");
+    }
+}

--- a/unit-tests/src/org/commcare/android/mocks/HttpResponseMock.java
+++ b/unit-tests/src/org/commcare/android/mocks/HttpResponseMock.java
@@ -1,0 +1,172 @@
+package org.commcare.android.mocks;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.params.HttpParams;
+
+import java.util.Locale;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class HttpResponseMock {
+    public static HttpResponse buildHttpResponseMock(final int statusCode) {
+        return new HttpResponse() {
+            private final StatusLine statusLine = new StatusLine() {
+                @Override
+                public ProtocolVersion getProtocolVersion() {
+                    return null;
+                }
+
+                @Override
+                public int getStatusCode() {
+                    return statusCode;
+                }
+
+                @Override
+                public String getReasonPhrase() {
+                    return null;
+                }
+            };
+
+            @Override
+            public StatusLine getStatusLine() {
+                return statusLine;
+            }
+
+            @Override
+            public void setStatusLine(StatusLine statusLine) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setStatusLine(ProtocolVersion protocolVersion, int i) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setStatusLine(ProtocolVersion protocolVersion, int i, String s) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setStatusCode(int i) throws IllegalStateException {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setReasonPhrase(String s) throws IllegalStateException {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public HttpEntity getEntity() {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setEntity(HttpEntity httpEntity) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public Locale getLocale() {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setLocale(Locale locale) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public ProtocolVersion getProtocolVersion() {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public boolean containsHeader(String s) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public Header[] getHeaders(String s) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public Header getFirstHeader(String s) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public Header getLastHeader(String s) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public Header[] getAllHeaders() {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void addHeader(Header header) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void addHeader(String s, String s1) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setHeader(Header header) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setHeader(String s, String s1) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setHeaders(Header[] headers) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void removeHeader(Header header) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void removeHeaders(String s) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public HeaderIterator headerIterator() {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public HeaderIterator headerIterator(String s) {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public HttpParams getParams() {
+                throw new RuntimeException("not supported in mock");
+            }
+
+            @Override
+            public void setParams(HttpParams httpParams) {
+                throw new RuntimeException("not supported in mock");
+            }
+        };
+    }
+}

--- a/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
+++ b/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
@@ -1,0 +1,165 @@
+package org.commcare.android.tests;
+
+import org.commcare.CommCareApp;
+import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
+import org.commcare.android.CommCareTestRunner;
+import org.commcare.android.mocks.HttpRequestEndpointsMock;
+import org.commcare.android.util.TestAppInstaller;
+import org.commcare.dalvik.BuildConfig;
+import org.commcare.tasks.DataPullTask;
+import org.commcare.tasks.ResultAndError;
+import org.commcare.tasks.network.DebugDataPullResponseFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+/**
+ * Coverage for different DataPullTask codepaths.
+ * Doesn't yet check logical correctness of any actions.
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+@Config(application = CommCareTestApplication.class,
+        constants = BuildConfig.class)
+@RunWith(CommCareTestRunner.class)
+public class DataPullTaskTest {
+    private final static String APP_BASE = "jr://resource/commcare-apps/form_nav_tests/";
+    private final static String GOOD_RESTORE = APP_BASE + "simple_data_restore.xml";
+    private final static String BAD_RESTORE_XML = APP_BASE + "bad_xml_data_restore.xml";
+    private final static String SELF_INDEXING_CASE_RESTORE = APP_BASE + "self_indexing_case_data_restore.xml";
+
+    /**
+     * Stores the result of the data pull task
+     *
+     * TODO PLM: refactor from static setter to allow parallel execution.
+     * requires making a smarter task connector
+     */
+    private static ResultAndError<DataPullTask.PullTaskResult> dataPullResult;
+
+    @Test
+    public void dataPullWithMissingRemoteKeyRecordTest() {
+        TestAppInstaller.installApp(APP_BASE + "profile.ccpr");
+        runDataPull(200, GOOD_RESTORE);
+        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+        Assert.assertEquals("Unable to generate encryption key", dataPullResult.errorMessage);
+    }
+
+    @Test
+    public void dataPullWithLocalKeysTest() {
+        installAndUseLocalKeys();
+        runDataPull(200, GOOD_RESTORE);
+    }
+
+    @Test
+    public void dataPullServerErrorTest() {
+        installAndUseLocalKeys();
+        runDataPull(500, GOOD_RESTORE);
+        Assert.assertEquals(DataPullTask.PullTaskResult.SERVER_ERROR, dataPullResult.data);
+    }
+
+    @Test
+    public void dataPullAuthFailedTest() {
+        installAndUseLocalKeys();
+        runDataPull(401, GOOD_RESTORE);
+        Assert.assertEquals(DataPullTask.PullTaskResult.AUTH_FAILED, dataPullResult.data);
+    }
+
+    @Test
+    public void dataPullRecoverTest() {
+        installLoginAndUseLocalKeys();
+        runDataPull(new Integer[]{412, 200}, new String[]{GOOD_RESTORE, GOOD_RESTORE});
+        Assert.assertEquals(DataPullTask.PullTaskResult.DOWNLOAD_SUCCESS, dataPullResult.data);
+    }
+
+    @Test
+    public void dataPullRecoverFailTest() {
+        installLoginAndUseLocalKeys();
+        runDataPull(new Integer[]{412, 500}, new String[]{GOOD_RESTORE, GOOD_RESTORE});
+        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+    }
+
+    @Test
+    public void dataPullRecoverFailLoginNeededTest() {
+        installWithUserAndUseLocalKeys();
+        runDataPull(new Integer[]{412, 500}, new String[]{GOOD_RESTORE, GOOD_RESTORE});
+        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+    }
+
+    @Test
+    public void dataPullBadRecoverPayloadTest() {
+        installLoginAndUseLocalKeys();
+        runDataPull(new Integer[]{412, 200}, new String[]{GOOD_RESTORE, BAD_RESTORE_XML});
+        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+    }
+
+    @Test
+    public void dataPullBadRestoreXMLTest() {
+        installAndUseLocalKeys();
+        runDataPull(200, BAD_RESTORE_XML);
+        Assert.assertEquals(DataPullTask.PullTaskResult.BAD_DATA, dataPullResult.data);
+    }
+
+    @Test
+    public void dataPullSelfIndexingCaseTest() {
+        installAndUseLocalKeys();
+        runDataPull(200, SELF_INDEXING_CASE_RESTORE);
+        Assert.assertEquals(DataPullTask.PullTaskResult.BAD_DATA_REQUIRES_INTERVENTION, dataPullResult.data);
+    }
+
+    private static void runDataPull(Integer resultCode, String payloadResource) {
+        runDataPull(new Integer[]{resultCode}, new String[]{payloadResource});
+    }
+
+    private static void runDataPull(Integer[] resultCodes, String[] payloadResources) {
+        HttpRequestEndpointsMock.setCaseFetchResponseCodes(resultCodes);
+
+        DebugDataPullResponseFactory dataPullRequestor =
+                new DebugDataPullResponseFactory(payloadResources);
+        DataPullTask<Object> task =
+                new DataPullTask<Object>("test", "123", "fake.server.com", RuntimeEnvironment.application, dataPullRequestor) {
+                    @Override
+                    protected void deliverResult(Object o, ResultAndError<PullTaskResult> pullTaskResultResultAndError) {
+                        dataPullResult = pullTaskResultResultAndError;
+                    }
+
+                    @Override
+                    protected void deliverUpdate(Object o, Integer... update) {
+
+                    }
+
+                    @Override
+                    protected void deliverError(Object o, Exception e) {
+
+                    }
+                };
+        task.connect(TestAppInstaller.fakeConnector);
+        task.execute();
+
+        Robolectric.flushBackgroundThreadScheduler();
+        Robolectric.flushForegroundThreadScheduler();
+    }
+
+    private void installAndUseLocalKeys() {
+        TestAppInstaller.installApp(APP_BASE + "profile.ccpr");
+        useLocalKeys();
+    }
+
+    private void installLoginAndUseLocalKeys() {
+        TestAppInstaller.installAppAndLogin(APP_BASE + "profile.ccpr", "test", "123");
+        useLocalKeys();
+    }
+
+    private void installWithUserAndUseLocalKeys() {
+        TestAppInstaller.installAppAndUser(APP_BASE + "profile.ccpr", "test", "123");
+        useLocalKeys();
+    }
+
+    private static void useLocalKeys() {
+        CommCareApp app = CommCareApplication._().getCurrentApp();
+        app.getAppPreferences().edit().putString("key_server", null).commit();
+    }
+}

--- a/unit-tests/src/org/commcare/android/tests/application/AppInitializationTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AppInitializationTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.application;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestAppInstaller;
 import org.commcare.dalvik.BuildConfig;
@@ -17,14 +18,14 @@ import org.robolectric.annotation.Config;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-@Config(application = CommCareApplication.class,
+@Config(application = CommCareTestApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class AppInitializationTest {
 
     @Before
     public void setup() {
-        TestAppInstaller.initInstallAndLogin(
+        TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/archive_form_tests/profile.ccpr",
                 "test",
                 "123");

--- a/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
@@ -3,6 +3,7 @@ package org.commcare.android.tests.application;
 import android.util.Log;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestAppInstaller;
 import org.commcare.dalvik.BuildConfig;
@@ -27,7 +28,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Phillip Mates (pmates@dimagi.com).
  */
-@Config(application = CommCareApplication.class,
+@Config(application = CommCareTestApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class AppUpdateTest {
@@ -36,7 +37,7 @@ public class AppUpdateTest {
 
     @Before
     public void setup() {
-        TestAppInstaller.initInstallAndLogin(
+        TestAppInstaller.installAppAndLogin(
                 buildResourceRef("base_app", "profile.ccpr"),
                 "test", "123");
 

--- a/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
@@ -4,6 +4,7 @@ import android.text.format.DateUtils;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestAppInstaller;
 import org.commcare.dalvik.BuildConfig;
@@ -14,8 +15,6 @@ import org.commcare.suite.model.Profile;
 import org.commcare.tasks.TaskListener;
 import org.commcare.tasks.TaskListenerRegistrationException;
 import org.commcare.tasks.UpdateTask;
-import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,7 +33,7 @@ import static org.junit.Assert.fail;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-@Config(application = CommCareApplication.class,
+@Config(application = CommCareTestApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class AutoUpdateTest {
@@ -85,7 +84,7 @@ public class AutoUpdateTest {
     }
 
     private void installBaseApp() {
-        TestAppInstaller.initInstallAndLogin(
+        TestAppInstaller.installAppAndLogin(
                 buildResourceRef("base_app", "profile.ccpr"),
                 username, password);
 

--- a/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
+++ b/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
@@ -6,12 +6,12 @@ import android.util.Log;
 import android.widget.ImageButton;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.activities.CommCareHomeActivity;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.mocks.FormAndDataSyncerFake;
 import org.commcare.android.util.TestAppInstaller;
-import org.commcare.android.util.TestUtils;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.commcare.models.AndroidSessionWrapper;
@@ -21,8 +21,6 @@ import org.commcare.session.CommCareSession;
 import org.commcare.session.SessionNavigator;
 import org.commcare.views.QuestionsView;
 import org.commcare.views.widgets.IntegerWidget;
-import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +36,7 @@ import static junit.framework.Assert.assertTrue;
 /**
  * @author Phillip Mates (pmates@dimagi.com).
  */
-@Config(application = CommCareApplication.class,
+@Config(application = CommCareTestApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class EndOfFormTest {
@@ -47,7 +45,7 @@ public class EndOfFormTest {
 
     @Before
     public void setup() {
-        TestAppInstaller.initInstallAndLogin(
+        TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/form_nav_tests/profile.ccpr",
                 "test", "123");
         ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);

--- a/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
+++ b/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import android.widget.ImageButton;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.activities.CommCareHomeActivity;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.CommCareTestRunner;
@@ -43,7 +44,7 @@ import static junit.framework.Assert.assertTrue;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-@Config(application = CommCareApplication.class,
+@Config(application = CommCareTestApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class FormRecordProcessingTest {
@@ -51,7 +52,7 @@ public class FormRecordProcessingTest {
 
     @Before
     public void setup() {
-        TestAppInstaller.initInstallAndLogin(
+        TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/form_save_regressions/profile.ccpr",
                 "test", "123");
         ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);

--- a/unit-tests/src/org/commcare/android/tests/processing/ArchivedFormPurgeTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/ArchivedFormPurgeTest.java
@@ -2,13 +2,12 @@ package org.commcare.android.tests.processing;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.SavedFormLoader;
 import org.commcare.android.util.TestAppInstaller;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.tasks.PurgeStaleArchivedFormsTask;
-import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -24,14 +23,14 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-@Config(application = CommCareApplication.class,
+@Config(application = CommCareTestApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class ArchivedFormPurgeTest {
 
     @Before
     public void setup() {
-        TestAppInstaller.initInstallAndLogin(
+        TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/archive_form_tests/profile.ccpr",
                 "test", "123");
 

--- a/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -1,7 +1,8 @@
 package org.commcare.android.tests.processing;
 
-import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
+import org.commcare.android.resource.installers.XFormAndroidInstaller;
 import org.commcare.android.util.TestUtils;
 import org.commcare.dalvik.BuildConfig;
 import org.javarosa.core.model.FormDef;
@@ -20,13 +21,14 @@ import java.io.IOException;
  *
  * @author ctsims
  */
-@Config(application = CommCareApplication.class,
+@Config(application = CommCareTestApplication.class,
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class FormStorageTest {
+
     @Before
-    public void setupTests() {
-        TestUtils.initializeStaticTestStorage();
+    public void setup() {
+        XFormAndroidInstaller.registerAndroidLevelFormParsers();
     }
 
     @Test

--- a/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
+++ b/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
@@ -53,9 +53,6 @@ public class TestAppInstaller {
         // needed to resolve "jr://resource" type references
         ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
 
-        TestUtils.initializeStaticTestStorage();
-        TestAppInstaller.setupPrototypeFactory();
-
         TestAppInstaller appTestInstaller =
                 new TestAppInstaller(
                         appPath, username, password);
@@ -125,11 +122,5 @@ public class TestAppInstaller {
             }
         }
         return null;
-    }
-
-    private static void setupPrototypeFactory() {
-        // Sets DB to use an in-memory store for class serialization tagging.
-        // This avoids the need to use apk reflection to perform read/writes
-        TestUtils.initializeStaticTestStorage();
     }
 }

--- a/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
+++ b/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
@@ -3,14 +3,12 @@ package org.commcare.android.util;
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.CommCareTestApp;
-import org.commcare.android.mocks.CommCareTaskConnectorFake;
-import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.global.models.ApplicationRecord;
+import org.commcare.android.mocks.CommCareTaskConnectorFake;
+import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.models.database.user.DemoUserBuilder;
-import org.commcare.services.CommCareSessionService;
 import org.commcare.tasks.ResourceEngineTask;
-import org.javarosa.core.model.User;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.util.PropertyUtils;
@@ -28,7 +26,7 @@ public class TestAppInstaller {
     private final String password;
     private final String resourceFilepath;
 
-    private final CommCareTaskConnectorFake<Object> fakeConnector =
+    public final static CommCareTaskConnectorFake<Object> fakeConnector =
             new CommCareTaskConnectorFake<>();
 
     private TestAppInstaller(String resourceFilepath,
@@ -39,24 +37,43 @@ public class TestAppInstaller {
         this.password = password;
     }
 
-    private void installAppAndLogin() {
-        installApp();
-
-        buildTestUser();
-
+    /**
+     * Install an app and create / login with a (test) user
+     */
+    public static void installAppAndLogin(String appPath,
+                                          String username,
+                                          String password) {
+        installAppAndUser(appPath, username, password);
         login(username, password);
     }
 
-    public static void initInstallAndLogin(String appPath,
-                                           String username,
-                                           String password) {
-        // needed to resolve "jr://resource" type references
-        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
+    /**
+     * Install an app without creating a user
+     */
+    public static void installApp(String appPath) {
+        storageSetup();
+        TestAppInstaller appTestInstaller =
+                new TestAppInstaller(appPath, null, null);
+        appTestInstaller.installApp();
+    }
 
+    /**
+     * Install an app with creating a user
+     */
+    public static void installAppAndUser(String appPath,
+                                         String username,
+                                         String password) {
+        storageSetup();
         TestAppInstaller appTestInstaller =
                 new TestAppInstaller(
                         appPath, username, password);
-        appTestInstaller.installAppAndLogin();
+        appTestInstaller.installApp();
+        appTestInstaller.buildTestUser();
+    }
+
+    private static void storageSetup() {
+        // needed to resolve "jr://resource" type references
+        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
     }
 
     private void installApp() {
@@ -101,26 +118,6 @@ public class TestAppInstaller {
         CommCareApp ccApp = CommCareApplication._().getCurrentApp();
         UserKeyRecord keyRecord =
                 UserKeyRecord.getCurrentValidRecordByPassword(ccApp, username, password, true);
-        startSessionService(keyRecord, password);
-    }
-
-    private static void startSessionService(UserKeyRecord keyRecord, String password) {
-        // manually create/setup session service because robolectric doesn't
-        // really support services
-        CommCareSessionService ccService = new CommCareSessionService();
-        ccService.createCipherPool();
-        ccService.prepareStorage(keyRecord.unWrapKey(password), keyRecord);
-        ccService.startSession(getUserFromDb(ccService, keyRecord), keyRecord);
-
-        CommCareApplication._().setTestingService(ccService);
-    }
-
-    private static User getUserFromDb(CommCareSessionService ccService, UserKeyRecord keyRecord) {
-        for (User u : CommCareApplication._().getRawStorage("USER", User.class, ccService.getUserDbHandle())) {
-            if (keyRecord.getUsername().equals(u.getUsername())) {
-                return u;
-            }
-        }
-        return null;
+        CommCareApplication._().startUserSession(keyRecord.unWrapKey(password), keyRecord, false);
     }
 }

--- a/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -57,9 +57,12 @@ public class TestUtils {
         //based on an optimized md5 hasher. Major speed improvements.
         DbUtil.setDBUtilsPrototypeFactory(new LivePrototypeFactory(new AndroidClassHasher()));
         AndroidUtil.initializeStaticHandlers();
-        
+        disableSqlOptimizations();
+    }
+
+    public static void disableSqlOptimizations() {
         // For now, disable the optimizations, since they require in-depth SQL code that
-        // we need better shadows for 
+        // we need better shadows for
         SqlStorage.STORAGE_OPTIMIZATIONS_ACTIVE = false;
     }
     

--- a/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -3,6 +3,7 @@ package org.commcare.android.util;
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.data.xml.TransactionParser;
 import org.commcare.data.xml.TransactionParserFactory;
@@ -160,7 +161,7 @@ public class TestUtils {
     }
 
     public static PrototypeFactory getStaticPrototypeFactory(){
-        return DbUtil.getPrototypeFactory(RuntimeEnvironment.application);
+        return CommCareTestApplication._().getPrototypeFactory(RuntimeEnvironment.application);
     }
     
     /**

--- a/unit-tests/src/org/commcare/models/database/StoreFixturesOnFilesystemTests.java
+++ b/unit-tests/src/org/commcare/models/database/StoreFixturesOnFilesystemTests.java
@@ -4,13 +4,10 @@ import org.commcare.CommCareApplication;
 import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestAppInstaller;
-import org.commcare.android.util.TestUtils;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.xml.AndroidTransactionParserFactory;
 import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.services.storage.EntityFilter;
 import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.IStorageUtility;
@@ -53,7 +50,7 @@ public class StoreFixturesOnFilesystemTests {
     }
 
     public static AndroidSandbox installAppWithFixtureData(Class testClass, String fixtureResource) {
-        TestAppInstaller.initInstallAndLogin(
+        TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/archive_form_tests/profile.ccpr",
                 "test", "123");
 

--- a/unit-tests/src/org/commcare/tasks/network/DebugDataPullResponse.java
+++ b/unit-tests/src/org/commcare/tasks/network/DebugDataPullResponse.java
@@ -1,5 +1,6 @@
 package org.commcare.tasks.network;
 
+import org.apache.http.HttpResponse;
 import org.commcare.network.RemoteDataPullResponse;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
@@ -15,8 +16,9 @@ import java.io.InputStream;
 public class DebugDataPullResponse extends RemoteDataPullResponse {
     private InputStream debugStream = null;
 
-    public DebugDataPullResponse(String xmlPayloadReference) throws IOException {
-        super(200);
+    public DebugDataPullResponse(String xmlPayloadReference,
+                                 HttpResponse response) throws IOException {
+        super(null, response);
 
         try {
             debugStream =

--- a/unit-tests/src/org/commcare/tasks/network/DebugDataPullResponseFactory.java
+++ b/unit-tests/src/org/commcare/tasks/network/DebugDataPullResponseFactory.java
@@ -1,11 +1,16 @@
 package org.commcare.tasks.network;
 
+import org.apache.http.HttpResponse;
+import org.commcare.android.mocks.HttpRequestEndpointsMock;
+import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.network.DataPullRequester;
-import org.commcare.network.HttpRequestGenerator;
 import org.commcare.network.RemoteDataPullResponse;
 import org.commcare.tasks.DataPullTask;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Builds data pull requester that gets data from a local reference.
@@ -13,17 +18,24 @@ import java.io.IOException;
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class DebugDataPullResponseFactory implements DataPullRequester {
-    private final String xmlPayloadReference;
+    // data pull requests will pop off and use the top reference in this list
+    private final List<String> xmlPayloadReferences = new ArrayList<>();
 
-    public DebugDataPullResponseFactory(String xmlPayloadReference) {
-        this.xmlPayloadReference = xmlPayloadReference;
+    public DebugDataPullResponseFactory(String[] payloadReferences) {
+        Collections.addAll(xmlPayloadReferences, payloadReferences);
     }
 
     @Override
     public RemoteDataPullResponse makeDataPullRequest(DataPullTask task,
-                                                      HttpRequestGenerator requestor,
+                                                      HttpRequestEndpoints requestor,
                                                       String server,
                                                       boolean includeSyncToken) throws IOException {
-        return new DebugDataPullResponse(xmlPayloadReference);
+        HttpResponse response = requestor.makeCaseFetchRequest(server, includeSyncToken);
+        return new DebugDataPullResponse(xmlPayloadReferences.remove(0), response);
+    }
+
+    @Override
+    public HttpRequestEndpoints getHttpGenerator(String username, String password) {
+        return new HttpRequestEndpointsMock();
     }
 }


### PR DESCRIPTION
Make sure Robolectric tests that use `CommCareTestApplication` share more prototype factory code with the live app.

Would have caught the bug fixed by https://github.com/dimagi/commcare-odk/pull/1215 

Includes commits from https://github.com/dimagi/commcare-odk/pull/1224