### PR TITLE
Tell user when CommCare's unable to save unsupported unicode

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -144,6 +144,7 @@ form.entry.processing.title=Processing Form
 form.entry.complete.save.success=Form successfully completed
 form.entry.incomplete.save.success=Form saved as incomplete
 form.entry.save.error=Sorry, form save failed. Please contact technical support to look into the issue.
+form.entry.save.invalid.unicode=Could not save '${0}' text in form.
 form.entry.finish.button=FINISH
 
 login.attempt.badcred=Username or password are incorrect. Please try again.

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -23,9 +23,11 @@ import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.model.xform.XFormSerializingVisitor;
+import org.javarosa.xform.util.XFormSerializer;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -104,10 +106,10 @@ public class SaveToDiskTask extends
             e.printStackTrace();
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,
                     "Something is blocking acesss to the submission file in " + FormEntryActivity.mInstancePath);
-        } catch(UnsupportedEncodingException uee) {
-            Logger.log(AndroidLogger.TYPE_ERROR_CONFIG_STRUCTURE, "Form contains invalid data encoding\n\n" + ForceCloseLogger.getStackTrace(uee));
+        } catch(XFormSerializer.UnsupportedUnicodeSurrogatesException e) {
+            Logger.log(AndroidLogger.TYPE_ERROR_CONFIG_STRUCTURE, "Form contains invalid data encoding\n\n" + ForceCloseLogger.getStackTrace(e));
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,
-                    "Form contains invalidly encoded text! Unable to save contents.");
+                    Localization.get("form.entry.save.invalid.unicode", e.getMessage()));
         }  catch (IOException e) {
             Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "I/O Error when serializing form\n\n" + ForceCloseLogger.getStackTrace(e));
             return new ResultAndError<>(SaveStatus.SAVE_ERROR,


### PR DESCRIPTION
cross-request: https://github.com/dimagi/javarosa/pull/295

See description in that PR

![screen](https://cloud.githubusercontent.com/assets/94817/15085413/2ce8856c-13a8-11e6-8a02-19590db4f591.png)
