### PR TITLE
Fix issue where install checkmark was blue instead of green

### DIFF
--- a/app/res/drawable/check_update.xml
+++ b/app/res/drawable/check_update.xml
@@ -5,5 +5,5 @@
         android:viewportHeight="232.5">
     <path
         android:pathData="M238.1,74.1l-117.2,109.2l-0.8,-0.9l-23,-24.6l-34,-36.6l25.2,-23.4l34,36.4l91.9,-85.7z"
-        android:fillColor="#D6EACC"/>
+        android:fillColor="#BCDEFF"/>
 </vector>

--- a/app/res/layout-land/update_activity.xml
+++ b/app/res/layout-land/update_activity.xml
@@ -80,7 +80,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     SquareButtonWithText:backgroundColor="@color/cc_brand_color"
-                    SquareButtonWithText:img="@drawable/install_start"
+                    SquareButtonWithText:img="@drawable/check_update"
                     SquareButtonWithText:subtitle=""
                     SquareButtonWithText:textColor="@color/white"/>
 

--- a/app/res/layout/update_activity.xml
+++ b/app/res/layout/update_activity.xml
@@ -61,7 +61,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 SquareButtonWithText:backgroundColor="@color/cc_brand_color"
-                SquareButtonWithText:img="@drawable/install_start"
+                SquareButtonWithText:img="@drawable/check_update"
                 SquareButtonWithText:subtitle=""
                 SquareButtonWithText:textColor="@color/white"/>
 


### PR DESCRIPTION
Realized that https://github.com/dimagi/commcare-odk/pull/1170 changed the color of the install check mark to blue, which looks bad.

Fixes the color of:
![screen](https://cloud.githubusercontent.com/assets/94817/14611204/1019a12a-055f-11e6-9b00-100e6fd956da.png)
