### PR TITLE
Fix cutting off of images in GridWidget 

### DIFF
--- a/app/src/org/commcare/views/widgets/GridWidget.java
+++ b/app/src/org/commcare/views/widgets/GridWidget.java
@@ -153,7 +153,6 @@ public class GridWidget extends QuestionWidget {
         Display display = ((WindowManager)getContext().getSystemService(Context.WINDOW_SERVICE))
                 .getDefaultDisplay();
         int screenWidth = display.getWidth();
-        int screenHeight = display.getHeight();
 
         // Use the user's choice for num columns, otherwise decide based upon what will fit.
         int maxColumnsThatWillFit = screenWidth / maxImageWidth;
@@ -164,7 +163,7 @@ public class GridWidget extends QuestionWidget {
         }
 
         // Because grid views are designed to scroll rather than wrap their contents, we have to
-        // explicitly set the view's size 
+        // explicitly set the view's size
         int numRowsThatWillBeUsed = (mItems.size() / maxColumnsThatWillFit) + 1;
         int approxTotalHeightNeeded = numRowsThatWillBeUsed * maxImageHeight;
         GridView.LayoutParams params = new GridView.LayoutParams(screenWidth - 5, approxTotalHeightNeeded + 5);

--- a/app/src/org/commcare/views/widgets/GridWidget.java
+++ b/app/src/org/commcare/views/widgets/GridWidget.java
@@ -76,10 +76,11 @@ public class GridWidget extends QuestionWidget {
         gridview = new GridView(context);
         imageViews = new ImageView[mItems.size()];
 
-        // The max width of an icon in a given column. Used to line
-        // up the columns and automatically fit the columns in when
-        // they are chosen automatically
+        // The max width of an icon in a given column. Used to line up the columns and
+        // automatically fit the columns in when they are chosen automatically
         int maxImageWidth = -1;
+        // The max width of an icon in a given column. Used to determine the approximate total
+        // height that the entire grid view will take up
         int maxImageHeight = -1;
 
         for (int i = 0; i < mItems.size(); i++) {

--- a/app/src/org/commcare/views/widgets/GridWidget.java
+++ b/app/src/org/commcare/views/widgets/GridWidget.java
@@ -89,8 +89,8 @@ public class GridWidget extends QuestionWidget {
         // Build view
         for (int i = 0; i < mItems.size(); i++) {
             SelectChoice sc = mItems.get(i);
-            // Read the image sizes and set maxImageWidth. This allows us to make sure all of our
-            // columns are going to fit
+            // Read the image sizes and set maxImageWidth and maxImageHeight. This allows us to
+            // make sure all of our columns are going to fit
             String imageURI =
                     mPrompt.getSpecialFormSelectChoiceText(sc, FormEntryCaption.TEXT_FORM_IMAGE);
 


### PR DESCRIPTION
Fixes issue caused by https://github.com/dimagi/commcare-odk/pull/1233, while retaining the fix that that PR was for.

Since a GridView is intended to be a scrolling container, rather than to wrap all of its contents, we have to explicitly set the height of the GridView based upon how much space we need to fit all of the images. 