### PR TITLE
Fix double app icon

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -70,17 +70,6 @@
             </intent-filter>
         </activity>
 
-        <!-- For legacy reasons: alias to the old launch name. If you remove this,
-         updating from below 2.27 will remove launchers from the homescreen -->
-        <activity-alias
-            android:name=".activities.DispatchActivity"
-            android:targetActivity="org.commcare.activities.DispatchActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity-alias>
-
         <activity
             android:name="org.commcare.activities.AppManagerActivity"
             android:label="@string/manager_activity_name"

--- a/app/src/org/commcare/activities/MenuList.java
+++ b/app/src/org/commcare/activities/MenuList.java
@@ -14,7 +14,6 @@ import org.commcare.dalvik.R;
 import org.commcare.fragments.BreadcrumbBarFragment;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Entry;
-import org.commcare.suite.model.FormEntry;
 import org.commcare.suite.model.Menu;
 import org.commcare.util.CommCarePlatform;
 import org.commcare.views.ManagedUi;

--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,10 @@ dependencies {
     compile project(':commcare')
     compile fileTree(dir: 'app/libs', include: '*.jar')
     compile(name: 'htmlspanner-custom', ext: 'aar')
-    compile 'com.android.support:cardview-v7:23.2.1'
-    compile 'com.android.support:recyclerview-v7:23.2.1'
-    compile 'com.android.support:support-v4:23.2.1'
-    compile 'com.android.support:gridlayout-v7:23.2.1'
+    compile 'com.android.support:cardview-v7:23.3.0'
+    compile 'com.android.support:recyclerview-v7:23.3.0'
+    compile 'com.android.support:support-v4:23.3.0'
+    compile 'com.android.support:gridlayout-v7:23.3.0'
     compile 'com.madgag.spongycastle:core:1.54.0.0'
     compile 'com.madgag.spongycastle:prov:1.54.0.0'
     compile 'com.google.android.gms:play-services-maps:8.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.google.gms:google-services:2.0.0'
     }
 }


### PR DESCRIPTION
https://github.com/dimagi/commcare-odk/pull/1227 introduced the issue where 2 `CommCare` launcher icons show up in the Android app list:

![screen](https://cloud.githubusercontent.com/assets/94817/14890275/f3211aa2-0d2f-11e6-94fb-083497cc4b13.png)

This fixes that.

Also, bump to gradle plugin to 2.1.0 (time to update to Android Studio 2.1 :) )
And update Google support libs from `23.2.1` to `23.3.0`