### PR TITLE
Show cancel button during data download part of sync

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -25,12 +25,12 @@ import android.widget.SearchView;
 import android.widget.TextView;
 
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.user.models.ACase;
 import org.commcare.fragments.BreadcrumbBarFragment;
 import org.commcare.fragments.ContainerFragment;
 import org.commcare.fragments.TaskConnectorFragment;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.logging.AndroidLogger;
-import org.commcare.android.database.user.models.ACase;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.StackFrameStep;
@@ -503,6 +503,13 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             } else {
                 warnInvalidProgressUpdate(taskId);
             }
+        }
+    }
+
+    public void hideTaskCancelButton() {
+        CustomProgressDialog mProgressDialog = getCurrentProgressDialog();
+        if (mProgressDialog != null) {
+            mProgressDialog.removeCancelButton();
         }
     }
 

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -20,6 +20,9 @@ import android.view.View;
 import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.app.models.UserKeyRecord;
+import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
@@ -31,9 +34,6 @@ import org.commcare.logging.analytics.GoogleAnalyticsFields;
 import org.commcare.logging.analytics.GoogleAnalyticsUtils;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.android.database.app.models.UserKeyRecord;
-import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.provider.FormsProviderAPI;
@@ -159,6 +159,7 @@ public class CommCareHomeActivity
     private boolean loginExtraWasConsumed;
     private static final String EXTRA_CONSUMED_KEY = "login_extra_was_consumed";
     private boolean isRestoringSession = false;
+    private boolean isSyncUserLaunched = false;
 
     @Override
     protected void onCreateSessionSafe(Bundle savedInstanceState) throws SessionUnavailableException {
@@ -1057,6 +1058,7 @@ public class CommCareHomeActivity
      */
     private boolean checkAndStartUnsentFormsTask(final boolean syncAfterwards,
                                                  boolean userTriggered) {
+        isSyncUserLaunched = userTriggered;
         SqlStorage<FormRecord> storage = CommCareApplication._().getUserStorage(FormRecord.class);
         FormRecord[] records = StorageUtils.getUnsentRecords(storage);
 
@@ -1324,27 +1326,33 @@ public class CommCareHomeActivity
     @Override
     public CustomProgressDialog generateProgressDialog(int taskId) {
         String title, message;
+        CustomProgressDialog dialog;
         switch (taskId) {
             case ProcessAndSendTask.SEND_PHASE_ID:
                 title = Localization.get("sync.progress.submitting.title");
                 message = Localization.get("sync.progress.submitting");
+                dialog = CustomProgressDialog.newInstance(title, message, taskId);
                 break;
             case ProcessAndSendTask.PROCESSING_PHASE_ID:
                 title = Localization.get("form.entry.processing.title");
                 message = Localization.get("form.entry.processing");
+                dialog = CustomProgressDialog.newInstance(title, message, taskId);
+                dialog.addProgressBar();
                 break;
             case DataPullTask.DATA_PULL_TASK_ID:
                 title = Localization.get("sync.progress.title");
                 message = Localization.get("sync.progress.purge");
+                dialog = CustomProgressDialog.newInstance(title, message, taskId);
+                if (isSyncUserLaunched) {
+                    // allow users to cancel syncs that they launched
+                    dialog.addCancelButton();
+                }
+                isSyncUserLaunched = false;
                 break;
             default:
                 Log.w(TAG, "taskId passed to generateProgressDialog does not match "
                         + "any valid possibilities in CommCareHomeActivity");
                 return null;
-        }
-        CustomProgressDialog dialog = CustomProgressDialog.newInstance(title, message, taskId);
-        if (taskId == ProcessAndSendTask.PROCESSING_PHASE_ID) {
-            dialog.addProgressBar();
         }
         return dialog;
     }

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -190,6 +190,8 @@ public class FormAndDataSyncer {
                     receiver.updateProgress(Localization.get("sync.progress.downloading"), DataPullTask.DATA_PULL_TASK_ID);
                 } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
                     receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[]{String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
+                } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING_COMPLETE) {
+                    receiver.hideTaskCancelButton();
                 } else if (update[0] == DataPullTask.PROGRESS_PROCESSING) {
                     receiver.updateProgress(Localization.get("sync.process.processing", new String[]{String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
                     receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -249,6 +249,8 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                             receiver.updateProgress(Localization.get("sync.progress.downloading"), DataPullTask.DATA_PULL_TASK_ID);
                         } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
                             receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[]{String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
+                        } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING_COMPLETE) {
+                            receiver.hideTaskCancelButton();
                         } else if (update[0] == DataPullTask.PROGRESS_PROCESSING) {
                             receiver.updateProgress(Localization.get("sync.process.processing", new String[]{String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
                             receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);

--- a/app/src/org/commcare/fragments/TaskConnectorFragment.java
+++ b/app/src/org/commcare/fragments/TaskConnectorFragment.java
@@ -64,6 +64,7 @@ public class TaskConnectorFragment<R> extends Fragment {
     public void cancelTask() {
         if (currentTask != null) {
             currentTask.cancel(false);
+            currentTask.tryAbort();
         }
     }
 

--- a/app/src/org/commcare/network/HttpRequestGenerator.java
+++ b/app/src/org/commcare/network/HttpRequestGenerator.java
@@ -26,10 +26,10 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.user.models.ACase;
 import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.android.database.user.models.ACase;
 import org.commcare.utils.GlobalConstants;
 import org.javarosa.core.model.User;
 import org.javarosa.core.model.utils.DateUtils;
@@ -76,6 +76,11 @@ public class HttpRequestGenerator {
     PasswordAuthentication passwordAuthentication;
     private String username;
     private String userType;
+
+    /**
+     * Keep track of current request to allow for early aborting
+     */
+    private HttpRequestBase currentRequest;
 
     public HttpRequestGenerator(User user) {
         this(user.getUsername(), user.getCachedPwd(), user.getUserType());
@@ -160,10 +165,12 @@ public class HttpRequestGenerator {
 
         String uri = serverUri.toString();
         Log.d(TAG, "Fetching from: " + uri);
-        HttpGet request = new HttpGet(uri);
-        AndroidHttpClient.modifyRequestToAcceptGzipResponse(request);
-        addHeaders(request, syncToken);
-        return execute(client, request);
+        currentRequest = new HttpGet(uri);
+        AndroidHttpClient.modifyRequestToAcceptGzipResponse(currentRequest);
+        addHeaders(currentRequest, syncToken);
+        HttpResponse response = execute(client, currentRequest);
+        currentRequest = null;
+        return response;
     }
 
     public HttpResponse makeKeyFetchRequest(String baseUri, Date lastRequest) throws ClientProtocolException, IOException {
@@ -358,4 +365,15 @@ public class HttpRequestGenerator {
         con.setDoInput(true);
         con.setInstanceFollowRedirects(true);
     }
+
+    public void abortCurrentRequest() {
+        if (currentRequest != null) {
+            try {
+                currentRequest.abort();
+            } catch (Exception e) {
+                Log.i(TAG, "Error thrown while aborting http: " + e.getMessage());
+            }
+        }
+    }
+
 }

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -208,6 +208,8 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
 
                 if (isCancelled()) {
                     // avoid making the http request if user cancelled the task
+                    // NOTE: The result returned is never processed since
+                    // cancelled task results are sent to onCancelled.
                     return PullTaskResult.UNKNOWN_FAILURE;
                 }
                 RemoteDataPullResponse pullResponse = dataPullRequester.makeDataPullRequest(this, requestor, server, useRequestFlags);
@@ -232,7 +234,10 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
 
                     this.publishProgress(PROGRESS_AUTHED, 0);
                     if (isCancelled()) {
-                        // About to enter data commit phase; last chance to finish early if cancelled
+                        // About to enter data commit phase; last chance to
+                        // finish early if cancelled.
+                        // NOTE: The result returned is never processed since
+                        // cancelled task results are sent to onCancelled.
                         return PullTaskResult.UNKNOWN_FAILURE;
                     }
                     this.publishProgress(PROGRESS_DOWNLOADING_COMPLETE, 0);

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -11,13 +11,13 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.app.models.UserKeyRecord;
+import org.commcare.android.database.user.models.ACase;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.engine.cases.CaseUtils;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.logging.analytics.GoogleAnalyticsFields;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.android.database.app.models.UserKeyRecord;
-import org.commcare.android.database.user.models.ACase;
 import org.commcare.models.encryption.CryptUtil;
 import org.commcare.modern.models.RecordTooLargeException;
 import org.commcare.network.DataPullRequester;
@@ -78,6 +78,7 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
     private static final int PROGRESS_RECOVERY_FAIL_BAD = 64;
     public static final int PROGRESS_PROCESSING = 128;
     public static final int PROGRESS_DOWNLOADING = 256;
+    public static final int PROGRESS_DOWNLOADING_COMPLETE = 512;
     private DataPullRequester dataPullRequester;
 
     private DataPullTask(String username, String password, String server, Context context, boolean restoreOldSession) {
@@ -108,6 +109,7 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
             CommCareApplication._().releaseUserResourcesAndServices();
         }
     }
+    private HttpRequestGenerator requestor;
 
     @Override
     protected PullTaskResult doTaskBackground(Void... params) {
@@ -148,7 +150,7 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
             //This should be per _user_, not per app
             prefs.edit().putLong("last-ota-restore", new Date().getTime()).commit();
 
-            HttpRequestGenerator requestor = new HttpRequestGenerator(username, password);
+            requestor = new HttpRequestGenerator(username, password);
 
             AndroidTransactionParserFactory factory = new AndroidTransactionParserFactory(context, requestor) {
                 boolean publishedAuth = false;
@@ -204,6 +206,10 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
                 //Either way, don't re-do this step
                 this.publishProgress(PROGRESS_CLEANED);
 
+                if (isCancelled()) {
+                    // avoid making the http request if user cancelled the task
+                    return PullTaskResult.UNKNOWN_FAILURE;
+                }
                 RemoteDataPullResponse pullResponse = dataPullRequester.makeDataPullRequest(this, requestor, server, useRequestFlags);
                 Logger.log(AndroidLogger.TYPE_USER, "Request opened. Response code: " + pullResponse.responseCode);
 
@@ -224,8 +230,13 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
                         wasKeyLoggedIn = true;
                     }
 
-
                     this.publishProgress(PROGRESS_AUTHED, 0);
+                    if (isCancelled()) {
+                        // About to enter data commit phase; last chance to finish early if cancelled
+                        return PullTaskResult.UNKNOWN_FAILURE;
+                    }
+                    this.publishProgress(PROGRESS_DOWNLOADING_COMPLETE, 0);
+
                     Logger.log(AndroidLogger.TYPE_USER, "Remote Auth Successful|" + username);
 
                     try {
@@ -342,6 +353,13 @@ public abstract class DataPullTask<R> extends CommCareTask<Void, Integer, DataPu
             return responseError;
         } finally {
             CommCareSessionService.sessionAliveLock.unlock();
+        }
+    }
+
+    @Override
+    public void tryAbort() {
+        if (requestor != null) {
+            requestor.abortCurrentRequest();
         }
     }
 

--- a/app/src/org/commcare/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTask.java
@@ -170,6 +170,12 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
         }
     }
 
+    /**
+     * Attempts to kill long running processes prematurely in the task
+     */
+    public void tryAbort() {
+    }
+
     protected void transitionPhase(int newTaskId) {
         synchronized (connectorLock) {
             if (newTaskId != taskId) {

--- a/app/src/org/commcare/views/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/views/dialogs/CustomProgressDialog.java
@@ -60,6 +60,7 @@ public class CustomProgressDialog extends DialogFragment {
 
     //for cancel button
     private boolean usingCancelButton;
+    private Button cancelButton;
 
     //for progress bar
     private boolean usingHorizontalProgressBar;
@@ -82,6 +83,13 @@ public class CustomProgressDialog extends DialogFragment {
 
     public void addCancelButton() {
         usingCancelButton = true;
+    }
+
+    public void removeCancelButton() {
+        usingCancelButton = false;
+        if (cancelButton != null) {
+            cancelButton.setVisibility(View.INVISIBLE);
+        }
     }
 
     public void setCancelable() {
@@ -157,7 +165,7 @@ public class CustomProgressDialog extends DialogFragment {
         messageView.setText(message);
 
         if (usingCancelButton) {
-            Button cancelButton = setupCancelButton(view);
+            cancelButton = setupCancelButton(view);
             if (wasCancelPressed) {
                 setCancellingText(titleView, messageView, cancelButton);
             }


### PR DESCRIPTION
Allow user to cancel `DataPullTask` up until point where data has been downloaded and processing begins.

Don't allow user to cancel syncs that have been started automatically.

Avoid synchronization between button hiding and starting the data processing block. We avoid it because it isn't that bad if a user presses the cancel button after data processing has begun. If that happens, the task dialog says it is cancelling, butt the data processing still completes (because we don't check the `AsyncTask.isCancelled()` state in that block). Resulting in the user being slightly annoyed, if the data processing takes a long time.