### PR TITLE
Fix NotificationMessage parcel logic

### DIFF
--- a/app/src/org/commcare/views/notifications/NotificationMessage.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessage.java
@@ -28,22 +28,20 @@ public class NotificationMessage implements Parcelable {
         dest.writeLong(date.getTime());
     }
 
-    public static final Parcelable.Creator<NotificationMessage> CREATOR = new Parcelable.Creator<NotificationMessage>() {
+    public static final Creator<NotificationMessage> CREATOR = new Creator<NotificationMessage>() {
 
         @Override
         public NotificationMessage createFromParcel(Parcel source) {
-            String[] array = new String[3];
+            String[] array = new String[4];
             source.readStringArray(array);
             Date date = new Date(source.readLong());
             return new NotificationMessage(array[0], array[1], array[2], array[3], date);
-
         }
 
         @Override
         public NotificationMessage[] newArray(int size) {
             return new NotificationMessage[size];
         }
-
     };
 
     public NotificationMessage(String context, String title, String details, String action, Date date) {

--- a/unit-tests/src/org/commcare/notifications/NotificationMessageTest.java
+++ b/unit-tests/src/org/commcare/notifications/NotificationMessageTest.java
@@ -1,0 +1,35 @@
+package org.commcare.notifications;
+
+import android.os.Parcel;
+
+import org.commcare.CommCareTestApplication;
+import org.commcare.android.CommCareTestRunner;
+import org.commcare.dalvik.BuildConfig;
+import org.commcare.views.notifications.NotificationMessage;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import java.util.Date;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+@Config(application = CommCareTestApplication.class,
+        constants = BuildConfig.class)
+@RunWith(CommCareTestRunner.class)
+public class NotificationMessageTest {
+    @Test
+    public void notificationParcellingTest() {
+        NotificationMessage sampleNotification =
+                new NotificationMessage("ctx", "title", "message", "action", new Date());
+        Parcel parcel = Parcel.obtain();
+        sampleNotification.writeToParcel(parcel, 0);
+
+        parcel.setDataPosition(0);
+
+        NotificationMessage createdFromParcel = NotificationMessage.CREATOR.createFromParcel(parcel);
+        Assert.assertEquals(sampleNotification, createdFromParcel);
+    }
+}

--- a/unit-tests/src/org/commcare/notifications/NotificationMessageTest.java
+++ b/unit-tests/src/org/commcare/notifications/NotificationMessageTest.java
@@ -20,6 +20,9 @@ import java.util.Date;
         constants = BuildConfig.class)
 @RunWith(CommCareTestRunner.class)
 public class NotificationMessageTest {
+    /**
+     * Write NotificationMessage to parcel and read it back out again
+     */
     @Test
     public void notificationParcellingTest() {
         NotificationMessage sampleNotification =
@@ -29,7 +32,8 @@ public class NotificationMessageTest {
 
         parcel.setDataPosition(0);
 
-        NotificationMessage createdFromParcel = NotificationMessage.CREATOR.createFromParcel(parcel);
+        NotificationMessage createdFromParcel =
+                NotificationMessage.CREATOR.createFromParcel(parcel);
         Assert.assertEquals(sampleNotification, createdFromParcel);
     }
 }


### PR DESCRIPTION
Add test coverage to `NotificationMessage` parcel code and fix crash associated with that code.

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{org.commcare.dalvik/org.commcare.activities.MessageActivity}: java.lang.RuntimeException: bad array lengths
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2338)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2390)
at android.app.ActivityThread.access$800(ActivityThread.java:151)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1321)
at android.os.Handler.dispatchMessage(Handler.java:110)
at android.os.Looper.loop(Looper.java:193)
at android.app.ActivityThread.main(ActivityThread.java:5299)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:829)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:645)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.RuntimeException: bad array lengths
at android.os.Parcel.readStringArray(Parcel.java:967)
at org.commcare.views.notifications.NotificationMessage$1.createFromParcel(NotificationMessage.java:36)
at org.commcare.views.notifications.NotificationMessage$1.createFromParcel(NotificationMessage.java:31)
at android.os.Parcel.readParcelable(Parcel.java:2104)
at android.os.Parcel.readValue(Parcel.java:2013)
at android.os.Parcel.readListInternal(Parcel.java:2343)
at android.os.Parcel.readArrayList(Parcel.java:1703)
at android.os.Parcel.readValue(Parcel.java:2034)
at android.os.Parcel.readArrayMapInternal(Parcel.java:2314)
at android.os.Bundle.unparcel(Bundle.java:249)
at android.os.Bundle.getParcelable(Bundle.java:1206)
at android.app.Activity.onCreate(Activity.java:898)
at org.commcare.activities.MessageActivity.onCreate(MessageActivity.java:32)
```