### PR TITLE
Handle app seating in app manager properly

### DIFF
--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -105,7 +105,6 @@ public class CommCareHomeActivity
     private static final int MODEL_RESULT = 4;
 
     private static final int GET_INCOMPLETE_FORM = 16;
-    public static final int UPGRADE_APP = 32;
     public static final int REPORT_PROBLEM_ACTIVITY = 64;
 
     private static final int DUMP_FORMS_ACTIVITY=512;

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -68,7 +68,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     public final static String KEY_ENTERED_PW_OR_PIN = "entered-password-or-pin";
 
     private static final int SEAT_APP_ACTIVITY = 0;
-    public final static String KEY_APP_TO_SEAT = "app_to_seat";
     public final static String USER_TRIGGERED_LOGOUT = "user-triggered-logout";
 
     public final static String LOGIN_MODE = "login-mode";
@@ -549,7 +548,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
             // Launch the activity to seat the new app
             Intent i = new Intent(this, SeatAppActivity.class);
-            i.putExtra(KEY_APP_TO_SEAT, appId);
+            i.putExtra(SeatAppActivity.KEY_APP_TO_SEAT, appId);
             this.startActivityForResult(i, SEAT_APP_ACTIVITY);
         }
     }

--- a/app/src/org/commcare/activities/SeatAppActivity.java
+++ b/app/src/org/commcare/activities/SeatAppActivity.java
@@ -21,6 +21,8 @@ import org.javarosa.core.services.locale.Localization;
 public class SeatAppActivity extends Activity {
 
     private static final String KEY_IN_PROGRESS = "initialization_in_progress";
+    public final static String KEY_APP_TO_SEAT = "app_to_seat";
+
     private boolean inProgress;
 
     @Override
@@ -35,7 +37,7 @@ public class SeatAppActivity extends Activity {
 
         if (!inProgress) {
 
-            String idOfAppToSeat = getIntent().getStringExtra(LoginActivity.KEY_APP_TO_SEAT);
+            String idOfAppToSeat = getIntent().getStringExtra(KEY_APP_TO_SEAT);
             ApplicationRecord record = CommCareApplication._().getAppById(idOfAppToSeat);
 
             if (record == null) {

--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -39,12 +39,17 @@ public class SingleAppManagerActivity extends Activity {
     private static final int MISSING_MEDIA_ACTIVITY = 1;
     private static final int SEAT_APP_ACTIVITY = 2;
 
-    boolean launchUpdateAfterSeating;
+    private static final String KEY_LAUNCH_UPDATE_AFTER_SEATING = "launch-update-after-seating";
+    private boolean launchUpdateAfterSeating;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.single_app_view);
+
+        if (savedInstanceState != null) {
+            launchUpdateAfterSeating = savedInstanceState.getBoolean(KEY_LAUNCH_UPDATE_AFTER_SEATING);
+        }
 
         // Retrieve the app record that should be represented by this activity
         int position = getIntent().getIntExtra("position", -1);
@@ -67,6 +72,11 @@ public class SingleAppManagerActivity extends Activity {
     protected void onResume() {
         super.onResume();
         refresh();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(KEY_LAUNCH_UPDATE_AFTER_SEATING, launchUpdateAfterSeating);
     }
 
     /**
@@ -229,7 +239,7 @@ public class SingleAppManagerActivity extends Activity {
     private void launchVerificationActivity() {
         Intent i = new Intent(this, CommCareVerificationActivity.class);
         i.putExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, true);
-        this.startActivityForResult(i, DispatchActivity.MISSING_MEDIA_ACTIVITY);
+        this.startActivityForResult(i, MISSING_MEDIA_ACTIVITY);
     }
 
     /**
@@ -271,7 +281,7 @@ public class SingleAppManagerActivity extends Activity {
     private void launchUpdateActivity() {
         Intent i = new Intent(getApplicationContext(), UpdateActivity.class);
         i.putExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, true);
-        startActivityForResult(i, CommCareHomeActivity.UPGRADE_APP);
+        startActivityForResult(i, UPGRADE_APP);
     }
 
     /**


### PR DESCRIPTION
Was doing a couple of things carelessly in regards to app seating in the app manager. This PR makes it so that:
-For operations in `SingleAppManagerActivity` that require the current app to be seated (updating and verifying MM), we only try to seat the app if it is not already seated.
-When seating the current app is necessary, use the `SeatAppActivity` rather than just calling 'initializeAppResources()` (for the same reason we decided to use the SeatAppActivity on the login screen -- the seating process can take a while for some apps, and having the screen just go unresponsive with no indication of what's happening is a terrible UX).