### PR TITLE
Make form save not fire all form triggers the default

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -67,7 +67,7 @@
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
-        android:defaultValue="yes"
+        android:defaultValue="no"
         android:key="cc-fire-triggers-on-save"
         android:title="Fire triggers on form save"/>
     <ListPreference

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -202,7 +202,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
 
     public static boolean shouldFireTriggersOnSave() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
-        return properties.getString(FIRE_TRIGGERS_ON_SAVE, CommCarePreferences.YES).equals(CommCarePreferences.YES);
+        return properties.getString(FIRE_TRIGGERS_ON_SAVE, CommCarePreferences.NO).equals(CommCarePreferences.YES);
     }
 
     public static boolean isAutoLoginEnabled() {


### PR DESCRIPTION
Currently, when you save a form on CommCare for Android, it walks through all questions, re-answering them and firing all associated triggers. So if you have iteration in your form, it will step through everything again, potentially taking a long time. This behavior is a data assurance measure.

We have fixed some bugs that made this refiring required and verified that it is no longer needed. Hence, it is time to enable it by default. I'm leaving the dev option listed in the off chance that someone needs to quickly disable the optimization to check if it is messing with form save behavior.

ICDS and TDH have done QA to check that enabling this optimization is okay in terms of exhibiting the same form save behavior. We have also done a standard round of QA (by accident) with this optimization enabled, not that we checked the form xml closely.