### PR TITLE
Prevent crash when an add-repeat dialog is the first thing shown in a form

### DIFF
--- a/app/src/org/commcare/activities/components/FormNavigationUI.java
+++ b/app/src/org/commcare/activities/components/FormNavigationUI.java
@@ -39,6 +39,10 @@ public class FormNavigationUI {
     public static void updateNavigationCues(CommCareActivity activity,
                                             FormController formController,
                                             QuestionsView view) {
+        if (view == null) {
+            return;
+        }
+
         updateFloatingLabels(activity, view);
 
         FormNavigationController.NavigationDetails details;


### PR DESCRIPTION
Fix for this crash, which was showing up in the ICDS force close logs:
```java.lang.NullPointerException at org.odk.collect.android.activities.components.FormNavigationUI.updateFloatingLabels(FormNavigationUI.java:157) at org.odk.collect.android.activities.components.FormNavigationUI.updateNavigationCues(FormNavigationUI.java:37) at org.odk.collect.android.activities.FormEntryActivity.handleFormLoadCompletion(FormEntryActivity.java:1942) at org.odk.collect.android.activities.FormEntryActivity.access$1700(FormEntryActivity.java:136) at org.odk.collect.android.activities.FormEntryActivity$15.deliverResult(FormEntryActivity.java:1862) at org.odk.collect.android.activities.FormEntryActivity$15.deliverResult(FormEntryActivity.java:1859) at org.commcare.android.tasks.templates.CommCareTask.onPostExecute(CommCareTask.java:83) at android.os.AsyncTask.finish(AsyncTask.java:632) at android.os.AsyncTask.access$600(AsyncTask.java:177) at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:645) at android.os.Handler.dispatchMessage(Handler.java:102) at android.os.Looper.loop(Looper.java:136) at android.app.ActivityThread.main(ActivityThread.java:5426) at java.lang.reflect.Method.invokeNative(Native Method) at java.lang.reflect.Method.invoke(Method.java:515) at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1268) at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1084) at dalvik.system.NativeStart.main(Native Method)```

Explanation: `handleFormLoadCompletion()` calls `refreshCurrentView()` and then `FormNavigationUI.updateNavigationCues(this, mFormController, questionsView)`. The latter method assumes that the `questionsView` field has been assigned in the call to `refreshCurrentView()` via a downstream call to `showView()`, which is true in all instances but one- If the first event encountered is `EVENT_PROMPT_NEW_REPEAT`, then we just create the dialog, and do NOT call `showView()`, rendering `questionsView` null when the UI update method is called. 

Seems fine to me to resolve this by just checking if `view` is null, now that I know what's causing it.