### PR TITLE
Catch UserStorageClosedException thrown on home screen

### DIFF
--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -12,6 +12,7 @@ import org.commcare.adapters.SquareButtonViewHolder;
 import org.commcare.dalvik.R;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.models.database.UserStorageClosedException;
 import org.commcare.modern.util.Pair;
 import org.javarosa.core.services.locale.Localization;
 
@@ -32,7 +33,14 @@ public class SyncDetailCalculations {
                                      HomeCardDisplayData cardDisplayData) {
 
         SqlStorage<FormRecord> formsStorage = CommCareApplication._().getUserStorage(FormRecord.class);
-        int numUnsentForms = formsStorage.getIDsForValue(FormRecord.META_STATUS, FormRecord.STATUS_UNSENT).size();
+        int numUnsentForms;
+        try {
+            numUnsentForms = formsStorage.getIDsForValue(FormRecord.META_STATUS, FormRecord.STATUS_UNSENT).size();
+        } catch (UserStorageClosedException e) {
+            // Addresses unexpected issue where this db lookup occurs after session ends.
+            // If possible, replace this with fix that addresses root issue
+            numUnsentForms = 0;
+        }
 
         Pair<Long, String> lastSyncTimeAndMessage = getLastSyncTimeAndMessage();
 


### PR DESCRIPTION
Unsatisfying 'fix' for following exception that has been showing up a lot on ACRA:
```
org.commcare.models.database.UserStorageClosedException
at org.commcare.models.database.SqlStorage.getIDsForValues(SqlStorage.java:91)
at org.commcare.models.database.SqlStorage.getIDsForValue(SqlStorage.java:83)
at org.commcare.utils.SyncDetailCalculations.updateSubText(SyncDetailCalculations.java:35)
at org.commcare.activities.HomeButtons$3.update(HomeButtons.java:122)
at org.commcare.adapters.SquareButtonAdapter.bindCard(SquareButtonAdapter.java:78)
at org.commcare.adapters.SquareButtonAdapter.onBindViewHolder(SquareButtonAdapter.java:63)
at org.commcare.adapters.HomeScreenAdapter.onBindViewHolder(HomeScreenAdapter.java:84)
at android.support.v7.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:5250)
at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:4487)
at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:4363)
at android.support.v7.widget.LayoutState.next(LayoutState.java:86)
at android.support.v7.widget.StaggeredGridLayoutManager.fill(StaggeredGridLayoutManager.java:1423)
at android.support.v7.widget.StaggeredGridLayoutManager.onLayoutChildren(StaggeredGridLayoutManager.java:610)
at android.support.v7.widget.RecyclerView.dispatchLayout(RecyclerView.java:2900)
at android.support.v7.widget.RecyclerView.onLayout(RecyclerView.java:3071)
```