### PR TITLE
Tell user about non-existent fixture when loading module list

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -256,10 +256,6 @@ public class CommCareApplication extends Application {
         }
     }
 
-    public void triggerHandledAppExit(Context c, String message) {
-        triggerHandledAppExit(c, message, Localization.get("app.handled.error.title"));
-    }
-
     public void triggerHandledAppExit(Context c, String message, String title) {
         triggerHandledAppExit(c, message, title, true);
     }

--- a/app/src/org/commcare/activities/MenuGrid.java
+++ b/app/src/org/commcare/activities/MenuGrid.java
@@ -49,6 +49,7 @@ public class MenuGrid extends SaveSessionCommCareActivity implements OnItemClick
        }
        
        adapter = new GridMenuAdapter(this, platform,menuId);
+       adapter.showAnyLoadErrors(this);
        refreshView();
        
        grid.setOnItemClickListener(this);

--- a/app/src/org/commcare/activities/MenuList.java
+++ b/app/src/org/commcare/activities/MenuList.java
@@ -51,6 +51,7 @@ public class MenuList extends SaveSessionCommCareActivity implements OnItemClick
         }
 
         adapter = new MenuAdapter(this, platform, menuId);
+        adapter.showAnyLoadErrors(this);
         refreshView();
 
         list.setOnItemClickListener(this);

--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.CommCareActivity;
+import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.dalvik.R;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.logging.XPathErrorLogger;
@@ -76,7 +77,8 @@ public class MenuAdapter implements ListAdapter {
                             addUnaddedMenu(menuID, m, items);
                         }
                     }
-                } catch (XPathSyntaxException | XPathException xpe) {
+                } catch (CommCareInstanceInitializer.FixtureInitializationException
+                        | XPathSyntaxException | XPathException xpe) {
                     loadError = xpe;
                     displayableData = new MenuDisplayable[0];
                     return;

--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -13,6 +13,7 @@ import android.widget.ListAdapter;
 import android.widget.TextView;
 
 import org.commcare.CommCareApplication;
+import org.commcare.activities.CommCareActivity;
 import org.commcare.dalvik.R;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.logging.XPathErrorLogger;
@@ -26,6 +27,7 @@ import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.Suite;
 import org.commcare.util.CommCarePlatform;
 import org.commcare.utils.MediaUtil;
+import org.commcare.views.UserfacingErrorHandling;
 import org.commcare.views.media.AudioButton;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.reference.InvalidReferenceException;
@@ -51,6 +53,7 @@ import java.util.Vector;
 public class MenuAdapter implements ListAdapter {
 
     private final AndroidSessionWrapper asw;
+    private Exception loadError;
     private String errorXpathException = "";
     final Context context;
     MenuDisplayable[] displayableData;
@@ -73,14 +76,8 @@ public class MenuAdapter implements ListAdapter {
                             addUnaddedMenu(menuID, m, items);
                         }
                     }
-                } catch (XPathSyntaxException xpse) {
-                    XPathErrorLogger.INSTANCE.logErrorToCurrentApp(errorXpathException, xpse.getMessage());
-                    CommCareApplication._().triggerHandledAppExit(context, Localization.get("app.menu.display.cond.bad.xpath", new String[]{errorXpathException, xpse.getMessage()}));
-                    displayableData = new MenuDisplayable[0];
-                    return;
-                } catch (XPathException xpe) {
-                    XPathErrorLogger.INSTANCE.logErrorToCurrentApp(xpe);
-                    CommCareApplication._().triggerHandledAppExit(context, Localization.get("app.menu.display.cond.xpath.err", new String[]{errorXpathException, xpe.getMessage()}));
+                } catch (XPathSyntaxException | XPathException xpe) {
+                    loadError = xpe;
                     displayableData = new MenuDisplayable[0];
                     return;
                 }
@@ -89,6 +86,21 @@ public class MenuAdapter implements ListAdapter {
 
         displayableData = new MenuDisplayable[items.size()];
         items.copyInto(displayableData);
+    }
+
+    public void showAnyLoadErrors(CommCareActivity activity) {
+        if (loadError != null) {
+            String errorMessage = loadError.getMessage();
+
+            if (loadError instanceof XPathSyntaxException) {
+                XPathErrorLogger.INSTANCE.logErrorToCurrentApp(errorXpathException, loadError.getMessage());
+                errorMessage = Localization.get("app.menu.display.cond.bad.xpath", new String[]{errorXpathException, loadError.getMessage()});
+            } else if (loadError instanceof XPathException) {
+                XPathErrorLogger.INSTANCE.logErrorToCurrentApp((XPathException)loadError);
+                errorMessage = Localization.get("app.menu.display.cond.xpath.err", new String[]{errorXpathException, loadError.getMessage()});
+            }
+            UserfacingErrorHandling.createErrorDialog(activity, errorMessage, true);
+        }
     }
 
     private boolean menuIsRelevant(Menu m) throws XPathSyntaxException {


### PR DESCRIPTION
When loading the menu list, fixtures used by suite entries will be loaded. If there is a fixture reference typo in the suite file or the fixture hasn't been pulled down from HQ, CommCare crashes. This PR instead shows the user and lets them back-out of the module list, so that they can try to update the app or sync with HQ.

```
Caused by: org.commcare.core.process.CommCareInstanceInitializer$FixtureInitializationException: Could not find an lookup table for src: jr://fixture/commcare:reports
at org.commcare.core.process.CommCareInstanceInitializer.setupFixtureData(CommCareInstanceInitializer.java:115)
at org.commcare.core.process.CommCareInstanceInitializer.generateRoot(CommCareInstanceInitializer.java:70)
at org.javarosa.core.model.instance.ExternalDataInstance.initialize(ExternalDataInstance.java:75)
at org.commcare.session.CommCareSession.getEvaluationContext(CommCareSession.java:499)
at org.commcare.models.AndroidSessionWrapper.getEvaluationContext(AndroidSessionWrapper.java:285)
at org.commcare.adapters.MenuAdapter.<init>(MenuAdapter.java:72)
at org.commcare.adapters.GridMenuAdapter.<init>(GridMenuAdapter.java:26)
at org.commcare.activities.MenuGrid.onCreate(MenuGrid.java:53)
```

![screen](https://cloud.githubusercontent.com/assets/94817/15278248/e38b58c0-1ae3-11e6-8e5e-3fe5ef4a6622.png)
