### PR TITLE
Don't send XPath errors found during form loading to ACRA

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1674,11 +1674,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 }
             };
             mFormLoaderTask.connect(this);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                mFormLoaderTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, formUri);
-            } else {
-                mFormLoaderTask.execute(formUri);
-            }
+            mFormLoaderTask.executeParallel(formUri);
             hasFormLoadBeenTriggered = true;
         }
     }

--- a/app/src/org/commcare/logging/UserCausedRuntimeException.java
+++ b/app/src/org/commcare/logging/UserCausedRuntimeException.java
@@ -1,0 +1,7 @@
+package org.commcare.logging;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class UserCausedRuntimeException {
+}

--- a/app/src/org/commcare/logging/UserCausedRuntimeException.java
+++ b/app/src/org/commcare/logging/UserCausedRuntimeException.java
@@ -3,5 +3,8 @@ package org.commcare.logging;
 /**
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public class UserCausedRuntimeException {
+public class UserCausedRuntimeException extends RuntimeException {
+    public UserCausedRuntimeException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
 }

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -196,14 +196,14 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
         }
 
         //TODO: Get a reasonable IIF object
-        // import existing data into formdef
-        if (FormEntryActivity.mInstancePath != null) {
-            // This order is important. Import data, then initialize.
+
+        boolean isNewFormInstance = FormEntryActivity.mInstancePath == null;
+
+        if (!isNewFormInstance) {
             importData(FormEntryActivity.mInstancePath, fec);
-            formDef.initialize(false, iif, getSystemLocale());
-        } else {
-            formDef.initialize(true, iif, getSystemLocale());
         }
+
+        formDef.initialize(isNewFormInstance, iif, getSystemLocale());
         if (mReadOnly) {
             formDef.getInstance().getRoot().setEnabled(false);
         }

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -12,14 +12,15 @@ import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.logging.ForceCloseLogger;
 import org.commcare.android.resource.installers.XFormAndroidInstaller;
 import org.commcare.engine.extensions.CalendaredDateFormatHandler;
-import org.commcare.engine.extensions.IntentExtensionParser;
-import org.odk.collect.android.jr.extensions.PollSensorAction;
-import org.commcare.engine.extensions.PollSensorExtensionParser;
+import org.commcare.logging.UserCausedRuntimeException;
+import org.commcare.logging.XPathErrorLogger;
+import org.commcare.views.UserfacingErrorHandling;
+import org.javarosa.xpath.XPathException;
+import org.javarosa.xpath.XPathUnhandledException;
 import org.commcare.engine.extensions.XFormExtensionUtils;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.logic.FileReferenceFactory;
 import org.commcare.logic.FormController;
-import org.commcare.models.database.DbUtil;
 import org.commcare.models.encryption.EncryptionIO;
 import org.commcare.provider.FormsProviderAPI;
 import org.commcare.tasks.templates.CommCareTask;
@@ -203,7 +204,13 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
             importData(FormEntryActivity.mInstancePath, fec);
         }
 
-        formDef.initialize(isNewFormInstance, iif, getSystemLocale());
+        try {
+            formDef.initialize(isNewFormInstance, iif, getSystemLocale());
+        } catch (XPathException e) {
+            XPathErrorLogger.INSTANCE.logErrorToCurrentApp(e);
+            throw new UserCausedRuntimeException(e.getMessage(), e);
+        }
+
         if (mReadOnly) {
             formDef.getInstance().getRoot().setEnabled(false);
         }

--- a/app/src/org/commcare/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTask.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import org.acra.ACRA;
 import org.commcare.logging.UserCausedRuntimeException;
+import org.commcare.utils.ACRAUtil;
 import org.javarosa.core.services.Logger;
 
 /**
@@ -42,7 +43,7 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
 
             if (!(e instanceof UserCausedRuntimeException)) {
                 // Report crashes we know weren't caused by user misconfiguration
-                ACRA.getErrorReporter().handleException(e);
+                ACRAUtil.reportException(e);
             }
 
             // Save error for reporting during post-execute

--- a/app/src/org/commcare/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTask.java
@@ -4,6 +4,7 @@ import android.os.AsyncTask;
 import android.util.Log;
 
 import org.acra.ACRA;
+import org.commcare.logging.UserCausedRuntimeException;
 import org.javarosa.core.services.Logger;
 
 /**
@@ -39,8 +40,10 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
             Logger.log(TAG, e.getMessage());
             e.printStackTrace();
 
-            // Report to unified crash report dashboard
-            ACRA.getErrorReporter().handleException(e);
+            if (!(e instanceof UserCausedRuntimeException)) {
+                // Report crashes we know weren't caused by user misconfiguration
+                ACRA.getErrorReporter().handleException(e);
+            }
 
             // Save error for reporting during post-execute
             unknownError = e;

--- a/app/src/org/commcare/utils/ACRAUtil.java
+++ b/app/src/org/commcare/utils/ACRAUtil.java
@@ -7,6 +7,7 @@ import org.acra.ACRA;
 import org.acra.ErrorReporter;
 import org.acra.config.ACRAConfiguration;
 import org.acra.config.ACRAConfigurationFactory;
+import org.acra.config.ConfigurationBuilder;
 import org.commcare.android.logging.ReportingUtils;
 import org.commcare.dalvik.BuildConfig;
 
@@ -36,11 +37,11 @@ public class ACRAUtil {
     public static void initACRA(Application app) {
         String url = BuildConfig.ACRA_URL;
         if (URLUtil.isValidUrl(url)) {
-            ACRAConfiguration acraConfig = new ACRAConfigurationFactory().create(app);
-            acraConfig.setFormUriBasicAuthLogin(BuildConfig.ACRA_USER);
-            acraConfig.setFormUriBasicAuthPassword(BuildConfig.ACRA_PASSWORD);
-            acraConfig.setFormUri(url);
-            ACRA.init(app, acraConfig);
+            ConfigurationBuilder acraConfigBuilder = new ConfigurationBuilder(app);
+            acraConfigBuilder.setFormUriBasicAuthLogin(BuildConfig.ACRA_USER);
+            acraConfigBuilder.setFormUriBasicAuthPassword(BuildConfig.ACRA_PASSWORD);
+            acraConfigBuilder.setFormUri(url);
+            ACRA.init(app, acraConfigBuilder.build());
             isAcraConfigured = true;
         }
     }

--- a/app/src/org/commcare/utils/ACRAUtil.java
+++ b/app/src/org/commcare/utils/ACRAUtil.java
@@ -4,9 +4,6 @@ import android.app.Application;
 import android.webkit.URLUtil;
 
 import org.acra.ACRA;
-import org.acra.ErrorReporter;
-import org.acra.config.ACRAConfiguration;
-import org.acra.config.ACRAConfigurationFactory;
 import org.acra.config.ConfigurationBuilder;
 import org.commcare.android.logging.ReportingUtils;
 import org.commcare.dalvik.BuildConfig;
@@ -30,8 +27,13 @@ public class ACRAUtil {
      * stored for each key.
      */
     private static void addCustomData(String key, String value) {
-        ErrorReporter mReporter = ACRA.getErrorReporter();
-        mReporter.putCustomData(key, value);
+        ACRA.getErrorReporter().putCustomData(key, value);
+    }
+
+    public static void reportException(Exception e) {
+        if (isAcraConfigured) {
+            ACRA.getErrorReporter().handleException(e);
+        }
     }
 
     public static void initACRA(Application app) {


### PR DESCRIPTION
When a form load crashes due to an `XPathException`, don't send that crash to ACRA, since it is most likely a app builder misconfiguration made by the user. Still shows the error to the user so they can address it (and logs it to HQ).

Made these changes because we got hundreds of these exceptions reported to ACRA from the 2.27 release.

Also, prevent ACRA from crashing commcare debug builds when it tries to submit to an invalid URL due to bad debug default configs.