### PR TITLE
Make alert dialogs persist across orientation change

### DIFF
--- a/app/src/org/commcare/activities/AppManagerActivity.java
+++ b/app/src/org/commcare/activities/AppManagerActivity.java
@@ -30,7 +30,7 @@ import org.javarosa.core.services.locale.Localization;
  * @author amstone326
  */
 
-public class AppManagerActivity extends Activity implements OnItemClickListener {
+public class AppManagerActivity extends CommCareActivity implements OnItemClickListener {
 
     public static final String KEY_LAUNCH_FROM_MANAGER = "from_manager";
     private static final int MENU_CONNECTION_DIAGNOSTIC = 0;
@@ -127,14 +127,16 @@ public class AppManagerActivity extends Activity implements OnItemClickListener 
                 if (resultCode == RESULT_CANCELED) {
                     String title = getString(R.string.media_not_verified);
                     String msg = getString(R.string.skipped_verification_warning);
-                    AlertDialogFactory.getBasicAlertFactory(this, title, msg, new DialogInterface.OnClickListener() {
+                    showAlertDialog(
+                            AlertDialogFactory.getBasicAlertFactory(
+                                    this, title, msg, new DialogInterface.OnClickListener() {
 
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             dialog.dismiss();
                         }
 
-                    }).showDialog();
+                    }));
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }
@@ -178,6 +180,6 @@ public class AppManagerActivity extends Activity implements OnItemClickListener 
         };
         factory.setPositiveButton(getString(R.string.ok), listener);
         factory.setNegativeButton(getString(R.string.cancel), listener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 }

--- a/app/src/org/commcare/activities/AppManagerActivity.java
+++ b/app/src/org/commcare/activities/AppManagerActivity.java
@@ -1,6 +1,5 @@
 package org.commcare.activities;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -18,7 +17,7 @@ import org.commcare.adapters.AppManagerAdapter;
 import org.commcare.dalvik.R;
 import org.commcare.services.CommCareSessionService;
 import org.commcare.utils.SessionUnavailableException;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
 
 /**
@@ -128,7 +127,7 @@ public class AppManagerActivity extends CommCareActivity implements OnItemClickL
                     String title = getString(R.string.media_not_verified);
                     String msg = getString(R.string.skipped_verification_warning);
                     showAlertDialog(
-                            AlertDialogFactory.getBasicAlertFactory(
+                            StandardAlertDialog.getBasicAlertDialog(
                                     this, title, msg, new DialogInterface.OnClickListener() {
 
                         @Override
@@ -166,7 +165,7 @@ public class AppManagerActivity extends CommCareActivity implements OnItemClickL
     private void triggerLogoutWarning() {
         String title = getString(R.string.logging_out);
         String message = getString(R.string.logout_warning);
-        AlertDialogFactory factory = new AlertDialogFactory(this, title, message);
+        StandardAlertDialog d = new StandardAlertDialog(this, title, message);
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -178,8 +177,8 @@ public class AppManagerActivity extends CommCareActivity implements OnItemClickL
             }
 
         };
-        factory.setPositiveButton(getString(R.string.ok), listener);
-        factory.setNegativeButton(getString(R.string.cancel), listener);
-        showAlertDialog(factory);
+        d.setPositiveButton(getString(R.string.ok), listener);
+        d.setNegativeButton(getString(R.string.cancel), listener);
+        showAlertDialog(d);
     }
 }

--- a/app/src/org/commcare/activities/CallOutActivity.java
+++ b/app/src/org/commcare/activities/CallOutActivity.java
@@ -18,6 +18,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import org.commcare.interfaces.RuntimePermissionRequester;
+import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.DialogChoiceItem;
 import org.commcare.views.dialogs.DialogCreationHelpers;
 import org.commcare.views.dialogs.PaneledChoiceDialog;
@@ -137,12 +138,12 @@ public class CallOutActivity extends FragmentActivity
     private void dispatchActionWithPermissions() {
         if (missingPhonePermission()) {
             if (shouldShowPhonePermissionRationale()) {
-                AlertDialog dialog =
+                CommCareAlertDialog dialog =
                         DialogCreationHelpers.buildPermissionRequestDialog(this, this,
                                 CALL_OR_SMS_PERMISSION_REQUEST,
                                 Localization.get("permission.case.callout.title"),
                                 Localization.get("permission.case.callout.message"));
-                dialog.show();
+                dialog.showDialog();
             } else {
                 requestNeededPermissions(CALL_OR_SMS_PERMISSION_REQUEST);
             }

--- a/app/src/org/commcare/activities/CallOutActivity.java
+++ b/app/src/org/commcare/activities/CallOutActivity.java
@@ -124,7 +124,7 @@ public class CallOutActivity extends FragmentActivity
                 finish();
             }
         });
-        dialog.show();
+        dialog.showDialog();
     }
 
     @Override

--- a/app/src/org/commcare/activities/CallOutActivity.java
+++ b/app/src/org/commcare/activities/CallOutActivity.java
@@ -1,7 +1,6 @@
 package org.commcare.activities;
 
 import android.Manifest;
-import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
@@ -125,7 +124,7 @@ public class CallOutActivity extends FragmentActivity
                 finish();
             }
         });
-        dialog.showDialog();
+        dialog.showNonPersistentDialog();
     }
 
     @Override
@@ -143,7 +142,7 @@ public class CallOutActivity extends FragmentActivity
                                 CALL_OR_SMS_PERMISSION_REQUEST,
                                 Localization.get("permission.case.callout.title"),
                                 Localization.get("permission.case.callout.message"));
-                dialog.showDialog();
+                dialog.showNonPersistentDialog();
             } else {
                 requestNeededPermissions(CALL_OR_SMS_PERMISSION_REQUEST);
             }

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -43,8 +43,10 @@ import org.commcare.utils.SessionStateUninitException;
 import org.commcare.views.ManagedUiFramework;
 import org.commcare.views.dialogs.AlertDialogFactory;
 import org.commcare.views.dialogs.AlertDialogFragment;
+import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogController;
+import org.commcare.views.dialogs.PaneledChoiceDialog;
 import org.commcare.views.media.AudioController;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
@@ -588,12 +590,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     }
 
     @Override
-    public void showAlertDialog(AlertDialogFactory f) {
+    public void showAlertDialog(CommCareAlertDialog d) {
         if (getCurrentAlertDialog() != null) {
             // Means we already have an alert dialog on screen
             return;
         }
-        AlertDialogFragment dialog = AlertDialogFragment.fromFactory(f);
+        AlertDialogFragment dialog = AlertDialogFragment.fromCommCareAlertDialog(d);
         if (areFragmentsPaused) {
             alertDialogToShowOnResume = dialog;
         } else {

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -41,12 +41,11 @@ import org.commcare.utils.ConnectivityStatus;
 import org.commcare.utils.MarkupUtil;
 import org.commcare.utils.SessionStateUninitException;
 import org.commcare.views.ManagedUiFramework;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.AlertDialogFragment;
 import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogController;
-import org.commcare.views.dialogs.PaneledChoiceDialog;
 import org.commcare.views.media.AudioController;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
@@ -246,7 +245,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     private void showPendingUserMessage() {
         String[] messageAndTitle = CommCareApplication._().getPendingUserMessage();
         if (messageAndTitle != null) {
-            showAlertDialog(AlertDialogFactory.getBasicAlertFactory(
+            showAlertDialog(StandardAlertDialog.getBasicAlertDialog(
                     this, messageAndTitle[1], messageAndTitle[0], null));
             CommCareApplication._().clearPendingUserMessage();
         }
@@ -396,9 +395,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                 }
             }
         };
-        AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactoryWithIcon(this, title,
-                message, android.R.drawable.ic_dialog_info, listener);
-        showAlertDialog(f);
+        showAlertDialog(StandardAlertDialog.getBasicAlertDialogWithIcon(this, title,
+                message, android.R.drawable.ic_dialog_info, listener));
     }
 
     @Override

--- a/app/src/org/commcare/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/activities/CommCareFormDumpActivity.java
@@ -23,7 +23,7 @@ import org.commcare.utils.FileUtil;
 import org.commcare.utils.StorageUtils;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.UiElement;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.notifications.NotificationMessageFactory;
 import org.commcare.views.notifications.NotificationMessageFactory.StockMessages;
@@ -187,7 +187,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
     }
 
     private void showWarningMessage() {
-        AlertDialogFactory factory = new AlertDialogFactory(this,
+        StandardAlertDialog d = new StandardAlertDialog(this,
                 Localization.get("bulk.form.alert.title"), Localization.get("bulk.form.warning"));
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
@@ -200,9 +200,9 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
                 }
             }
         };
-        factory.setPositiveButton("OK", listener);
-        factory.setNegativeButton("NO", listener);
-        showAlertDialog(factory);
+        d.setPositiveButton("OK", listener);
+        d.setNegativeButton("NO", listener);
+        showAlertDialog(d);
     }
 
     private void updateCounters() {

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -63,7 +63,7 @@ import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StorageUtils;
 import org.commcare.views.HorizontalMediaView;
 import org.commcare.views.UserfacingErrorHandling;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogChoiceItem;
@@ -308,10 +308,9 @@ public class CommCareHomeActivity
     }
 
     private void showPinFutureAccessDialog() {
-        AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactory(this,
+        showAlertDialog(StandardAlertDialog.getBasicAlertDialog(this,
                 Localization.get("pin.dialog.set.later.title"),
-                Localization.get("pin.dialog.set.later.message"), null);
-        showAlertDialog(f);
+                Localization.get("pin.dialog.set.later.message"), null));
     }
 
     private void launchPinAuthentication() {
@@ -745,7 +744,7 @@ public class CommCareHomeActivity
     }
 
     private void showSessionRefreshWarning() {
-        showAlertDialog(AlertDialogFactory.getBasicAlertFactory(this,
+        showAlertDialog(StandardAlertDialog.getBasicAlertDialog(this,
                 Localization.get("session.refresh.error.title"),
                 Localization.get("session.refresh.error.message"), null));
     }
@@ -772,10 +771,9 @@ public class CommCareHomeActivity
     }
 
     private void createErrorDialog(String errorMsg, AlertDialog.OnClickListener errorListener) {
-        AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactoryWithIcon(this,
+        showAlertDialog(StandardAlertDialog.getBasicAlertDialogWithIcon(this,
                 Localization.get("app.handled.error.title"), errorMsg,
-                android.R.drawable.ic_dialog_info, errorListener);
-        showAlertDialog(f);
+                android.R.drawable.ic_dialog_info, errorListener));
     }
 
     @Override
@@ -1112,7 +1110,7 @@ public class CommCareHomeActivity
         final AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
         String title = Localization.get("app.workflow.incomplete.continue.title");
         String msg = Localization.get("app.workflow.incomplete.continue");
-        AlertDialogFactory factory = new AlertDialogFactory(this, title, msg);
+        StandardAlertDialog d = new StandardAlertDialog(this, title, msg);
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {
@@ -1133,10 +1131,10 @@ public class CommCareHomeActivity
                 dialog.dismiss();
             }
         };
-        factory.setPositiveButton(Localization.get("option.yes"), listener);
-        factory.setNegativeButton(Localization.get("app.workflow.incomplete.continue.option.delete"), listener);
-        factory.setNeutralButton(Localization.get("option.no"), listener);
-        showAlertDialog(factory);
+        d.setPositiveButton(Localization.get("option.yes"), listener);
+        d.setNegativeButton(Localization.get("app.workflow.incomplete.continue.option.delete"), listener);
+        d.setNeutralButton(Localization.get("option.no"), listener);
+        showAlertDialog(d);
     }
 
     void displayMessage(String message) {

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -308,9 +308,9 @@ public class CommCareHomeActivity
     }
 
     private void showPinFutureAccessDialog() {
-        showAlertDialog(StandardAlertDialog.getBasicAlertDialog(this,
+        StandardAlertDialog.getBasicAlertDialog(this,
                 Localization.get("pin.dialog.set.later.title"),
-                Localization.get("pin.dialog.set.later.message"), null));
+                Localization.get("pin.dialog.set.later.message"), null).showDialog();
     }
 
     private void launchPinAuthentication() {

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -310,7 +310,7 @@ public class CommCareHomeActivity
     private void showPinFutureAccessDialog() {
         StandardAlertDialog.getBasicAlertDialog(this,
                 Localization.get("pin.dialog.set.later.title"),
-                Localization.get("pin.dialog.set.later.message"), null).showDialog();
+                Localization.get("pin.dialog.set.later.message"), null).showNonPersistentDialog();
     }
 
     private void launchPinAuthentication() {

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -64,6 +64,7 @@ import org.commcare.utils.StorageUtils;
 import org.commcare.views.HorizontalMediaView;
 import org.commcare.views.UserfacingErrorHandling;
 import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogChoiceItem;
 import org.commcare.views.dialogs.DialogCreationHelpers;
@@ -1303,7 +1304,7 @@ public class CommCareHomeActivity
     }
 
     private void showAboutCommCareDialog() {
-        AlertDialog dialog = DialogCreationHelpers.buildAboutCommCareDialog(this);
+        CommCareAlertDialog dialog = DialogCreationHelpers.buildAboutCommCareDialog(this);
 
         dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
             @Override
@@ -1319,7 +1320,8 @@ public class CommCareHomeActivity
             }
 
         });
-        dialog.show();
+
+        showAlertDialog(dialog);
     }
 
     private boolean hasP2p() {

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -303,14 +303,14 @@ public class CommCareHomeActivity
 
         dialog.setChoiceItems(new DialogChoiceItem[]{createPinChoice, nextTimeChoice, notAgainChoice});
         dialog.addCollapsibleInfoPane(Localization.get("pin.dialog.extra.info"));
-        dialog.show();
+        showAlertDialog(dialog);
     }
 
     private void showPinFutureAccessDialog() {
         AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactory(this,
                 Localization.get("pin.dialog.set.later.title"),
                 Localization.get("pin.dialog.set.later.message"), null);
-        f.showDialog();
+        showAlertDialog(f);
     }
 
     private void launchPinAuthentication() {
@@ -744,9 +744,9 @@ public class CommCareHomeActivity
     }
 
     private void showSessionRefreshWarning() {
-        AlertDialogFactory.getBasicAlertFactory(this,
+        showAlertDialog(AlertDialogFactory.getBasicAlertFactory(this,
                 Localization.get("session.refresh.error.title"),
-                Localization.get("session.refresh.error.message"), null).showDialog();
+                Localization.get("session.refresh.error.message"), null));
     }
 
     private void showDemoModeWarning() {

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -45,6 +45,7 @@ import org.commcare.tasks.RetrieveParseVerifyMessageTask;
 import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.Permissions;
 import org.commcare.views.ManagedUi;
+import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogCreationHelpers;
 import org.commcare.views.notifications.NotificationMessage;
@@ -496,12 +497,10 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
             if (ActivityCompat.shouldShowRequestPermissionRationale(this,
                     Manifest.permission.READ_SMS)) {
-                AlertDialog dialog =
-                        DialogCreationHelpers.buildPermissionRequestDialog(this, this,
+                DialogCreationHelpers.buildPermissionRequestDialog(this, this,
                                 SMS_PERMISSIONS_REQUEST,
                                 Localization.get("permission.sms.install.title"),
-                                Localization.get("permission.sms.install.message"));
-                dialog.show();
+                                Localization.get("permission.sms.install.message")).showDialog();
             } else {
                 requestNeededPermissions(SMS_PERMISSIONS_REQUEST);
             }

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -3,7 +3,6 @@ package org.commcare.activities;
 import android.Manifest;
 import android.app.ActionBar;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
@@ -45,7 +44,6 @@ import org.commcare.tasks.RetrieveParseVerifyMessageTask;
 import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.Permissions;
 import org.commcare.views.ManagedUi;
-import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogCreationHelpers;
 import org.commcare.views.notifications.NotificationMessage;
@@ -500,7 +498,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 DialogCreationHelpers.buildPermissionRequestDialog(this, this,
                                 SMS_PERMISSIONS_REQUEST,
                                 Localization.get("permission.sms.install.title"),
-                                Localization.get("permission.sms.install.message")).showDialog();
+                                Localization.get("permission.sms.install.message")).showNonPersistentDialog();
             } else {
                 requestNeededPermissions(SMS_PERMISSIONS_REQUEST);
             }

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -48,7 +48,7 @@ import org.commcare.tasks.ZipTask;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.StorageUtils;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
@@ -208,7 +208,7 @@ public class CommCareWiFiDirectActivity
     }
 
     private void showDialog(Activity activity, String title, String message) {
-        AlertDialogFactory factory = new AlertDialogFactory(activity, title, message);
+        StandardAlertDialog d = new StandardAlertDialog(activity, title, message);
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -226,10 +226,10 @@ public class CommCareWiFiDirectActivity
                 dialog.dismiss();
             }
         };
-        factory.setNeutralButton(localize("wifi.direct.receive.forms"), listener);
-        factory.setNegativeButton(localize("wifi.direct.transfer.forms"), listener);
-        factory.setPositiveButton(localize("wifi.direct.submit.forms"), listener);
-        showAlertDialog(factory);
+        d.setNeutralButton(localize("wifi.direct.receive.forms"), listener);
+        d.setNegativeButton(localize("wifi.direct.transfer.forms"), listener);
+        d.setPositiveButton(localize("wifi.direct.submit.forms"), listener);
+        showAlertDialog(d);
     }
 
     private void beSender() {

--- a/app/src/org/commcare/activities/CreatePinActivity.java
+++ b/app/src/org/commcare/activities/CreatePinActivity.java
@@ -198,7 +198,7 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
             }
         });
 
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 
     public static TextWatcher getPinTextWatcher(final Button confirmButton) {

--- a/app/src/org/commcare/activities/CreatePinActivity.java
+++ b/app/src/org/commcare/activities/CreatePinActivity.java
@@ -19,7 +19,7 @@ import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.UiElement;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
 
 /**
@@ -172,11 +172,11 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
     }
 
     private void launchRememberPasswordConfirmDialog() {
-        AlertDialogFactory factory = new AlertDialogFactory(this,
+        StandardAlertDialog d = new StandardAlertDialog(this,
                 Localization.get("remember.password.confirm.title"),
                 Localization.get("remember.password.confirm.message"));
 
-        factory.setPositiveButton(Localization.get("dialog.ok"), new DialogInterface.OnClickListener() {
+        d.setPositiveButton(Localization.get("dialog.ok"), new DialogInterface.OnClickListener() {
 
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -190,7 +190,7 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
             }
         });
 
-        factory.setNegativeButton(Localization.get("option.cancel"), new DialogInterface.OnClickListener() {
+        d.setNegativeButton(Localization.get("option.cancel"), new DialogInterface.OnClickListener() {
 
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -198,7 +198,7 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
             }
         });
 
-        showAlertDialog(factory);
+        showAlertDialog(d);
     }
 
     public static TextWatcher getPinTextWatcher(final Button confirmButton) {

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -15,7 +15,7 @@ import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.utils.AndroidShortcuts;
 import org.commcare.utils.SessionUnavailableException;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
@@ -350,7 +350,7 @@ public class DispatchActivity extends FragmentActivity {
         String title = "Storage is Corrupt :/";
         String message = "Sorry, something really bad has happened, and the app can't start up. " +
                 "With your permission CommCare can try to repair itself if you have network access.";
-        AlertDialogFactory factory = new AlertDialogFactory(this, title, message);
+        StandardAlertDialog d = new StandardAlertDialog(this, title, message);
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {
@@ -364,8 +364,8 @@ public class DispatchActivity extends FragmentActivity {
                 }
             }
         };
-        factory.setPositiveButton("Enter Recovery Mode", listener);
-        factory.setNegativeButton("Shut Down", listener);
-        return factory.getDialog();
+        d.setPositiveButton("Enter Recovery Mode", listener);
+        d.setNegativeButton("Shut Down", listener);
+        return d.getDialog();
     }
 }

--- a/app/src/org/commcare/activities/DrawActivity.java
+++ b/app/src/org/commcare/activities/DrawActivity.java
@@ -321,7 +321,7 @@ public class DrawActivity extends Activity {
             }
         });
 
-        dialog.show();
+        dialog.showDialog();
     }
 
     private static class DrawView extends View {

--- a/app/src/org/commcare/activities/DrawActivity.java
+++ b/app/src/org/commcare/activities/DrawActivity.java
@@ -321,7 +321,7 @@ public class DrawActivity extends Activity {
             }
         });
 
-        dialog.showDialog();
+        dialog.showNonPersistentDialog();
     }
 
     private static class DrawView extends View {

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -786,7 +786,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     private void createSortMenu() {
         final PaneledChoiceDialog dialog = new PaneledChoiceDialog(this, Localization.get("select.menu.sort"));
         dialog.setChoiceItems(getSortOptionsList(dialog));
-        dialog.show();
+        showAlertDialog(dialog);
     }
 
     private DialogChoiceItem[] getSortOptionsList(final PaneledChoiceDialog dialog) {

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1292,7 +1292,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     }
                 }
         );
-        dialog.show();
+        showAlertDialog(dialog);
     }
 
     private void saveFormToDisk(boolean exit) {
@@ -1413,7 +1413,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             items = new DialogChoiceItem[] {stayInFormItem, quitFormItem};
         }
         dialog.setChoiceItems(items);
-        dialog.show();
+        showAlertDialog(dialog);
     }
 
     private void discardChangesAndExit() {
@@ -1505,7 +1505,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         );
 
         dialog.setChoiceItems(choiceItems);
-        dialog.show();
+        showAlertDialog(dialog);
     }
 
     @Override

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -85,7 +85,7 @@ import org.commcare.utils.UriToFilePath;
 import org.commcare.views.QuestionsView;
 import org.commcare.views.ResizingImageView;
 import org.commcare.views.UserfacingErrorHandling;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogChoiceItem;
 import org.commcare.views.dialogs.HorizontalPaneledChoiceDialog;
@@ -1432,8 +1432,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             question = question.substring(0, 50) + "...";
         }
         String msg = StringUtils.getStringSpannableRobust(this, R.string.clearanswer_confirm, question).toString();
-        AlertDialogFactory factory = new AlertDialogFactory(this, title, msg);
-        factory.setIcon(android.R.drawable.ic_dialog_info);
+        StandardAlertDialog d = new StandardAlertDialog(this, title, msg);
+        d.setIcon(android.R.drawable.ic_dialog_info);
 
         DialogInterface.OnClickListener quitListener = new DialogInterface.OnClickListener() {
 
@@ -1450,9 +1450,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 dialog.dismiss();
             }
         };
-        factory.setPositiveButton(StringUtils.getStringSpannableRobust(this, R.string.discard_answer), quitListener);
-        factory.setNegativeButton(StringUtils.getStringSpannableRobust(this, R.string.clear_answer_no), quitListener);
-        showAlertDialog(factory);
+        d.setPositiveButton(StringUtils.getStringSpannableRobust(this, R.string.discard_answer), quitListener);
+        d.setNegativeButton(StringUtils.getStringSpannableRobust(this, R.string.clear_answer_no), quitListener);
+        showAlertDialog(d);
     }
 
     /**

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -52,7 +52,7 @@ import org.commcare.tasks.TaskListenerRegistrationException;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.CommCareUtil;
 import org.commcare.views.IncompleteFormRecordView;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
@@ -376,9 +376,8 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
 
             finish();
         } else {
-            AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactory(this, "Form Missing",
-                    Localization.get("form.record.gone.message"), null);
-            showAlertDialog(f);
+            showAlertDialog(StandardAlertDialog.getBasicAlertDialog(this, "Form Missing",
+                    Localization.get("form.record.gone.message"), null));
         }
     }
 
@@ -445,9 +444,8 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
             title = Localization.get("app.workflow.forms.scan.title.invalid");
         }
         int resId = result.first ? R.drawable.checkmark : R.drawable.redx;
-        AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactoryWithIcon(this, title,
-                result.second, resId, null);
-        showAlertDialog(f);
+        showAlertDialog(StandardAlertDialog.getBasicAlertDialogWithIcon(this, title,
+                result.second, resId, null));
     }
 
     /**

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -440,7 +440,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                         false, LoginMode.PASSWORD);
                 return true;
             case MENU_ABOUT:
-                DialogCreationHelpers.buildAboutCommCareDialog(this).showDialog();
+                DialogCreationHelpers.buildAboutCommCareDialog(this).showNonPersistentDialog();
                 return true;
             case MENU_PERMISSIONS:
                 Permissions.acquireAllAppPermissions(this, this, Permissions.ALL_PERMISSIONS_REQUEST);

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -440,7 +440,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                         false, LoginMode.PASSWORD);
                 return true;
             case MENU_ABOUT:
-                DialogCreationHelpers.buildAboutCommCareDialog(this).show();
+                DialogCreationHelpers.buildAboutCommCareDialog(this).showDialog();
                 return true;
             case MENU_PERMISSIONS:
                 Permissions.acquireAllAppPermissions(this, this, Permissions.ALL_PERMISSIONS_REQUEST);

--- a/app/src/org/commcare/activities/RefreshToLatestBuildActivity.java
+++ b/app/src/org/commcare/activities/RefreshToLatestBuildActivity.java
@@ -1,6 +1,5 @@
 package org.commcare.activities;
 
-import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -11,7 +10,7 @@ import org.commcare.dalvik.R;
 import org.commcare.preferences.DevSessionRestorer;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.utils.SessionUnavailableException;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
 
 /**
@@ -113,8 +112,7 @@ public class RefreshToLatestBuildActivity extends CommCareActivity {
             }
         };
 
-        AlertDialogFactory factory = AlertDialogFactory.getBasicAlertFactory(this, title, message, listener);
-        showAlertDialog(factory);
+        showAlertDialog(StandardAlertDialog.getBasicAlertDialog(this, title, message, listener));
     }
 
     private String getCurrentUserPassword() throws SessionUnavailableException {

--- a/app/src/org/commcare/activities/RefreshToLatestBuildActivity.java
+++ b/app/src/org/commcare/activities/RefreshToLatestBuildActivity.java
@@ -24,7 +24,7 @@ import org.javarosa.core.services.locale.Localization;
  *
  * @author Aliza Stone (astone@dimagi.com)
  */
-public class RefreshToLatestBuildActivity extends Activity {
+public class RefreshToLatestBuildActivity extends CommCareActivity {
 
     public static final String KEY_FROM_LATEST_BUILD_ACTIVITY = "from-test-latest-build-util";
     public static final String KEY_UPDATE_ATTEMPT_RESULT = "result-of-update-attempt";
@@ -114,7 +114,7 @@ public class RefreshToLatestBuildActivity extends Activity {
         };
 
         AlertDialogFactory factory = AlertDialogFactory.getBasicAlertFactory(this, title, message, listener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 
     private String getCurrentUserPassword() throws SessionUnavailableException {

--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -28,7 +28,7 @@ import org.commcare.views.dialogs.AlertDialogFactory;
  * @author amstone
  */
 
-public class SingleAppManagerActivity extends Activity {
+public class SingleAppManagerActivity extends CommCareActivity {
 
     private ApplicationRecord appRecord;
     private static final int LOGOUT_FOR_UPDATE = 0;
@@ -130,7 +130,7 @@ public class SingleAppManagerActivity extends Activity {
                 if (resultCode == RESULT_CANCELED) {
                     String title = getString(R.string.media_not_verified);
                     String msg = getString(R.string.skipped_verification_warning_2);
-                    AlertDialogFactory.getBasicAlertFactory(this, title, msg, null).showDialog();
+                    showAlertDialog(AlertDialogFactory.getBasicAlertFactory(this, title, msg, null));
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }
@@ -257,7 +257,7 @@ public class SingleAppManagerActivity extends Activity {
         };
         factory.setPositiveButton(getString(R.string.ok), listener);
         factory.setNegativeButton(getString(R.string.cancel), listener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 
     /**
@@ -291,6 +291,6 @@ public class SingleAppManagerActivity extends Activity {
         };
         factory.setPositiveButton(getString(R.string.ok), listener);
         factory.setNegativeButton(getString(R.string.cancel), listener);
-        factory.showDialog();
+        showAlertDialog(factory);
     }
 }

--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -1,6 +1,5 @@
 package org.commcare.activities;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -17,7 +16,7 @@ import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.services.CommCareSessionService;
 import org.commcare.tasks.UpdateTask;
 import org.commcare.utils.SessionUnavailableException;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 
 
 /**
@@ -130,7 +129,7 @@ public class SingleAppManagerActivity extends CommCareActivity {
                 if (resultCode == RESULT_CANCELED) {
                     String title = getString(R.string.media_not_verified);
                     String msg = getString(R.string.skipped_verification_warning_2);
-                    showAlertDialog(AlertDialogFactory.getBasicAlertFactory(this, title, msg, null));
+                    showAlertDialog(StandardAlertDialog.getBasicAlertDialog(this, title, msg, null));
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }
@@ -244,7 +243,7 @@ public class SingleAppManagerActivity extends CommCareActivity {
      * @param v linter sees this as unused, but is required for a button to find its onClick method
      */
     public void rebootAlertDialog(View v) {
-        AlertDialogFactory factory = new AlertDialogFactory(this, getString(R.string.uninstalling),
+        StandardAlertDialog d = new StandardAlertDialog(this, getString(R.string.uninstalling),
                 getString(R.string.uninstall_reboot_warning));
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             @Override
@@ -255,9 +254,9 @@ public class SingleAppManagerActivity extends CommCareActivity {
                 }
             }
         };
-        factory.setPositiveButton(getString(R.string.ok), listener);
-        factory.setNegativeButton(getString(R.string.cancel), listener);
-        showAlertDialog(factory);
+        d.setPositiveButton(getString(R.string.ok), listener);
+        d.setNegativeButton(getString(R.string.cancel), listener);
+        showAlertDialog(d);
     }
 
     /**
@@ -265,7 +264,7 @@ public class SingleAppManagerActivity extends CommCareActivity {
      * session being logged out
      */
     private void triggerLogoutWarning(final int actionKey) {
-        AlertDialogFactory factory = new AlertDialogFactory(this, getString(R.string.logging_out),
+        StandardAlertDialog d = new StandardAlertDialog(this, getString(R.string.logging_out),
                 getString(R.string.logout_warning));
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
 
@@ -289,8 +288,8 @@ public class SingleAppManagerActivity extends CommCareActivity {
             }
 
         };
-        factory.setPositiveButton(getString(R.string.ok), listener);
-        factory.setNegativeButton(getString(R.string.cancel), listener);
-        showAlertDialog(factory);
+        d.setPositiveButton(getString(R.string.ok), listener);
+        d.setNegativeButton(getString(R.string.cancel), listener);
+        showAlertDialog(d);
     }
 }

--- a/app/src/org/commcare/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/activities/UnrecoverableErrorActivity.java
@@ -6,7 +6,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 
 import org.commcare.CommCareApplication;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
 
 /**
@@ -36,13 +36,13 @@ public class UnrecoverableErrorActivity extends Activity {
         if (useExtraMessage) {
             message = message + "\n\n" + Localization.get("app.handled.error.explanation");
         }
-        AlertDialogFactory factory = new AlertDialogFactory(this, title, message);
+        StandardAlertDialog d = new StandardAlertDialog(this, title, message);
         DialogInterface.OnClickListener buttonListener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
                 CommCareApplication.restartCommCare(UnrecoverableErrorActivity.this);
             }
         };
-        factory.setPositiveButton(Localization.get("app.storage.missing.button"), buttonListener);
-        return factory.getDialog();
+        d.setPositiveButton(Localization.get("app.storage.missing.button"), buttonListener);
+        return d.getDialog();
     }
 }

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.CommCareSetupActivity;
 import org.commcare.android.nsd.MicroNode;
 import org.commcare.android.nsd.NSDDiscoveryTools;
@@ -133,7 +134,7 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
             count++;
         }
         chooseApp.setChoiceItems(items);
-        chooseApp.show();
+        ((CommCareActivity)getActivity()).showAlertDialog(chooseApp);
     }
 
     @Override

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -280,7 +280,7 @@ public class CommCarePreferences
                     }
                 });
 
-        f.showDialog();
+        f.showNonPersistentDialog();
     }
 
 

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -28,7 +28,7 @@ import org.commcare.utils.CommCareUtil;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.TemplatePrinterUtils;
 import org.commcare.utils.UriToFilePath;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 
@@ -257,7 +257,7 @@ public class CommCarePreferences
     }
 
     private void showAnalyticsOptOutDialog() {
-        AlertDialogFactory f = new AlertDialogFactory(this,
+        StandardAlertDialog f = new StandardAlertDialog(this,
                 Localization.get("analytics.opt.out.title"),
                 Localization.get("analytics.opt.out.message"));
 

--- a/app/src/org/commcare/utils/AndroidShortcuts.java
+++ b/app/src/org/commcare/utils/AndroidShortcuts.java
@@ -57,7 +57,7 @@ public class AndroidShortcuts extends Activity {
                 sc.finish();
             }
         });
-        dialog.show();
+        dialog.showDialog();
     }
 
     private DialogChoiceItem[] getChoiceItemList(final PaneledChoiceDialog dialog) {

--- a/app/src/org/commcare/utils/AndroidShortcuts.java
+++ b/app/src/org/commcare/utils/AndroidShortcuts.java
@@ -57,7 +57,7 @@ public class AndroidShortcuts extends Activity {
                 sc.finish();
             }
         });
-        dialog.showDialog();
+        dialog.showNonPersistentDialog();
     }
 
     private DialogChoiceItem[] getChoiceItemList(final PaneledChoiceDialog dialog) {

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -106,7 +106,7 @@ public class GeoUtils {
         StandardAlertDialog factory = setupAlertFactory(activity, onChange, onCancel);
 
         // NOTE PLM: this dialog will not persist through orientation changes.
-        factory.showDialog();
+        factory.showNonPersistentDialog();
     }
 
     private static StandardAlertDialog setupAlertFactory(Context context,

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -11,7 +11,7 @@ import android.support.v4.content.ContextCompat;
 
 import org.commcare.activities.CommCareActivity;
 import org.commcare.dalvik.R;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.UncastData;
 
@@ -90,7 +90,7 @@ public class GeoUtils {
      */
     public static void showNoGpsDialog(CommCareActivity activity,
                                        DialogInterface.OnClickListener onChange) {
-        AlertDialogFactory factory = setupAlertFactory(activity, onChange, null);
+        StandardAlertDialog factory = setupAlertFactory(activity, onChange, null);
         activity.showAlertDialog(factory);
     }
 
@@ -103,17 +103,17 @@ public class GeoUtils {
     public static void showNoGpsDialog(Activity activity,
                                        DialogInterface.OnClickListener onChange,
                                        DialogInterface.OnCancelListener onCancel) {
-        AlertDialogFactory factory = setupAlertFactory(activity, onChange, onCancel);
+        StandardAlertDialog factory = setupAlertFactory(activity, onChange, onCancel);
 
         // NOTE PLM: this dialog will not persist through orientation changes.
         factory.showDialog();
     }
 
-    private static AlertDialogFactory setupAlertFactory(Context context,
-                                                        DialogInterface.OnClickListener onChange,
-                                                        DialogInterface.OnCancelListener onCancel) {
-        AlertDialogFactory factory =
-                new AlertDialogFactory(context,
+    private static StandardAlertDialog setupAlertFactory(Context context,
+                                                         DialogInterface.OnClickListener onChange,
+                                                         DialogInterface.OnCancelListener onCancel) {
+        StandardAlertDialog factory =
+                new StandardAlertDialog(context,
                         context.getString(R.string.no_gps_title),
                         context.getString(R.string.no_gps_message));
         factory.setPositiveButton(context.getString(R.string.change_settings), onChange);

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -9,6 +9,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 
 import org.commcare.interfaces.RuntimePermissionRequester;
+import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.DialogCreationHelpers;
 import org.javarosa.core.services.locale.Localization;
 
@@ -37,12 +38,12 @@ public class Permissions {
 
         if (missingAppPermission(activity, permissions)) {
             if (shouldShowPermissionRationale(activity, permissions)) {
-                AlertDialog dialog =
+                CommCareAlertDialog dialog =
                         DialogCreationHelpers.buildPermissionRequestDialog(activity, permRequester,
                                 permRequestCode,
                                 Localization.get("permission.all.title"),
                                 Localization.get("permission.all.message"));
-                dialog.show();
+                dialog.showDialog();
             } else {
                 permRequester.requestNeededPermissions(permRequestCode);
             }

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -2,7 +2,6 @@ package org.commcare.utils;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.v4.app.ActivityCompat;
@@ -43,7 +42,7 @@ public class Permissions {
                                 permRequestCode,
                                 Localization.get("permission.all.title"),
                                 Localization.get("permission.all.message"));
-                dialog.showDialog();
+                dialog.showNonPersistentDialog();
             } else {
                 permRequester.requestNeededPermissions(permRequestCode);
             }

--- a/app/src/org/commcare/utils/TemplatePrinterUtils.java
+++ b/app/src/org/commcare/utils/TemplatePrinterUtils.java
@@ -153,7 +153,7 @@ public abstract class TemplatePrinterUtils {
                     activity.finish();
                 }
             }
-        }).showDialog();
+        }).showNonPersistentDialog();
     }
 
     public static void showPrintStatusDialog(final Activity activity, String title, String msg,
@@ -170,7 +170,7 @@ public abstract class TemplatePrinterUtils {
                         activity.setResult(Activity.RESULT_OK, intent);
                         activity.finish();
                     }
-                }).showDialog();
+                }).showNonPersistentDialog();
 
     }
 

--- a/app/src/org/commcare/utils/TemplatePrinterUtils.java
+++ b/app/src/org/commcare/utils/TemplatePrinterUtils.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 import android.text.TextUtils;
 
 import org.commcare.models.encryption.CryptUtil;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -146,7 +146,7 @@ public abstract class TemplatePrinterUtils {
      */
     public static void showAlertDialog(final Activity activity, String title, String msg,
                                        final boolean finishActivity) {
-        AlertDialogFactory.getBasicAlertFactory(activity, title, msg, new DialogInterface.OnClickListener() {
+        StandardAlertDialog.getBasicAlertDialog(activity, title, msg, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();
                 if (finishActivity) {
@@ -158,7 +158,7 @@ public abstract class TemplatePrinterUtils {
 
     public static void showPrintStatusDialog(final Activity activity, String title, String msg,
                                              final boolean printInitiated) {
-        AlertDialogFactory.getBasicAlertFactory(activity, title, msg,
+        StandardAlertDialog.getBasicAlertDialog(activity, title, msg,
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {

--- a/app/src/org/commcare/views/UserfacingErrorHandling.java
+++ b/app/src/org/commcare/views/UserfacingErrorHandling.java
@@ -6,7 +6,7 @@ import android.content.DialogInterface;
 import org.commcare.activities.CommCareActivity;
 import org.commcare.logging.XPathErrorLogger;
 import org.commcare.utils.StringUtils;
-import org.commcare.views.dialogs.AlertDialogFactory;
+import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.xpath.XPathException;
 
 /**
@@ -39,7 +39,7 @@ public class UserfacingErrorHandling {
 
     public static void createErrorDialog(final CommCareActivity activity, String errorMsg,
                                          String dialogTitle, final boolean shouldExit) {
-        AlertDialogFactory factory = new AlertDialogFactory(activity, dialogTitle, errorMsg);
+        StandardAlertDialog factory = new StandardAlertDialog(activity, dialogTitle, errorMsg);
         factory.setIcon(android.R.drawable.ic_dialog_info);
 
         DialogInterface.OnCancelListener cancelListener =

--- a/app/src/org/commcare/views/dialogs/AlertDialogFactory.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFactory.java
@@ -27,7 +27,6 @@ public class AlertDialogFactory extends CommCareAlertDialog {
         messageView.setText(msg);
 
         dialog = builder.create();
-        isCancelable = false;
     }
 
     /**

--- a/app/src/org/commcare/views/dialogs/AlertDialogFactory.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFactory.java
@@ -15,12 +15,7 @@ import org.javarosa.core.services.locale.Localization;
 /**
  * Created by amstone326 on 10/9/15.
  */
-public class AlertDialogFactory {
-
-    private final AlertDialog dialog;
-    private final View view;
-    private DialogInterface.OnCancelListener cancelListener;
-    private boolean isCancelable = false;
+public class AlertDialogFactory extends CommCareAlertDialog {
 
     public AlertDialogFactory(Context context, String title, String msg) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
@@ -31,8 +26,8 @@ public class AlertDialogFactory {
         TextView messageView = (TextView)view.findViewById(R.id.dialog_message);
         messageView.setText(msg);
 
-        this.dialog = builder.create();
-        dialog.setCancelable(false); // false by default, can change using makeCancelable()
+        dialog = builder.create();
+        isCancelable = false;
     }
 
     /**
@@ -82,37 +77,6 @@ public class AlertDialogFactory {
         return factory;
     }
 
-    public AlertDialog getDialog() {
-        finalizeView();
-        return this.dialog;
-    }
-
-    public void showDialog() {
-        finalizeView();
-        dialog.show();
-    }
-
-    private void finalizeView() {
-        dialog.setView(this.view);
-    }
-
-    private void makeCancelable() {
-        isCancelable = true;
-        dialog.setCancelable(true);
-    }
-
-    public void setOnCancelListener(DialogInterface.OnCancelListener cancelListener) {
-        makeCancelable();
-        this.cancelListener = cancelListener;
-        dialog.setOnCancelListener(cancelListener);
-    }
-
-    public void performCancel(DialogInterface dialog) {
-        if (cancelListener != null) {
-            cancelListener.onCancel(dialog);
-        }
-    }
-
     public void setIcon(int resId) {
         ImageView icon = (ImageView)view.findViewById(R.id.dialog_title).findViewById(R.id.dialog_title_icon);
         icon.setImageResource(resId);
@@ -155,7 +119,4 @@ public class AlertDialogFactory {
         neutralButton.setVisibility(View.VISIBLE);
     }
 
-    public boolean isCancelable() {
-        return isCancelable;
-    }
 }

--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -38,11 +38,13 @@ public class AlertDialogFragment extends DialogFragment {
 
     @Override
     public void onCancel(DialogInterface dialog) {
+        super.onCancel(dialog);
         underlyingDialog.performCancel(dialog);
     }
 
     @Override
     public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
         underlyingDialog.performDismiss(dialog);
     }
 

--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -7,7 +7,9 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 
 /**
- * Dialog that persists across screen orientation changes, wraps AlertDialogFactory
+ * Wrapper for CommCareAlertDialogs that allows them to persist across screen orientation changes,
+ * by creating a DialogFragment from a CommCareAlertDialog at the time of actually showing the
+ * dialog
  *
  * @author Phillip Mates (pmates@dimagi.com)
  * @author Aliza Stone (astone@dimagi.com)

--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -14,17 +14,18 @@ import android.support.v4.app.DialogFragment;
  */
 public class AlertDialogFragment extends DialogFragment {
 
-    private AlertDialogFactory factory;
+    private CommCareAlertDialog underlyingDialog;
 
-    public static AlertDialogFragment fromFactory(AlertDialogFactory f) {
+    public static AlertDialogFragment fromCommCareAlertDialog(CommCareAlertDialog d) {
+        d.finalizeView();
         AlertDialogFragment frag = new AlertDialogFragment();
-        frag.setFactory(f);
-        frag.setCancelable(f.isCancelable());
+        frag.setUnderlyingDialog(d);
+        frag.setCancelable(d.isCancelable());
         return frag;
     }
 
-    private void setFactory(AlertDialogFactory f) {
-        this.factory = f;
+    private void setUnderlyingDialog(CommCareAlertDialog d) {
+        this.underlyingDialog = d;
     }
 
     @Override
@@ -35,13 +36,18 @@ public class AlertDialogFragment extends DialogFragment {
 
     @Override
     public void onCancel(DialogInterface dialog) {
-        factory.performCancel(dialog);
+        underlyingDialog.performCancel(dialog);
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        underlyingDialog.performDismiss(dialog);
     }
 
     @Override
     @NonNull
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        return factory.getDialog();
+        return underlyingDialog.getDialog();
     }
 
     @Override

--- a/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
@@ -1,0 +1,62 @@
+package org.commcare.views.dialogs;
+
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.view.View;
+
+/**
+ * Created by amstone326 on 4/30/16.
+ */
+public abstract class CommCareAlertDialog {
+
+    protected AlertDialog dialog;
+    protected DialogInterface.OnCancelListener cancelListener;
+    protected DialogInterface.OnDismissListener dismissListener;
+
+    protected boolean isCancelable;
+    protected View view;
+
+    public void finalizeView() {
+        dialog.setCancelable(isCancelable);
+        dialog.setView(view);
+    }
+
+    public void performCancel(DialogInterface dialog) {
+        if (cancelListener != null) {
+            cancelListener.onCancel(dialog);
+        }
+    }
+
+    public void performDismiss(DialogInterface dialog) {
+        if (dismissListener != null) {
+            dismissListener.onDismiss(dialog);
+        }
+    }
+
+    public boolean isCancelable() {
+        return isCancelable;
+    }
+
+    public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
+        isCancelable = true;
+        dialog.setOnCancelListener(listener);
+        cancelListener = listener;
+    }
+
+    public void setOnDismissListener(DialogInterface.OnDismissListener listener) {
+        dialog.setOnDismissListener(listener);
+        dismissListener = listener;
+    }
+
+    public AlertDialog getDialog() {
+        return dialog;
+    }
+
+    // IMPORTANT: Should ONLY be used to show dialogs in activities that are NOT CommCareActivities
+    // (and therefore cannot use the DialogController infrastructure set up there)
+    public void showDialog() {
+        finalizeView();
+        dialog.show();
+    }
+
+}

--- a/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
@@ -13,6 +13,8 @@ public abstract class CommCareAlertDialog {
     protected DialogInterface.OnCancelListener cancelListener;
     protected DialogInterface.OnDismissListener dismissListener;
 
+    // false by default, can be overriden by calling setOnCancelListener(), or by subclass
+    // definitions if desired
     protected boolean isCancelable;
     protected View view;
 

--- a/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
@@ -5,18 +5,23 @@ import android.content.DialogInterface;
 import android.view.View;
 
 /**
- * Created by amstone326 on 4/30/16.
+ * Framework for all alert-type dialogs used across CommCare. Any specific implementations
+ * of an alert dialog in CommCare should subclass this class.
+ *
+ * The showing and persistence of all CommCareAlertDialogs should be managed by the implementation
+ * of the DialogController interface in CommCareActivity wherever possible (e.g. wherever the
+ * context of a dialog is a CommCareActivity)
+ *
  */
 public abstract class CommCareAlertDialog {
 
     protected AlertDialog dialog;
     protected DialogInterface.OnCancelListener cancelListener;
     protected DialogInterface.OnDismissListener dismissListener;
-
-    // false by default, can be overriden by calling setOnCancelListener(), or by subclass
+    protected View view;
+    // false by default, can be overridden by calling setOnCancelListener(), or by subclass
     // definitions if desired
     protected boolean isCancelable;
-    protected View view;
 
     public void finalizeView() {
         dialog.setCancelable(isCancelable);

--- a/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
@@ -17,7 +17,7 @@ public abstract class CommCareAlertDialog {
 
     protected AlertDialog dialog;
     protected DialogInterface.OnCancelListener cancelListener;
-    protected DialogInterface.OnDismissListener dismissListener;
+    private DialogInterface.OnDismissListener dismissListener;
     protected View view;
     // false by default, can be overridden by calling setOnCancelListener(), or by subclass
     // definitions if desired
@@ -25,6 +25,9 @@ public abstract class CommCareAlertDialog {
 
     public void finalizeView() {
         dialog.setCancelable(isCancelable);
+        if (isCancelable) {
+            dialog.setOnCancelListener(cancelListener);
+        }
         dialog.setView(view);
     }
 
@@ -46,7 +49,6 @@ public abstract class CommCareAlertDialog {
 
     public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
         isCancelable = true;
-        dialog.setOnCancelListener(listener);
         cancelListener = listener;
     }
 
@@ -61,7 +63,7 @@ public abstract class CommCareAlertDialog {
 
     // IMPORTANT: Should ONLY be used to show dialogs in activities that are NOT CommCareActivities
     // (and therefore cannot use the DialogController infrastructure set up there)
-    public void showDialog() {
+    public void showNonPersistentDialog() {
         finalizeView();
         dialog.show();
     }

--- a/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
@@ -6,7 +6,9 @@ import android.content.DialogInterface;
 import android.view.View;
 
 /**
- * Created by amstone326 on 5/2/16.
+ * An implementation of CommCareAlertDialog for which the dialog's entire view is created custom
+ *
+ * @author amstone
  */
 public class CustomViewAlertDialog extends CommCareAlertDialog {
 

--- a/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
@@ -24,12 +24,6 @@ public class CustomViewAlertDialog extends CommCareAlertDialog {
     }
 
     @Override
-    public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
-        isCancelable = true;
-        cancelListener = listener;
-    }
-
-    @Override
     public void finalizeView() {
         dialog = builder.create();
         dialog.setCancelable(isCancelable);

--- a/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
@@ -1,0 +1,39 @@
+package org.commcare.views.dialogs;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.View;
+
+/**
+ * Created by amstone326 on 5/2/16.
+ */
+public class CustomViewAlertDialog extends CommCareAlertDialog {
+
+    private AlertDialog.Builder builder;
+
+    public CustomViewAlertDialog(Context context, View view) {
+        this.builder = new AlertDialog.Builder(context);
+        builder.setView(view);
+    }
+
+    public void setPositiveButton(CharSequence displayText, final DialogInterface.OnClickListener buttonListener) {
+        builder.setPositiveButton(displayText, buttonListener);
+    }
+
+    @Override
+    public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
+        isCancelable = true;
+        cancelListener = listener;
+    }
+
+    @Override
+    public void finalizeView() {
+        dialog = builder.create();
+        dialog.setCancelable(isCancelable);
+        if (isCancelable) {
+            dialog.setOnCancelListener(cancelListener);
+        }
+    }
+
+}

--- a/app/src/org/commcare/views/dialogs/DialogController.java
+++ b/app/src/org/commcare/views/dialogs/DialogController.java
@@ -42,7 +42,7 @@ public interface DialogController {
     /**
      * Show the alert dialog provided by the given AlertDialogFactory
      */
-    void showAlertDialog(AlertDialogFactory factory);
+    void showAlertDialog(CommCareAlertDialog dialog);
 
     /**
      * @return the alert dialog that is currently on screen (possibly null)

--- a/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
+++ b/app/src/org/commcare/views/dialogs/DialogCreationHelpers.java
@@ -20,14 +20,13 @@ import org.javarosa.core.services.locale.Localization;
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public class DialogCreationHelpers {
-    public static AlertDialog buildAboutCommCareDialog(Activity activity) {
+
+    public static CommCareAlertDialog buildAboutCommCareDialog(Activity activity) {
 
         LayoutInflater li = LayoutInflater.from(activity);
         View view = li.inflate(R.layout.scrolling_info_dialog, null);
-
         TextView titleView = (TextView) view.findViewById(R.id.dialog_title_text);
         titleView.setText(activity.getString(R.string.about_cc));
-
         Spannable markdownText = buildAboutMessage(activity);
         TextView aboutText = (TextView)view.findViewById(R.id.dialog_text);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
@@ -36,15 +35,15 @@ public class DialogCreationHelpers {
             aboutText.setText(markdownText.toString());
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        builder.setView(view);
-        builder.setPositiveButton(Localization.get("dialog.ok"), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
-                });
-        return builder.create();
+        CustomViewAlertDialog dialog = new CustomViewAlertDialog(activity, view);
+        dialog.setPositiveButton(Localization.get("dialog.ok"), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        });
+
+        return dialog;
     }
 
     private static Spannable buildAboutMessage(Context context) {
@@ -62,29 +61,27 @@ public class DialogCreationHelpers {
      * @param permRequester interface for launching system permission request
      *                      dialog
      */
-    public static AlertDialog buildPermissionRequestDialog(Activity activity,
+    public static CommCareAlertDialog buildPermissionRequestDialog(Activity activity,
                                                            final RuntimePermissionRequester permRequester,
                                                            final int requestCode,
                                                            String title,
                                                            String body) {
-        View view = LayoutInflater.from(activity).inflate(R.layout.scrolling_info_dialog, null);
 
+        View view = LayoutInflater.from(activity).inflate(R.layout.scrolling_info_dialog, null);
         TextView bodyText = (TextView)view.findViewById(R.id.dialog_text);
         bodyText.setText(body);
-
         TextView titleText = (TextView) view.findViewById(R.id.dialog_title_text);
         titleText.setText(title);
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        builder.setCancelable(false);
-        builder.setView(view);
-        builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+        CustomViewAlertDialog dialog = new CustomViewAlertDialog(activity, view);
+        dialog.setPositiveButton(Localization.get("dialog.ok"), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 permRequester.requestNeededPermissions(requestCode);
                 dialog.dismiss();
             }
         });
-        return builder.create();
+
+        return dialog;
     }
 }

--- a/app/src/org/commcare/views/dialogs/PaneledChoiceDialog.java
+++ b/app/src/org/commcare/views/dialogs/PaneledChoiceDialog.java
@@ -15,8 +15,9 @@ import android.widget.TextView;
 import org.commcare.dalvik.R;
 
 /**
- * A dialog to use for any instance in which the user is being given a choice between multiple
- * options; the N choice options will be displayed in a vertically-oriented list
+ * An implementation of CommCareAlertDialog for use in any instance in which the user is being
+ * given a choice between multiple options; the N choice options will be displayed in a
+ * vertically-oriented list
  *
  * @author amstone
  */

--- a/app/src/org/commcare/views/dialogs/PaneledChoiceDialog.java
+++ b/app/src/org/commcare/views/dialogs/PaneledChoiceDialog.java
@@ -20,18 +20,16 @@ import org.commcare.dalvik.R;
  *
  * @author amstone
  */
-public class PaneledChoiceDialog {
+public class PaneledChoiceDialog extends CommCareAlertDialog {
 
-    protected final View view;
     protected final Context context;
-    private final AlertDialog dialog;
 
     public PaneledChoiceDialog(Context context, String title) {
         this.context = context;
         this.dialog = new AlertDialog.Builder(context).create();
         this.view = LayoutInflater.from(context).inflate(getLayoutFile(), null);
         setTitle(title);
-        dialog.setCancelable(true); // cancelable by default
+        isCancelable = true; // cancelable by default
     }
 
     protected int getLayoutFile() {
@@ -64,7 +62,7 @@ public class PaneledChoiceDialog {
     }
 
     public void makeNotCancelable() {
-        dialog.setCancelable(false);
+        isCancelable = false;
     }
 
     public void addButton(String text, View.OnClickListener listener) {
@@ -72,19 +70,6 @@ public class PaneledChoiceDialog {
         button.setText(text);
         button.setVisibility(View.VISIBLE);
         button.setOnClickListener(listener);
-    }
-
-    public void show() {
-        dialog.setView(view);
-        dialog.show();
-    }
-
-    public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
-        dialog.setOnCancelListener(listener);
-    }
-
-    public void setOnDismissListener(DialogInterface.OnDismissListener listener) {
-        dialog.setOnDismissListener(listener);
     }
 
     public void dismiss() {
@@ -116,4 +101,5 @@ public class PaneledChoiceDialog {
             extraInfoContent.setVisibility(View.VISIBLE);
         }
     }
+
 }

--- a/app/src/org/commcare/views/dialogs/StandardAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/StandardAlertDialog.java
@@ -13,11 +13,14 @@ import org.commcare.dalvik.R;
 import org.javarosa.core.services.locale.Localization;
 
 /**
- * Created by amstone326 on 10/9/15.
+ * An implementation of CommCareAlertDialog that utilizes a pre-set view template, with the ability
+ * to customize basic fields (title, message, buttons, listeners, etc.)
+ *
+ * @author amstone
  */
-public class AlertDialogFactory extends CommCareAlertDialog {
+public class StandardAlertDialog extends CommCareAlertDialog {
 
-    public AlertDialogFactory(Context context, String title, String msg) {
+    public StandardAlertDialog(Context context, String title, String msg) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         view = LayoutInflater.from(context).inflate(R.layout.custom_alert_dialog, null);
 
@@ -36,9 +39,9 @@ public class AlertDialogFactory extends CommCareAlertDialog {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                               null, applies a default listener of just dismissing the dialog
      */
-    public static AlertDialogFactory getBasicAlertFactory(Context context, String title, String msg,
+    public static StandardAlertDialog getBasicAlertDialog(Context context, String title, String msg,
                                                           DialogInterface.OnClickListener positiveButtonListener) {
-        AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
+        StandardAlertDialog d = new StandardAlertDialog(context, title, msg);
         if (positiveButtonListener == null) {
             positiveButtonListener = new DialogInterface.OnClickListener() {
                 @Override
@@ -47,8 +50,8 @@ public class AlertDialogFactory extends CommCareAlertDialog {
                 }
             };
         }
-        factory.setPositiveButton(Localization.get("dialog.ok"), positiveButtonListener);
-        return factory;
+        d.setPositiveButton(Localization.get("dialog.ok"), positiveButtonListener);
+        return d;
     }
 
     /**
@@ -60,9 +63,9 @@ public class AlertDialogFactory extends CommCareAlertDialog {
      * @param positiveButtonListener - the onClickListener to apply to the positive button. If
      *                               null, applies a default listener of just dismissing the dialog
      */
-    public static AlertDialogFactory getBasicAlertFactoryWithIcon(Context context, String title, String msg, int iconResId,
+    public static StandardAlertDialog getBasicAlertDialogWithIcon(Context context, String title, String msg, int iconResId,
                                                                   DialogInterface.OnClickListener positiveButtonListener) {
-        AlertDialogFactory factory = new AlertDialogFactory(context, title, msg);
+        StandardAlertDialog d = new StandardAlertDialog(context, title, msg);
         if (positiveButtonListener == null) {
             positiveButtonListener = new DialogInterface.OnClickListener() {
                 @Override
@@ -71,9 +74,9 @@ public class AlertDialogFactory extends CommCareAlertDialog {
                 }
             };
         }
-        factory.setPositiveButton(Localization.get("dialog.ok"), positiveButtonListener);
-        factory.setIcon(iconResId);
-        return factory;
+        d.setPositiveButton(Localization.get("dialog.ok"), positiveButtonListener);
+        d.setIcon(iconResId);
+        return d;
     }
 
     public void setIcon(int resId) {


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?222011.

Turns out that a lot of the infrastructure was already there for this via some combination of past work by @phillipm and I, but seems like we got our wires a little crossed at some point, and just weren't using the existing infrastructure everywhere we should have been. The implementations of the `showAlertDialog()` and `showPendingAlertDialog()` methods (from the `DialogController` interface) in `CommCareActivity` automatically handle persisting alert dialogs on orientation change. The problem was just that in many places, we were still showing dialogs via the `AlertDialogFactory`'s `showDialog()` method, instead of `CommCareActivity`'s `showAlertDialog()` method.

So, changes made by this PR:

1. Use `showAlertDialog()` to show dialogs wherever possible (i.e. for any dialogs whose context is `CommCareActivity`. For dialogs launched in a normal activity, I left the old show methods in use. We could talk about having an implementation of `DialogController` in non-CommCareActivities at some point, but I didn't want to do that in this PR, since it's already pretty large).

2. Previously, the `DialogController` alert dialog infrastructure was only set up to handle dialogs generated from an `AlertDialogFactory`. This meant that `PaneledChoiceDialog`s and a couple of other custom dialogs (including the About CommCare dialog, which was the actual originator of this ticket) could not be shown that way. In order to expand the utility of this infrastructure, I created an abstract class called `CommCareAlertDialog`, from which an `AlertDialogFragment` can be constructed (which is the class of dialogs that `DialogController` knows how to manage), and then made `StandardAlertDialog` (renaming of `AlertDialogFactory`), `PaneledChoiceDialog`, and `CustomViewDialog` (a new class for dialogs like the About CommCare dialog) all subclass that.