### PR TITLE
Correctly ask for SMS reading permissions during app install

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -186,9 +186,14 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 "startAllowed is: " + startAllowed + " "
         );
 
-        Permissions.acquireAllAppPermissions(this, this, Permissions.ALL_PERMISSIONS_REQUEST);
-
-        performSMSInstall(false);
+        boolean askingForPerms =
+                Permissions.acquireAllAppPermissions(this, this,
+                        Permissions.ALL_PERMISSIONS_REQUEST);
+        if (!askingForPerms) {
+            // With basic perms satisfied, ask user to allow SMS reading for
+            // sms app install code
+            performSMSInstall(false);
+        }
     }
 
     private void loadStateFromInstance(Bundle savedInstanceState) {
@@ -833,6 +838,9 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             CommCareApplication._().prepareTemporaryStorage();
             uiState = UiState.CHOOSE_INSTALL_ENTRY_METHOD;
             uiStateScreenTransition();
+
+            // Since SMS asks for more permissions, call was delayed until here
+            performSMSInstall(false);
         }
     }
 

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -29,10 +29,11 @@ public class Permissions {
      *                        permission requests
      * @param permRequester   performs user-facing permission request system calls
      * @param permRequestCode make the permission request using this request code
+     * @return Was the user asked for permissions?
      */
-    public static void acquireAllAppPermissions(Activity activity,
-                                                RuntimePermissionRequester permRequester,
-                                                int permRequestCode) {
+    public static boolean acquireAllAppPermissions(Activity activity,
+                                                   RuntimePermissionRequester permRequester,
+                                                   int permRequestCode) {
         String[] permissions = getAppPermissions();
 
         if (missingAppPermission(activity, permissions)) {
@@ -46,6 +47,9 @@ public class Permissions {
             } else {
                 permRequester.requestNeededPermissions(permRequestCode);
             }
+            return true;
+        } else {
+            return false;
         }
     }
 


### PR DESCRIPTION
Fix issue where install screen would consistently ask for SMS reading permissions.

Underlying issue was due to the fact that if you ask the user for permissions while the user is already being asked for permissions, the request automatically fails.