### PR TITLE
Allow for custom acknowledgement in 'about commcare'

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -673,3 +673,5 @@ permission.sms.install.message=CommCare would like to scan your recent messages 
 permission.form.gps.title=Permission to capture location during form entry
 permission.form.gps.message=CommCare would like to capture your location and provide it to forms you complete.
 permission.acquire.required=Acquire Required Permissions
+
+custom.acknowledgement=

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -54,19 +54,19 @@
     <string name="expirenotification">CommCare Login Expired</string>
     <string name="submission_notification_title">Submitting Data</string>
     <string name="submission_logs_title">Submitting CommCare Logs</string>
-    <string name="form_record_url"></string>
+    <string name="form_record_url"/>
 
     <item name="login_screen_hide_all_cuttoff" type="integer">200</item>
     <item name="login_screen_hide_banner_cuttoff" type="integer">250</item>
 
     <string name="url_prompt">Choose a URL</string>
 
-    <string name="aboutdialog">%s\n\n
+    <string name="about_dialog" formatted="false">%s\n\n
 _Copyright 2015, Dimagi inc, All rights reserved_ \n\n
 
 ---------------- \n\n
 __Acknowledgements:__ \n\n
-
+%s
 Some images in CommCare are graciously used under Creative Commons Licensing from thenounproject.com collection:\n\n
 * “Door” symbol by Tak Imoto \n
 * “Pencil” symbol by Creologica \n
@@ -77,7 +77,7 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
 
 _Android MapView Balloons_ project used under the Apache Software License 2.0. \n
 Author: Jeff Gilfelt \n
-Copyright (c) 2012 readyState Software Ltd.</string>
+Copyright © 2012 readyState Software Ltd.</string>
     <string name="notification_message_title">CommCare Notification</string>
 
     <string-array name="frequency_vals">

--- a/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
+++ b/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
@@ -2,6 +2,7 @@ package org.commcare.views.dialogs;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Build;
 import android.text.Spannable;
@@ -13,13 +14,13 @@ import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
 import org.commcare.interfaces.RuntimePermissionRequester;
 import org.commcare.utils.MarkupUtil;
+import org.javarosa.core.services.locale.Localization;
 
 /**
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public class DialogCreationHelpers {
     public static AlertDialog buildAboutCommCareDialog(Activity activity) {
-        final String commcareVersion = CommCareApplication._().getCurrentVersionString();
 
         LayoutInflater li = LayoutInflater.from(activity);
         View view = li.inflate(R.layout.scrolling_info_dialog, null);
@@ -27,9 +28,8 @@ public class DialogCreationHelpers {
         TextView titleView = (TextView) view.findViewById(R.id.dialog_title_text);
         titleView.setText(activity.getString(R.string.about_cc));
 
+        Spannable markdownText = buildAboutMessage(activity);
         TextView aboutText = (TextView)view.findViewById(R.id.dialog_text);
-        String msg = activity.getString(R.string.aboutdialog, commcareVersion);
-        Spannable markdownText = MarkupUtil.returnMarkdown(activity, msg);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
             aboutText.setText(markdownText);
         } else {
@@ -39,6 +39,13 @@ public class DialogCreationHelpers {
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
         builder.setView(view);
         return builder.create();
+    }
+
+    private static Spannable buildAboutMessage(Context context) {
+        String commcareVersion = CommCareApplication._().getCurrentVersionString();
+        String customAcknowledgment = Localization.get("custom.acknowledgement");
+        String message = context.getString(R.string.about_dialog, commcareVersion, customAcknowledgment);
+        return MarkupUtil.returnMarkdown(context, message);
     }
 
     /**

--- a/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
+++ b/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
@@ -43,7 +43,7 @@ public class DialogCreationHelpers {
 
     private static Spannable buildAboutMessage(Context context) {
         String commcareVersion = CommCareApplication._().getCurrentVersionString();
-        String customAcknowledgment = Localization.get("custom.acknowledgement");
+        String customAcknowledgment = Localization.getWithDefault("custom.acknowledgement", "");
         String message = context.getString(R.string.about_dialog, commcareVersion, customAcknowledgment);
         return MarkupUtil.returnMarkdown(context, message);
     }


### PR DESCRIPTION
ICDS feature to allow for adding custom acknowledgement in 'About CommCare' dialog.

Requires setting `custom.acknowledgement` translation key on HQ.
Requires double `\n\n` to do a new line break.

Adds the markdown enabled "Foo bar hello bold?".
![screen](https://cloud.githubusercontent.com/assets/94817/14709813/980033d6-07a0-11e6-9ff6-9c3f6c6c8cce.png)

When `custom.acknowledgement` is unset the about dialog looks like:
![screen](https://cloud.githubusercontent.com/assets/94817/14711985/6ca8c6ea-07a9-11e6-9cf4-265073431d89.png)

