### PR TITLE
Unify all sync paths

### DIFF
--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -51,8 +51,11 @@ import org.commcare.tasks.DumpTask;
 import org.commcare.tasks.FormLoaderTask;
 import org.commcare.tasks.FormRecordCleanupTask;
 import org.commcare.tasks.ProcessAndSendTask;
+import org.commcare.tasks.PullTaskReceiver;
+import org.commcare.tasks.ResultAndError;
 import org.commcare.tasks.SendTask;
 import org.commcare.tasks.WipeTask;
+import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.utils.ACRAUtil;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.AndroidInstanceInitializer;
@@ -85,7 +88,7 @@ import java.util.Vector;
 
 public class CommCareHomeActivity
         extends SessionAwareCommCareActivity<CommCareHomeActivity>
-        implements SessionNavigationResponder, WithUIController {
+        implements SessionNavigationResponder, WithUIController, PullTaskReceiver {
 
     private static final String TAG = CommCareHomeActivity.class.getSimpleName();
 
@@ -1052,7 +1055,7 @@ public class CommCareHomeActivity
     private void sendFormsOrSync(boolean userTriggeredSync) {
         boolean formsSentToServer = checkAndStartUnsentFormsTask(true, userTriggeredSync);
         if(!formsSentToServer) {
-            formAndDataSyncer.syncData(this, false, userTriggeredSync);
+            formAndDataSyncer.syncDataForLoggedInUser(this, false, userTriggeredSync);
         }
     }
 
@@ -1398,4 +1401,81 @@ public class CommCareHomeActivity
         return this.uiController;
     }
 
+    @Override
+    public void handlePullTaskResult(ResultAndError<DataPullTask.PullTaskResult> resultAndErrorMessage,
+                                     boolean userTriggeredSync, boolean formsToSend) {
+        getUIController().refreshView();
+
+        DataPullTask.PullTaskResult result = resultAndErrorMessage.data;
+        String reportSyncLabel = result.getCorrespondingGoogleAnalyticsLabel();
+        int reportSyncValue = result.getCorrespondingGoogleAnalyticsValue();
+
+        switch (result) {
+            case AUTH_FAILED:
+                displayMessage(Localization.get("sync.fail.auth.loggedin"), true);
+                break;
+            case BAD_DATA:
+            case BAD_DATA_REQUIRES_INTERVENTION:
+                displayMessage(Localization.get("sync.fail.bad.data"), true);
+                break;
+            case DOWNLOAD_SUCCESS:
+                if (formsToSend) {
+                    reportSyncValue = GoogleAnalyticsFields.VALUE_WITH_SEND_FORMS;
+                } else {
+                    reportSyncValue = GoogleAnalyticsFields.VALUE_JUST_PULL_DATA;
+                }
+                displayMessage(Localization.get("sync.success.synced"));
+                break;
+            case SERVER_ERROR:
+                displayMessage(Localization.get("sync.fail.server.error"));
+                break;
+            case UNREACHABLE_HOST:
+                displayMessage(Localization.get("sync.fail.bad.network"), true);
+                break;
+            case CONNECTION_TIMEOUT:
+                displayMessage(Localization.get("sync.fail.timeout"), true);
+                break;
+            case UNKNOWN_FAILURE:
+                displayMessage(Localization.get("sync.fail.unknown"), true);
+                break;
+        }
+
+        if (userTriggeredSync) {
+            GoogleAnalyticsUtils.reportSyncAttempt(
+                    GoogleAnalyticsFields.ACTION_USER_SYNC_ATTEMPT,
+                    reportSyncLabel, reportSyncValue);
+        } else {
+            GoogleAnalyticsUtils.reportSyncAttempt(
+                    GoogleAnalyticsFields.ACTION_AUTO_SYNC_ATTEMPT,
+                    reportSyncLabel, reportSyncValue);
+        }
+        //TODO: What if the user info was updated?
+    }
+
+    @Override
+    public void handlePullTaskUpdate(Integer... update) {
+        if (update[0] == DataPullTask.PROGRESS_STARTED) {
+            updateProgress(Localization.get("sync.progress.purge"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_CLEANED) {
+            updateProgress(Localization.get("sync.progress.authing"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_AUTHED) {
+            updateProgress(Localization.get("sync.progress.downloading"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
+            updateProgress(Localization.get("sync.process.downloading.progress", new String[]{String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING_COMPLETE) {
+            hideTaskCancelButton();
+        } else if (update[0] == DataPullTask.PROGRESS_PROCESSING) {
+            updateProgress(Localization.get("sync.process.processing", new String[]{String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
+            updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
+            updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
+            updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
+        }
+    }
+
+    @Override
+    public void handlePullTaskError(Exception e) {
+        displayMessage(Localization.get("sync.fail.unknown"), true);
+    }
 }

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -102,7 +102,7 @@ public class FormAndDataSyncer {
                 context.getString(R.string.PostURL));
     }
 
-    public void syncData(final CommCareActivity activity,
+    public <I extends CommCareActivity & PullTaskReceiver> void syncData(final I activity,
                          final boolean formsToSend,
                          final boolean userTriggeredSync,
                          String server,
@@ -141,9 +141,11 @@ public class FormAndDataSyncer {
 
     }
 
-    public void syncDataForLoggedInUser(final CommCareHomeActivity activity,
-                                        final boolean formsToSend,
-                                        final boolean userTriggeredSync) {
+    public void syncDataForLoggedInUser(
+            final CommCareHomeActivity activity,
+            final boolean formsToSend,
+            final boolean userTriggeredSync) {
+
         User u;
         try {
             u = CommCareApplication._().getSession().getLoggedInUser();
@@ -165,7 +167,8 @@ public class FormAndDataSyncer {
         }
 
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
-        syncData(activity, formsToSend, userTriggeredSync, u.getUsername(), u.getCachedPwd(),
-                prefs.getString(CommCarePreferences.PREFS_DATA_SERVER_KEY, activity.getString(R.string.ota_restore_url)));
+        syncData(activity, formsToSend, userTriggeredSync,
+                prefs.getString(CommCarePreferences.PREFS_DATA_SERVER_KEY, activity.getString(R.string.ota_restore_url)),
+                u.getUsername(), u.getCachedPwd());
     }
 }

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -14,6 +14,7 @@ import org.commcare.logging.analytics.GoogleAnalyticsUtils;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.ProcessAndSendTask;
+import org.commcare.tasks.PullTaskReceiver;
 import org.commcare.tasks.ResultAndError;
 import org.commcare.utils.FormUploadUtil;
 import org.commcare.utils.SessionUnavailableException;
@@ -59,7 +60,7 @@ public class FormAndDataSyncer {
                     receiver.displayMessage(label);
 
                     if (syncAfterwards) {
-                        syncData(receiver, true, userTriggered);
+                        syncDataForLoggedInUser(receiver, true, userTriggered);
                     }
                 } else if (result != FormUploadUtil.FAILURE) {
                     // Tasks with failure result codes will have already created a notification
@@ -101,9 +102,48 @@ public class FormAndDataSyncer {
                 context.getString(R.string.PostURL));
     }
 
-    public void syncData(final CommCareHomeActivity activity,
+    public void syncData(final CommCareActivity activity,
                          final boolean formsToSend,
-                         final boolean userTriggeredSync) {
+                         final boolean userTriggeredSync,
+                         String server,
+                         String username,
+                         String password) {
+
+        DataPullTask<PullTaskReceiver> mDataPullTask = new DataPullTask<PullTaskReceiver>(
+                username,
+                password,
+                server,
+                activity) {
+
+            @Override
+            protected void deliverResult(PullTaskReceiver receiver, ResultAndError<PullTaskResult> resultAndErrorMessage) {
+                receiver.handlePullTaskResult(resultAndErrorMessage, userTriggeredSync, formsToSend);
+            }
+
+            @Override
+            protected void deliverUpdate(PullTaskReceiver receiver, Integer... update) {
+                receiver.handlePullTaskUpdate(update);
+            }
+
+            @Override
+            protected void deliverError(PullTaskReceiver receiver,
+                                        Exception e) {
+                receiver.handlePullTaskError(e);
+            }
+        };
+
+        mDataPullTask.connect(activity);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            mDataPullTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        } else {
+            mDataPullTask.execute();
+        }
+
+    }
+
+    public void syncDataForLoggedInUser(final CommCareHomeActivity activity,
+                                        final boolean formsToSend,
+                                        final boolean userTriggeredSync) {
         User u;
         try {
             u = CommCareApplication._().getSession().getLoggedInUser();
@@ -125,98 +165,7 @@ public class FormAndDataSyncer {
         }
 
         SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
-        DataPullTask<CommCareHomeActivity> mDataPullTask = new DataPullTask<CommCareHomeActivity>(
-                u.getUsername(),
-                u.getCachedPwd(),
-                prefs.getString(CommCarePreferences.PREFS_DATA_SERVER_KEY,
-                        activity.getString(R.string.ota_restore_url)),
-                activity) {
-
-            @Override
-            protected void deliverResult(CommCareHomeActivity receiver, ResultAndError<PullTaskResult> resultAndErrorMessage) {
-                receiver.getUIController().refreshView();
-
-                PullTaskResult result = resultAndErrorMessage.data;
-                String reportSyncLabel = result.getCorrespondingGoogleAnalyticsLabel();
-                int reportSyncValue = result.getCorrespondingGoogleAnalyticsValue();
-
-                //TODO: SHARES _A LOT_ with login activity. Unify into service
-                switch (result) {
-                    case AUTH_FAILED:
-                        receiver.displayMessage(Localization.get("sync.fail.auth.loggedin"), true);
-                        break;
-                    case BAD_DATA:
-                    case BAD_DATA_REQUIRES_INTERVENTION:
-                        receiver.displayMessage(Localization.get("sync.fail.bad.data"), true);
-                        break;
-                    case DOWNLOAD_SUCCESS:
-                        if (formsToSend) {
-                            reportSyncValue = GoogleAnalyticsFields.VALUE_WITH_SEND_FORMS;
-                        } else {
-                            reportSyncValue = GoogleAnalyticsFields.VALUE_JUST_PULL_DATA;
-                        }
-                        receiver.displayMessage(Localization.get("sync.success.synced"));
-                        break;
-                    case SERVER_ERROR:
-                        receiver.displayMessage(Localization.get("sync.fail.server.error"));
-                        break;
-                    case UNREACHABLE_HOST:
-                        receiver.displayMessage(Localization.get("sync.fail.bad.network"), true);
-                        break;
-                    case CONNECTION_TIMEOUT:
-                        receiver.displayMessage(Localization.get("sync.fail.timeout"), true);
-                        break;
-                    case UNKNOWN_FAILURE:
-                        receiver.displayMessage(Localization.get("sync.fail.unknown"), true);
-                        break;
-                }
-
-                if (userTriggeredSync) {
-                    GoogleAnalyticsUtils.reportSyncAttempt(
-                            GoogleAnalyticsFields.ACTION_USER_SYNC_ATTEMPT,
-                            reportSyncLabel, reportSyncValue);
-                } else {
-                    GoogleAnalyticsUtils.reportSyncAttempt(
-                            GoogleAnalyticsFields.ACTION_AUTO_SYNC_ATTEMPT,
-                            reportSyncLabel, reportSyncValue);
-                }
-                //TODO: What if the user info was updated?
-            }
-
-            @Override
-            protected void deliverUpdate(CommCareHomeActivity receiver, Integer... update) {
-                if (update[0] == DataPullTask.PROGRESS_STARTED) {
-                    receiver.updateProgress(Localization.get("sync.progress.purge"), DataPullTask.DATA_PULL_TASK_ID);
-                } else if (update[0] == DataPullTask.PROGRESS_CLEANED) {
-                    receiver.updateProgress(Localization.get("sync.progress.authing"), DataPullTask.DATA_PULL_TASK_ID);
-                } else if (update[0] == DataPullTask.PROGRESS_AUTHED) {
-                    receiver.updateProgress(Localization.get("sync.progress.downloading"), DataPullTask.DATA_PULL_TASK_ID);
-                } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
-                    receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[]{String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
-                } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING_COMPLETE) {
-                    receiver.hideTaskCancelButton();
-                } else if (update[0] == DataPullTask.PROGRESS_PROCESSING) {
-                    receiver.updateProgress(Localization.get("sync.process.processing", new String[]{String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
-                    receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
-                } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
-                    receiver.updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
-                } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
-                    receiver.updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
-                }
-            }
-
-            @Override
-            protected void deliverError(CommCareHomeActivity receiver,
-                                        Exception e) {
-                receiver.displayMessage(Localization.get("sync.fail.unknown"), true);
-            }
-        };
-
-        mDataPullTask.connect(activity);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            mDataPullTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-        } else {
-            mDataPullTask.execute();
-        }
+        syncData(activity, formsToSend, userTriggeredSync, u.getUsername(), u.getCachedPwd(),
+                prefs.getString(CommCarePreferences.PREFS_DATA_SERVER_KEY, activity.getString(R.string.ota_restore_url)));
     }
 }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -34,6 +34,7 @@ import org.commcare.preferences.DevSessionRestorer;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.InstallStagedUpdateTask;
 import org.commcare.tasks.ManageKeyRecordTask;
+import org.commcare.tasks.PullTaskReceiver;
 import org.commcare.tasks.ResultAndError;
 import org.commcare.utils.ACRAUtil;
 import org.commcare.utils.Permissions;
@@ -53,7 +54,7 @@ import java.util.ArrayList;
  */
 public class LoginActivity extends CommCareActivity<LoginActivity>
         implements OnItemSelectedListener, DataPullController,
-        RuntimePermissionRequester, WithUIController {
+        RuntimePermissionRequester, WithUIController, PullTaskReceiver {
 
     private static final String TAG = LoginActivity.class.getSimpleName();
 
@@ -196,83 +197,10 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         // alternate route where we log in locally and sync (with unsent form
         // submissions) more centrally.
 
-        DataPullTask<LoginActivity> dataPuller =
-                new DataPullTask<LoginActivity>(getUniformUsername(), uiController.getEnteredPasswordOrPin(),
-                        prefs.getString(CommCarePreferences.PREFS_DATA_SERVER_KEY,
-                                LoginActivity.this.getString(R.string.ota_restore_url)),
-                        LoginActivity.this) {
-                    @Override
-                    protected void deliverResult(LoginActivity receiver, ResultAndError<PullTaskResult> resultAndErrorMessage) {
-                        PullTaskResult result = resultAndErrorMessage.data;
-                        if (result == null) {
-                            // The task crashed unexpectedly
-                            receiver.raiseLoginMessage(StockMessages.Restore_Unknown, true);
-                            return;
-                        }
-
-                        switch (result) {
-                            case AUTH_FAILED:
-                                receiver.raiseLoginMessage(StockMessages.Auth_BadCredentials, false);
-                                break;
-                            case BAD_DATA_REQUIRES_INTERVENTION:
-                                receiver.raiseLoginMessageWithInfo(StockMessages.Remote_BadRestoreRequiresIntervention, resultAndErrorMessage.errorMessage, true);
-                                break;
-                            case BAD_DATA:
-                                receiver.raiseLoginMessageWithInfo(StockMessages.Remote_BadRestore, resultAndErrorMessage.errorMessage, true);
-                                break;
-                            case STORAGE_FULL:
-                                receiver.raiseLoginMessage(StockMessages.Storage_Full, true);
-                                break;
-                            case DOWNLOAD_SUCCESS:
-                                if (!tryLocalLogin(true, uiController.isRestoreSessionChecked())) {
-                                    receiver.raiseLoginMessage(StockMessages.Auth_CredentialMismatch, true);
-                                }
-                                break;
-                            case UNREACHABLE_HOST:
-                                receiver.raiseLoginMessage(StockMessages.Remote_NoNetwork, true);
-                                break;
-                            case CONNECTION_TIMEOUT:
-                                receiver.raiseLoginMessage(StockMessages.Remote_Timeout, true);
-                                break;
-                            case SERVER_ERROR:
-                                receiver.raiseLoginMessage(StockMessages.Remote_ServerError, true);
-                                break;
-                            case UNKNOWN_FAILURE:
-                                receiver.raiseLoginMessageWithInfo(StockMessages.Restore_Unknown, resultAndErrorMessage.errorMessage, true);
-                                break;
-                        }
-                    }
-
-                    @Override
-                    protected void deliverUpdate(LoginActivity receiver, Integer... update) {
-                        if (update[0] == DataPullTask.PROGRESS_STARTED) {
-                            receiver.updateProgress(Localization.get("sync.progress.purge"), DataPullTask.DATA_PULL_TASK_ID);
-                        } else if (update[0] == DataPullTask.PROGRESS_CLEANED) {
-                            receiver.updateProgress(Localization.get("sync.progress.authing"), DataPullTask.DATA_PULL_TASK_ID);
-                        } else if (update[0] == DataPullTask.PROGRESS_AUTHED) {
-                            receiver.updateProgress(Localization.get("sync.progress.downloading"), DataPullTask.DATA_PULL_TASK_ID);
-                        } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
-                            receiver.updateProgress(Localization.get("sync.process.downloading.progress", new String[]{String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
-                        } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING_COMPLETE) {
-                            receiver.hideTaskCancelButton();
-                        } else if (update[0] == DataPullTask.PROGRESS_PROCESSING) {
-                            receiver.updateProgress(Localization.get("sync.process.processing", new String[]{String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
-                            receiver.updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
-                        } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
-                            receiver.updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
-                        } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
-                            receiver.updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
-                        }
-                    }
-
-                    @Override
-                    protected void deliverError(LoginActivity receiver, Exception e) {
-                        receiver.raiseLoginMessage(StockMessages.Restore_Unknown, true);
-                    }
-                };
-
-        dataPuller.connect(this);
-        dataPuller.execute();
+        (new FormAndDataSyncer()).syncData(this, false, false,
+                prefs.getString(CommCarePreferences.PREFS_DATA_SERVER_KEY, LoginActivity.this.getString(R.string.ota_restore_url)),
+                getUniformUsername(),
+                uiController.getEnteredPasswordOrPin());
     }
 
     @Override
@@ -615,5 +543,74 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     @Override
     public CommCareActivityUIController getUIController() {
         return this.uiController;
+    }
+
+    @Override
+    public void handlePullTaskResult(ResultAndError<DataPullTask.PullTaskResult> resultAndErrorMessage, boolean userTriggeredSync, boolean formsToSend) {
+        DataPullTask.PullTaskResult result = resultAndErrorMessage.data;
+        if (result == null) {
+            // The task crashed unexpectedly
+            raiseLoginMessage(StockMessages.Restore_Unknown, true);
+            return;
+        }
+
+        switch (result) {
+            case AUTH_FAILED:
+                raiseLoginMessage(StockMessages.Auth_BadCredentials, false);
+                break;
+            case BAD_DATA_REQUIRES_INTERVENTION:
+                raiseLoginMessageWithInfo(StockMessages.Remote_BadRestoreRequiresIntervention, resultAndErrorMessage.errorMessage, true);
+                break;
+            case BAD_DATA:
+                raiseLoginMessageWithInfo(StockMessages.Remote_BadRestore, resultAndErrorMessage.errorMessage, true);
+                break;
+            case STORAGE_FULL:
+                raiseLoginMessage(StockMessages.Storage_Full, true);
+                break;
+            case DOWNLOAD_SUCCESS:
+                if (!tryLocalLogin(true, uiController.isRestoreSessionChecked())) {
+                    raiseLoginMessage(StockMessages.Auth_CredentialMismatch, true);
+                }
+                break;
+            case UNREACHABLE_HOST:
+                raiseLoginMessage(StockMessages.Remote_NoNetwork, true);
+                break;
+            case CONNECTION_TIMEOUT:
+                raiseLoginMessage(StockMessages.Remote_Timeout, true);
+                break;
+            case SERVER_ERROR:
+                raiseLoginMessage(StockMessages.Remote_ServerError, true);
+                break;
+            case UNKNOWN_FAILURE:
+                raiseLoginMessageWithInfo(StockMessages.Restore_Unknown, resultAndErrorMessage.errorMessage, true);
+                break;
+        }
+    }
+
+    @Override
+    public void handlePullTaskUpdate(Integer... update) {
+        if (update[0] == DataPullTask.PROGRESS_STARTED) {
+            updateProgress(Localization.get("sync.progress.purge"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_CLEANED) {
+            updateProgress(Localization.get("sync.progress.authing"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_AUTHED) {
+            updateProgress(Localization.get("sync.progress.downloading"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING) {
+            updateProgress(Localization.get("sync.process.downloading.progress", new String[]{String.valueOf(update[1])}), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_DOWNLOADING_COMPLETE) {
+            hideTaskCancelButton();
+        } else if (update[0] == DataPullTask.PROGRESS_PROCESSING) {
+            updateProgress(Localization.get("sync.process.processing", new String[]{String.valueOf(update[1]), String.valueOf(update[2])}), DataPullTask.DATA_PULL_TASK_ID);
+            updateProgressBar(update[1], update[2], DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_NEEDED) {
+            updateProgress(Localization.get("sync.recover.needed"), DataPullTask.DATA_PULL_TASK_ID);
+        } else if (update[0] == DataPullTask.PROGRESS_RECOVERY_STARTED) {
+            updateProgress(Localization.get("sync.recover.started"), DataPullTask.DATA_PULL_TASK_ID);
+        }
+    }
+
+    @Override
+    public void handlePullTaskError(Exception e) {
+        raiseLoginMessage(StockMessages.Restore_Unknown, true);
     }
 }

--- a/app/src/org/commcare/tasks/PullTaskReceiver.java
+++ b/app/src/org/commcare/tasks/PullTaskReceiver.java
@@ -1,0 +1,14 @@
+package org.commcare.tasks;
+
+import org.commcare.activities.CommCareActivity;
+
+/**
+ * Created by amstone326 on 5/10/16.
+ */
+public interface PullTaskReceiver {
+
+    void handlePullTaskResult(ResultAndError<DataPullTask.PullTaskResult> resultAndError, boolean userTriggeredSync, boolean formsToSend);
+    void handlePullTaskUpdate(Integer... update);
+    void handlePullTaskError(Exception e);
+
+}

--- a/unit-tests/src/org/commcare/android/mocks/FormAndDataSyncerFake.java
+++ b/unit-tests/src/org/commcare/android/mocks/FormAndDataSyncerFake.java
@@ -2,9 +2,11 @@ package org.commcare.android.mocks;
 
 import android.util.Log;
 
+import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.CommCareHomeActivity;
 import org.commcare.activities.FormAndDataSyncer;
 import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.tasks.PullTaskReceiver;
 
 /**
  * Fake object that prevent tests from communicating with server to pull or submit data
@@ -29,6 +31,16 @@ public class FormAndDataSyncerFake extends FormAndDataSyncer {
     public void syncDataForLoggedInUser(CommCareHomeActivity activity,
                                         boolean formsToSend,
                                         boolean userTriggeredSync) {
+        Log.d(TAG, "faking data sync");
+    }
+
+    @Override
+    public <I extends CommCareActivity & PullTaskReceiver> void syncData(final I activity,
+                                                                         final boolean formsToSend,
+                                                                         final boolean userTriggeredSync,
+                                                                         String server,
+                                                                         String username,
+                                                                         String password) {
         Log.d(TAG, "faking data sync");
     }
 }

--- a/unit-tests/src/org/commcare/android/mocks/FormAndDataSyncerFake.java
+++ b/unit-tests/src/org/commcare/android/mocks/FormAndDataSyncerFake.java
@@ -26,9 +26,9 @@ public class FormAndDataSyncerFake extends FormAndDataSyncer {
     }
 
     @Override
-    public void syncData(CommCareHomeActivity activity,
-                         boolean formsToSend,
-                         boolean userTriggeredSync) {
+    public void syncDataForLoggedInUser(CommCareHomeActivity activity,
+                                        boolean formsToSend,
+                                        boolean userTriggeredSync) {
         Log.d(TAG, "faking data sync");
     }
 }


### PR DESCRIPTION
Allow all code paths that use `DataPullTask` (from both `LoginActivity` and `HomeActivity`) to utilize the same sync methods (in `FormAndDataSyncer`).

Heads up that this doesn't make a huge difference with the current state of the code, but I'm going to utilize it more in the consumer apps PR.