### PR TITLE
Don't swallow encoding errors when serializing

### DIFF
--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -31,6 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -102,8 +103,13 @@ public class SaveToDiskTask extends
             e.printStackTrace();
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,
                     "Something is blocking acesss to the submission file in " + FormEntryActivity.mInstancePath);
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch(UnsupportedEncodingException uee) {
+            Logger.exception(uee);
+            Logger.log(AndroidLogger.TYPE_ERROR_CONFIG_STRUCTURE, "Form contains invalid data encoding");
+            return new ResultAndError<>(SaveStatus.SAVE_ERROR,
+                    "Form contains invalidly encoded text! Unable to save contents.");
+        }  catch (IOException e) {
+            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "I/O Error when serializing form");
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,
                     "Unable to write xml to " + FormEntryActivity.mInstancePath);
         } catch (FormInstanceTransactionException e) {

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import org.commcare.activities.FormEntryActivity;
+import org.commcare.android.logging.ForceCloseLogger;
 import org.commcare.interfaces.FormSavedListener;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.encryption.EncryptionIO;
@@ -104,12 +105,11 @@ public class SaveToDiskTask extends
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,
                     "Something is blocking acesss to the submission file in " + FormEntryActivity.mInstancePath);
         } catch(UnsupportedEncodingException uee) {
-            Logger.exception(uee);
-            Logger.log(AndroidLogger.TYPE_ERROR_CONFIG_STRUCTURE, "Form contains invalid data encoding");
+            Logger.log(AndroidLogger.TYPE_ERROR_CONFIG_STRUCTURE, "Form contains invalid data encoding\n\n" + ForceCloseLogger.getStackTrace(uee));
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,
                     "Form contains invalidly encoded text! Unable to save contents.");
         }  catch (IOException e) {
-            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "I/O Error when serializing form");
+            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "I/O Error when serializing form\n\n" + ForceCloseLogger.getStackTrace(e));
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,
                     "Unable to write xml to " + FormEntryActivity.mInstancePath);
         } catch (FormInstanceTransactionException e) {


### PR DESCRIPTION
Moves a force close when serializing documents with encoding errors to a visible error, rather than swallowing those errors

cross-requested: https://github.com/dimagi/javarosa/pull/292