### PR TITLE
Tests: use same entry point for all app install logic

### DIFF
--- a/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
@@ -13,8 +13,6 @@ import org.commcare.tasks.InstallStagedUpdateTask;
 import org.commcare.tasks.TaskListener;
 import org.commcare.tasks.TaskListenerRegistrationException;
 import org.commcare.tasks.UpdateTask;
-import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,15 +36,9 @@ public class AppUpdateTest {
 
     @Before
     public void setup() {
-        // needed to resolve "jr://resource" type references
-        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
-
-        TestAppInstaller.setupPrototypeFactory();
-
-        TestAppInstaller appTestInstaller =
-                new TestAppInstaller(buildResourceRef("base_app", "profile.ccpr"),
-                        "test", "123");
-        appTestInstaller.installAppAndLogin();
+        TestAppInstaller.initInstallAndLogin(
+                buildResourceRef("base_app", "profile.ccpr"),
+                "test", "123");
 
         Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
         Assert.assertTrue(p.getVersion() == 6);

--- a/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AutoUpdateTest.java
@@ -85,15 +85,9 @@ public class AutoUpdateTest {
     }
 
     private void installBaseApp() {
-        // needed to resolve "jr://resource" type references
-        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
-
-        TestAppInstaller.setupPrototypeFactory();
-
-        TestAppInstaller appTestInstaller =
-                new TestAppInstaller(buildResourceRef("base_app", "profile.ccpr"),
-                        username, password);
-        appTestInstaller.installAppAndLogin();
+        TestAppInstaller.initInstallAndLogin(
+                buildResourceRef("base_app", "profile.ccpr"),
+                username, password);
 
         Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
         Assert.assertTrue(p.getVersion() == 6);

--- a/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
+++ b/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
@@ -47,16 +47,9 @@ public class EndOfFormTest {
 
     @Before
     public void setup() {
-        // needed to resolve "jr://resource" type references
-        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
-
-        TestUtils.initializeStaticTestStorage();
-        TestAppInstaller.setupPrototypeFactory();
-
-        TestAppInstaller appTestInstaller =
-                new TestAppInstaller("jr://resource/commcare-apps/form_nav_tests/profile.ccpr",
-                        "test", "123");
-        appTestInstaller.installAppAndLogin();
+        TestAppInstaller.initInstallAndLogin(
+                "jr://resource/commcare-apps/form_nav_tests/profile.ccpr",
+                "test", "123");
         ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
     }
 

--- a/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
+++ b/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
@@ -23,8 +23,6 @@ import org.commcare.session.SessionNavigator;
 import org.commcare.views.QuestionsView;
 import org.commcare.views.widgets.IntegerWidget;
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,16 +51,9 @@ public class FormRecordProcessingTest {
 
     @Before
     public void setup() {
-        // needed to resolve "jr://resource" type references
-        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
-
-        TestUtils.initializeStaticTestStorage();
-        TestAppInstaller.setupPrototypeFactory();
-
-        TestAppInstaller appTestInstaller =
-                new TestAppInstaller("jr://resource/commcare-apps/form_save_regressions/profile.ccpr",
-                        "test", "123");
-        appTestInstaller.installAppAndLogin();
+        TestAppInstaller.initInstallAndLogin(
+                "jr://resource/commcare-apps/form_save_regressions/profile.ccpr",
+                "test", "123");
         ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
     }
 

--- a/unit-tests/src/org/commcare/android/tests/processing/ArchivedFormPurgeTest.java
+++ b/unit-tests/src/org/commcare/android/tests/processing/ArchivedFormPurgeTest.java
@@ -31,15 +31,9 @@ public class ArchivedFormPurgeTest {
 
     @Before
     public void setup() {
-        // needed to resolve "jr://resource" type references
-        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
-
-        TestAppInstaller.setupPrototypeFactory();
-
-        TestAppInstaller appTestInstaller =
-                new TestAppInstaller("jr://resource/commcare-apps/archive_form_tests/profile.ccpr",
-                        "test", "123");
-        appTestInstaller.installAppAndLogin();
+        TestAppInstaller.initInstallAndLogin(
+                "jr://resource/commcare-apps/archive_form_tests/profile.ccpr",
+                "test", "123");
 
         SavedFormLoader.loadFormsFromPayload("/commcare-apps/archive_form_tests/saved_form_payload.xml");
     }

--- a/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
+++ b/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
@@ -31,15 +31,15 @@ public class TestAppInstaller {
     private final CommCareTaskConnectorFake<Object> fakeConnector =
             new CommCareTaskConnectorFake<>();
 
-    public TestAppInstaller(String resourceFilepath,
-                            String username,
-                            String password) {
+    private TestAppInstaller(String resourceFilepath,
+                             String username,
+                             String password) {
         this.resourceFilepath = resourceFilepath;
         this.username = username;
         this.password = password;
     }
 
-    public void installAppAndLogin() {
+    private void installAppAndLogin() {
         installApp();
 
         buildTestUser();
@@ -127,7 +127,7 @@ public class TestAppInstaller {
         return null;
     }
 
-    public static void setupPrototypeFactory() {
+    private static void setupPrototypeFactory() {
         // Sets DB to use an in-memory store for class serialization tagging.
         // This avoids the need to use apk reflection to perform read/writes
         TestUtils.initializeStaticTestStorage();

--- a/unit-tests/src/org/commcare/models/database/StoreFixturesOnFilesystemTests.java
+++ b/unit-tests/src/org/commcare/models/database/StoreFixturesOnFilesystemTests.java
@@ -53,16 +53,9 @@ public class StoreFixturesOnFilesystemTests {
     }
 
     public static AndroidSandbox installAppWithFixtureData(Class testClass, String fixtureResource) {
-        // needed to resolve "jr://resource" type references
-        ReferenceManager._().addReferenceFactory(new ResourceReferenceFactory());
-
-        TestUtils.initializeStaticTestStorage();
-        TestAppInstaller.setupPrototypeFactory();
-
-        TestAppInstaller appTestInstaller =
-                new TestAppInstaller("jr://resource/commcare-apps/archive_form_tests/profile.ccpr",
-                        "test", "123");
-        appTestInstaller.installAppAndLogin();
+        TestAppInstaller.initInstallAndLogin(
+                "jr://resource/commcare-apps/archive_form_tests/profile.ccpr",
+                "test", "123");
 
         AndroidSandbox sandbox = new AndroidSandbox(CommCareApplication._());
 


### PR DESCRIPTION
Removing a lot of duplicate app install code from odk unit tests.