### PR TITLE
prevent OOM error when processing image capture

### DIFF
--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -435,7 +435,7 @@ public class FileUtil {
             return false;
         }
 
-        Bitmap bitmap = BitmapFactory.decodeFile(originalImage.getAbsolutePath());
+        Bitmap bitmap = MediaUtil.inflateImageSafe(originalImage.getAbsolutePath());
         Bitmap scaledBitmap = getBitmapScaledByMaxDimen(bitmap, maxDimen);
         if (scaledBitmap != null) {
             // Write this scaled bitmap to the final file location

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -12,12 +12,15 @@ import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.util.Log;
+import android.util.Pair;
 
+import org.commcare.logging.AndroidLogger;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.services.Logger;
 import org.javarosa.core.util.PropertyUtils;
 
 import java.io.File;
@@ -435,8 +438,12 @@ public class FileUtil {
             return false;
         }
 
-        Bitmap bitmap = MediaUtil.inflateImageSafe(originalImage.getAbsolutePath());
-        Bitmap scaledBitmap = getBitmapScaledByMaxDimen(bitmap, maxDimen);
+        Pair<Bitmap, Boolean> bitmapAndScaledBool = MediaUtil.inflateImageSafe(originalImage.getAbsolutePath());
+        if (bitmapAndScaledBool.second) {
+            Logger.log(AndroidLogger.TYPE_FORM_ENTRY,
+                    "An image captured during form entry was too large to be processed at its original size, and had to be downsized");
+        }
+        Bitmap scaledBitmap = getBitmapScaledByMaxDimen(bitmapAndScaledBool.first, maxDimen);
         if (scaledBitmap != null) {
             // Write this scaled bitmap to the final file location
             FileOutputStream out = null;

--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -313,6 +313,14 @@ public class MediaUtil {
     }
 
     /**
+     * Inflate an image file into a bitmap, attempting first to inflate it at its full size,
+     * but progressively scaling down if an OutOfMemoryError is encountered
+     */
+    public static Bitmap inflateImageSafe(String imageFilepath) {
+        return performSafeScaleDown(imageFilepath, 1, 0);
+    }
+
+    /**
      * @return A scaled-down bitmap for the given image file, progressively increasing the
      * scale-down factor by 1 until allocating memory for the bitmap does not cause an OOM error
      */

--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -236,7 +236,7 @@ public class MediaUtil {
         } catch (OutOfMemoryError e) {
             // OOM encountered trying to decode the bitmap, so we know we need to scale down by
             // a larger factor
-            return performSafeScaleDown(imageFilepath, approximateScaleFactor + 1, 0);
+            return performSafeScaleDown(imageFilepath, approximateScaleFactor + 1, 1).first;
         }
     }
 
@@ -290,7 +290,7 @@ public class MediaUtil {
         } catch (OutOfMemoryError e) {
             // Just inflating the image at its original size caused an OOM error, don't have a
             // choice but to scale down
-            return performSafeScaleDown(imageFilepath, 2, 1);
+            return performSafeScaleDown(imageFilepath, 2, 1).first;
         }
     }
 
@@ -315,24 +315,27 @@ public class MediaUtil {
     /**
      * Inflate an image file into a bitmap, attempting first to inflate it at its full size,
      * but progressively scaling down if an OutOfMemoryError is encountered
+     *
+     * @return the bitmap, plus a boolean value representing whether the image had to be downsized
      */
-    public static Bitmap inflateImageSafe(String imageFilepath) {
+    public static Pair<Bitmap, Boolean> inflateImageSafe(String imageFilepath) {
         return performSafeScaleDown(imageFilepath, 1, 0);
     }
 
     /**
      * @return A scaled-down bitmap for the given image file, progressively increasing the
-     * scale-down factor by 1 until allocating memory for the bitmap does not cause an OOM error
+     * scale-down factor by 1 until allocating memory for the bitmap does not cause an OOM error,
+     * and a boolean value representing whether the image had to be downsized
      */
-    private static Bitmap performSafeScaleDown(String imageFilepath, int scale, int depth) {
+    private static Pair<Bitmap, Boolean> performSafeScaleDown(String imageFilepath, int scale, int depth) {
         if (depth == 5) {
             // Limit the number of recursive calls
-            return null;
+            return new Pair<>(null, true);
         }
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inSampleSize = scale;
         try {
-            return BitmapFactory.decodeFile(imageFilepath, options);
+            return new Pair<>(BitmapFactory.decodeFile(imageFilepath, options), scale > 1);
         } catch (OutOfMemoryError e) {
             return performSafeScaleDown(imageFilepath, scale + 1, depth + 1);
         }


### PR DESCRIPTION
Addresses this crash from the ICDS force-close logs:
```java.lang.OutOfMemoryError at android.graphics.BitmapFactory.nativeDecodeStream(Native Method) at android.graphics.BitmapFactory.decodeStreamInternal(BitmapFactory.java:709) at android.graphics.BitmapFactory.decodeStream(BitmapFactory.java:685) at android.graphics.BitmapFactory.decodeFile(BitmapFactory.java:447) at android.graphics.BitmapFactory.decodeFile(BitmapFactory.java:486) at org.odk.collect.android.utilities.FileUtils.scaleAndSaveImage(FileUtils.java:128) at org.odk.collect.android.activities.components.ImageCaptureProcessing.moveAndScaleImage(ImageCaptureProcessing.java:36) at org.odk.collect.android.activities.FormEntryActivity.processCaptureResponse(FormEntryActivity.java:484) at org.odk.collect.android.activities.FormEntryActivity.onActivityResult(FormEntryActivity.java:443) at android.app.Activity.dispatchActivityResult(Activity.java:5643) at android.app.ActivityThread.deliverResults(ActivityThread.java:3573) at android.app.ActivityThread.handleSendResult(ActivityThread.java:3620) at android.app.ActivityThread.access$1400(ActivityThread.java:169) at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1325) at android.os.Handler.dispatchMessage(Handler.java:102) at android.os.Looper.loop(Looper.java:136) at android.app.ActivityThread.main(ActivityThread.java:5479) at java.lang.reflect.Method.invokeNative(Native Method) at java.lang.reflect.Method.invoke(Method.java:515) at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1283) at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099) at dalvik.system.NativeStart.main(Native Method)```

Did not reproduce the specific crash, but definitely just looks like processing an image capture is sometimes causing an OOM error because the original captured image is too large. The only question I have here is whether it's proper to just downsize the user's captured image without telling them we did so. I guess the alternative would be to show a non-crashing error message to the user that tells them their image capture can't be processed due to memory constraints. I'm personally inclined toward downsizing the image, because the alternative leaves the user without any real path forward to fix the issue. But wanted to acknowledge that this solution does something potentially odd. 

(I did test out going through some image capture widgets with this change to make sure it still worked soundly).