### PR TITLE
Add activity alias for old launcher name

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -70,6 +70,17 @@
             </intent-filter>
         </activity>
 
+        <!-- For legacy reasons: alias to the old launch name. If you remove this,
+         updating from below 2.27 will remove launchers from the homescreen -->
+        <activity-alias
+            android:name=".activities.DispatchActivity"
+            android:targetActivity="org.commcare.activities.DispatchActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity-alias>
+
         <activity
             android:name="org.commcare.activities.AppManagerActivity"
             android:label="@string/manager_activity_name"


### PR DESCRIPTION
When I changed the `DispatchActivity` `android:name` in the AndroidManifest.xml file it caused anyone upgrading to 2.27 to loose their CommCare homescreen launcher.

Adding an alias from the old name to the new name prevents that. And if you already replaced the launcher icon on 2.27.0, it doesn't mess with that. 

http://blog.danlew.net/2014/01/16/preserve-your-launchers-use-activity-alias/