### PR TITLE
By default don't show form list search banner

### DIFF
--- a/app/res/layout/entity_select_layout.xml
+++ b/app/res/layout/entity_select_layout.xml
@@ -10,6 +10,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/universal_frame_tile"
         android:background="@color/cc_brand_bg"
+        android:visibility="gone"
         android:orientation="horizontal">
         <TextView
             android:id="@+id/search_results_status"


### PR DESCRIPTION
Fix bug https://github.com/dimagi/commcare-odk/pull/1119 changes where the search banner would always be shown for Incomplete and Saved form lists

![screen](https://cloud.githubusercontent.com/assets/94817/15278308/f92af66c-1ae4-11e6-9f75-a6ee78abbffd.png)
 