### PR TITLE
Form Hierarchy NPE fix

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1712,7 +1712,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
         } else {
             // we've just loaded a saved form, so start in the hierarchy view
-            Intent i = new Intent(FormEntryActivity.this, FormHierarchyActivity.class);
+            Intent i = new Intent(this, FormHierarchyActivity.class);
             startActivityForResult(i, HIERARCHY_ACTIVITY_FIRST_START);
             return; // so we don't show the intro screen before jumping to the hierarchy
         }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1550,14 +1550,16 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     private void saveInlineVideoState() {
-        for (int i = 0; i < questionsView.getWidgets().size(); i++) {
-            QuestionWidget q = questionsView.getWidgets().get(i);
-            if (q.findViewById(MediaLayout.INLINE_VIDEO_PANE_ID) != null) {
-                VideoView inlineVideo = (VideoView)q.findViewById(MediaLayout.INLINE_VIDEO_PANE_ID);
-                if (inlineVideo.isPlaying()) {
-                    indexOfWidgetWithVideoPlaying = i;
-                    positionOfVideoProgress = inlineVideo.getCurrentPosition();
-                    return;
+        if (questionsView != null) {
+            for (int i = 0; i < questionsView.getWidgets().size(); i++) {
+                QuestionWidget q = questionsView.getWidgets().get(i);
+                if (q.findViewById(MediaLayout.INLINE_VIDEO_PANE_ID) != null) {
+                    VideoView inlineVideo = (VideoView)q.findViewById(MediaLayout.INLINE_VIDEO_PANE_ID);
+                    if (inlineVideo.isPlaying()) {
+                        indexOfWidgetWithVideoPlaying = i;
+                        positionOfVideoProgress = inlineVideo.getCurrentPosition();
+                        return;
+                    }
                 }
             }
         }

--- a/app/src/org/commcare/activities/FormHierarchyActivity.java
+++ b/app/src/org/commcare/activities/FormHierarchyActivity.java
@@ -32,7 +32,6 @@ public class FormHierarchyActivity extends ListActivity {
     private Button jumpPreviousButton;
     private List<HierarchyElement> formList;
     private TextView mPath;
-    private FormIndex mStartIndex;
     public final static int RESULT_XPATH_ERROR = RESULT_FIRST_USER + 1;
 
     @Override
@@ -41,9 +40,6 @@ public class FormHierarchyActivity extends ListActivity {
         setContentView(R.layout.hierarchy_layout);
 
         addActionBarBackArrow();
-
-        // We use a static FormEntryController to make jumping faster.
-        mStartIndex = FormEntryActivity.mFormController.getFormIndex();
 
         setTitle(Localization.get("form.hierarchy"));
 
@@ -77,6 +73,9 @@ public class FormHierarchyActivity extends ListActivity {
                 finish();
             }
         });
+
+        // We use a static FormEntryController to make jumping faster.
+        final FormIndex mStartIndex = FormEntryActivity.mFormController.getFormIndex();
 
         // kinda slow, but works.
         // this scrolls to the last question the user was looking at


### PR DESCRIPTION
Fix NPE that occurs when opening a saved form.

Coming up because the inline video restore code was running when there were no questions loaded, since the `FormHierarchyActivity` is launched via the `FormEntryActivity`. Issue originated from changes in https://github.com/dimagi/commcare-odk/pull/1234