### PR TITLE
Start sync task from form submit task using receiver activity

### DIFF
--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -169,7 +169,7 @@ public class CommCareHomeActivity
         ACRAUtil.registerAppData();
         uiController.setupUI();
         sessionNavigator = new SessionNavigator(this);
-        formAndDataSyncer = new FormAndDataSyncer(this);
+        formAndDataSyncer = new FormAndDataSyncer();
 
         processFromExternalLaunch(savedInstanceState);
         processFromShortcutLaunch();
@@ -1048,7 +1048,7 @@ public class CommCareHomeActivity
     private void sendFormsOrSync(boolean userTriggeredSync) {
         boolean formsSentToServer = checkAndStartUnsentFormsTask(true, userTriggeredSync);
         if(!formsSentToServer) {
-            formAndDataSyncer.syncData(false, userTriggeredSync);
+            formAndDataSyncer.syncData(this, false, userTriggeredSync);
         }
     }
 
@@ -1061,7 +1061,7 @@ public class CommCareHomeActivity
         FormRecord[] records = StorageUtils.getUnsentRecords(storage);
 
         if(records.length > 0) {
-            formAndDataSyncer.processAndSendForms(records, syncAfterwards, userTriggered);
+            formAndDataSyncer.processAndSendForms(this, records, syncAfterwards, userTriggered);
             return true;
         } else {
             return false;

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -7,10 +7,10 @@ import android.os.AsyncTask;
 import android.os.Build;
 
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.dalvik.R;
 import org.commcare.logging.analytics.GoogleAnalyticsFields;
 import org.commcare.logging.analytics.GoogleAnalyticsUtils;
-import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.ProcessAndSendTask;
@@ -23,14 +23,13 @@ import org.javarosa.core.services.locale.Localization;
  * Processes and submits forms and syncs data with server
  */
 public class FormAndDataSyncer {
-    private final CommCareHomeActivity activity;
 
-    public FormAndDataSyncer(CommCareHomeActivity activity) {
-        this.activity = activity;
+    public FormAndDataSyncer() {
     }
 
     @SuppressLint("NewApi")
-    public void processAndSendForms(FormRecord[] records,
+    public void processAndSendForms(final CommCareHomeActivity activity,
+                                    FormRecord[] records,
                                     final boolean syncAfterwards,
                                     final boolean userTriggered) {
 
@@ -45,7 +44,7 @@ public class FormAndDataSyncer {
                     receiver.finish();
                     return;
                 }
-                activity.getUIController().refreshView();
+                receiver.getUIController().refreshView();
 
                 int successfulSends = this.getSuccessfulSends();
 
@@ -59,7 +58,7 @@ public class FormAndDataSyncer {
                     receiver.displayMessage(label);
 
                     if (syncAfterwards) {
-                        syncData(true, userTriggered);
+                        syncData(receiver, true, userTriggered);
                     }
                 } else if (result != FormUploadUtil.FAILURE) {
                     // Tasks with failure result codes will have already created a notification
@@ -101,7 +100,9 @@ public class FormAndDataSyncer {
                 context.getString(R.string.PostURL));
     }
 
-    public void syncData(final boolean formsToSend, final boolean userTriggeredSync) {
+    public void syncData(final CommCareHomeActivity activity,
+                         final boolean formsToSend,
+                         final boolean userTriggeredSync) {
         User u;
         try {
             u = CommCareApplication._().getSession().getLoggedInUser();

--- a/unit-tests/src/org/commcare/android/mocks/FormAndDataSyncerFake.java
+++ b/unit-tests/src/org/commcare/android/mocks/FormAndDataSyncerFake.java
@@ -14,19 +14,20 @@ import org.commcare.android.database.user.models.FormRecord;
 public class FormAndDataSyncerFake extends FormAndDataSyncer {
     private final String TAG = FormAndDataSyncerFake.class.getSimpleName();
 
-    public FormAndDataSyncerFake(CommCareHomeActivity activity) {
-        super(activity);
+    public FormAndDataSyncerFake() {
     }
 
     @Override
-    public void processAndSendForms(FormRecord[] records,
+    public void processAndSendForms(CommCareHomeActivity activity,
+                                    FormRecord[]records,
                                     final boolean syncAfterwards,
                                     final boolean userTriggered) {
         Log.d(TAG, "faking form processing and sending");
     }
 
     @Override
-    public void syncData(boolean formsToSend,
+    public void syncData(CommCareHomeActivity activity,
+                         boolean formsToSend,
                          boolean userTriggeredSync) {
         Log.d(TAG, "faking data sync");
     }

--- a/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
+++ b/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
@@ -94,7 +94,7 @@ public class EndOfFormTest {
         CommCareHomeActivity homeActivity =
                 Robolectric.buildActivity(CommCareHomeActivity.class).create().get();
         // make sure we don't actually submit forms by using a fake form submitter
-        homeActivity.setFormAndDataSyncer(new FormAndDataSyncerFake(homeActivity));
+        homeActivity.setFormAndDataSyncer(new FormAndDataSyncerFake());
         SessionNavigator sessionNavigator = homeActivity.getSessionNavigator();
         sessionNavigator.startNextSessionStep();
         return homeActivity;

--- a/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
+++ b/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
@@ -127,7 +127,7 @@ public class FormRecordProcessingTest {
         CommCareHomeActivity homeActivity =
                 Robolectric.buildActivity(CommCareHomeActivity.class).create().get();
         // make sure we don't actually submit forms by using a fake form submitter
-        homeActivity.setFormAndDataSyncer(new FormAndDataSyncerFake(homeActivity));
+        homeActivity.setFormAndDataSyncer(new FormAndDataSyncerFake());
         SessionNavigator sessionNavigator = homeActivity.getSessionNavigator();
         sessionNavigator.startNextSessionStep();
         return homeActivity;


### PR DESCRIPTION
If you press the sync button when there are forms to submit, rotate the screen while the form submit task is running, then the sync task will be launched using a stale activity due to the fact that the `FormAndDataSyncer` would using the `activity` field instead of the `receiver` method arg. 

Would cause sync to continue in background without user being aware of it.