### PR TITLE
Handle an XPathException in SessionNavigator properly

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -376,14 +376,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
 
-    /**
-     * Display exception details as a pop-up to the user.
-     *
-     * @param e Exception to handle
-     */
-    public void displayException(Exception e) {
-        String title =  Localization.get("notification.case.predicate.title");
-        String message = Localization.get("notification.case.predicate.action", new String[]{e.getMessage()});
+    public void displayException(String title, String message) {
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int i) {
@@ -397,6 +390,12 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         AlertDialogFactory f = AlertDialogFactory.getBasicAlertFactoryWithIcon(this, title,
                 message, android.R.drawable.ic_dialog_info, listener);
         showAlertDialog(f);
+    }
+
+    public void displayCaseListFilterException(Exception e) {
+        displayException(
+                Localization.get("notification.case.predicate.title"),
+                Localization.get("notification.case.predicate.action", new String[]{e.getMessage()}));
     }
 
     @Override

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -376,6 +376,9 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         }
     }
 
+    /**
+     * Display exception details as a pop-up to the user.
+     */
     public void displayException(String title, String message) {
         DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
             @Override

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -821,8 +821,9 @@ public class CommCareHomeActivity
             case SessionNavigator.LAUNCH_CONFIRM_DETAIL:
                 launchConfirmDetail(asw);
                 break;
-            case SessionNavigator.EXCEPTION_THROWN:
-                displayException(sessionNavigator.getCurrentException());
+            case SessionNavigator.XPATH_EXCEPTION_THROWN:
+                UserfacingErrorHandling
+                        .logErrorAndShowDialog(this, sessionNavigator.getCurrentException(), false);
         }
     }
 

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -48,7 +48,6 @@ import org.commcare.suite.model.CalloutData;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
 import org.commcare.suite.model.EntityDatum;
-import org.commcare.suite.model.SessionDatum;
 import org.commcare.tasks.EntityLoaderListener;
 import org.commcare.tasks.EntityLoaderTask;
 import org.commcare.utils.AndroidInstanceInitializer;
@@ -991,7 +990,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     @Override
     public void deliverLoadError(Exception e) {
-        displayException(e);
+        displayCaseListFilterException(e);
     }
 
     @Override

--- a/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
+++ b/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
@@ -93,6 +93,6 @@ public class EntitySubnodeDetailFragment extends EntityDetailFragment implements
 
     @Override
     public void deliverLoadError(Exception e) {
-        ((CommCareActivity)getActivity()).displayException(e);
+        ((CommCareActivity)getActivity()).displayCaseListFilterException(e);
     }
 }


### PR DESCRIPTION
While http://manage.dimagi.com/default.asp?225812 turned out to be an HQ issue at its root, it revealed some issues (one very large and one small) with how we were handling an XPathException thrown by `handleCompute()` in `SessionNavigator`. This PR resolves those 2 issues (comments in-line on the PR as to what was fixed).

cross-request: https://github.com/dimagi/commcare/pull/297