### PR TITLE
Hide form submit button animation behind feature flag

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -74,6 +74,13 @@
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
+        android:defaultValue="no"
+        android:key="cc-animate-form-submit-button"
+        android:title="Animate form submit button"/>
+    <ListPreference
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
         android:key="cc-home-report"
         android:title="Home Report Button enabled"/>
     <ListPreference

--- a/app/src/org/commcare/activities/components/FormNavigationUI.java
+++ b/app/src/org/commcare/activities/components/FormNavigationUI.java
@@ -23,6 +23,7 @@ import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.dalvik.R;
 import org.commcare.logic.FormController;
+import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.views.ClippingFrame;
 import org.commcare.views.QuestionsView;
 import org.commcare.views.UserfacingErrorHandling;
@@ -88,15 +89,20 @@ public class FormNavigationUI {
                                      final ClippingFrame finishButton,
                                      FormNavigationController.NavigationDetails details,
                                      ProgressBar progressBar) {
-        if(nextButton.getTag() == null) {
-            setFinishVisible(finishButton);
-        }else if(!FormEntryActivity.NAV_STATE_DONE.equals(nextButton.getTag())) {
-            nextButton.setTag(FormEntryActivity.NAV_STATE_DONE);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                expandAndShowFinishButton(context, finishButton);
-            } else {
+        if (DeveloperPreferences.shouldAnimateFormSubmitButton()) {
+            if (nextButton.getTag() == null) {
                 setFinishVisible(finishButton);
+            } else if (!FormEntryActivity.NAV_STATE_DONE.equals(nextButton.getTag())) {
+                nextButton.setTag(FormEntryActivity.NAV_STATE_DONE);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                    expandAndShowFinishButton(context, finishButton);
+                } else {
+                    setFinishVisible(finishButton);
+                }
             }
+        } else {
+            nextButton.setImageResource(R.drawable.icon_chevron_right_attnpos);
+            nextButton.setTag(FormEntryActivity.NAV_STATE_DONE);
         }
 
         progressBar.setProgressDrawable(context.getResources().getDrawable(R.drawable.progressbar_full));
@@ -144,11 +150,16 @@ public class FormNavigationUI {
                                               ClippingFrame finishButton,
                                               FormNavigationController.NavigationDetails details,
                                               ProgressBar progressBar) {
-        if(!FormEntryActivity.NAV_STATE_NEXT.equals(nextButton.getTag())) {
-            nextButton.setTag(FormEntryActivity.NAV_STATE_NEXT);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                finishButton.setVisibility(View.GONE);
+        if (DeveloperPreferences.shouldAnimateFormSubmitButton()) {
+            if (!FormEntryActivity.NAV_STATE_NEXT.equals(nextButton.getTag())) {
+                nextButton.setTag(FormEntryActivity.NAV_STATE_NEXT);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                    finishButton.setVisibility(View.GONE);
+                }
             }
+        } else {
+            nextButton.setImageResource(R.drawable.icon_chevron_right_brand);
+            nextButton.setTag(FormEntryActivity.NAV_STATE_NEXT);
         }
 
         progressBar.setProgressDrawable(context.getResources().getDrawable(R.drawable.progressbar_modern));

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -90,6 +90,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_MARKDOWN = "Markdown Enabled";
     public static final String LABEL_IMAGE_ABOVE_TEXT = "Image Above Question Text Enabled";
     public static final String LABEL_TRIGGERS_ON_SAVE = "Fire triggers on form save";
+    public static final String LABEL_ANIMATE_FORM_SUBMIT_BUTTON = "Animate form submit button";
     public static final String LABEL_REPORT_BUTTON_ENABLED = "Home Report Button enabled";
     public static final String LABEL_AUTO_PURGE = "Auto Purge on Save Enabled";
     public static final String LABEL_LOAD_FORM_PAYLOAD_AS = "Load form payload as";

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -47,6 +47,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
      * triggers.
      */
     public final static String FIRE_TRIGGERS_ON_SAVE = "cc-fire-triggers-on-save";
+    public final static String ANIMATE_FORM_SUBMIT_BUTTON = "cc-animate-form-submit-button";
     public final static String ALTERNATE_QUESTION_LAYOUT_ENABLED = "cc-alternate-question-text-format";
 
     public final static String OFFER_PIN_FOR_LOGIN = "cc-offer-pin-for-login";
@@ -82,6 +83,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefKeyToAnalyticsEvent.put(MARKDOWN_ENABLED, GoogleAnalyticsFields.LABEL_MARKDOWN);
         prefKeyToAnalyticsEvent.put(ALTERNATE_QUESTION_LAYOUT_ENABLED, GoogleAnalyticsFields.LABEL_IMAGE_ABOVE_TEXT);
         prefKeyToAnalyticsEvent.put(FIRE_TRIGGERS_ON_SAVE, GoogleAnalyticsFields.LABEL_TRIGGERS_ON_SAVE);
+        prefKeyToAnalyticsEvent.put(ANIMATE_FORM_SUBMIT_BUTTON, GoogleAnalyticsFields.LABEL_ANIMATE_FORM_SUBMIT_BUTTON);
         prefKeyToAnalyticsEvent.put(HOME_REPORT_ENABLED, GoogleAnalyticsFields.LABEL_REPORT_BUTTON_ENABLED);
         prefKeyToAnalyticsEvent.put(AUTO_PURGE_ENABLED, GoogleAnalyticsFields.LABEL_AUTO_PURGE);
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
@@ -203,6 +205,11 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean shouldFireTriggersOnSave() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
         return properties.getString(FIRE_TRIGGERS_ON_SAVE, CommCarePreferences.YES).equals(CommCarePreferences.YES);
+    }
+
+    public static boolean shouldAnimateFormSubmitButton() {
+        SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
+        return properties.getString(ANIMATE_FORM_SUBMIT_BUTTON, CommCarePreferences.YES).equals(CommCarePreferences.YES);
     }
 
     public static boolean isAutoLoginEnabled() {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -209,7 +209,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
 
     public static boolean shouldAnimateFormSubmitButton() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
-        return properties.getString(ANIMATE_FORM_SUBMIT_BUTTON, CommCarePreferences.YES).equals(CommCarePreferences.YES);
+        return properties.getString(ANIMATE_FORM_SUBMIT_BUTTON, CommCarePreferences.NO).equals(CommCarePreferences.YES);
     }
 
     public static boolean isAutoLoginEnabled() {


### PR DESCRIPTION
Make form submission button animation disabled by default, but allow it being enabled by the "Animate form submit button" developer option. You can enable at the app level by setting the `cc-animate-form-submit-button` custom property to `yes`

Allows the UI changes in https://github.com/dimagi/commcare-odk/pull/1133 to be field tested before being deployed widely