### PR TITLE
Revert "Standard aspect ratio for graphs"

### DIFF
--- a/app/src/org/commcare/graph/view/GraphView.java
+++ b/app/src/org/commcare/graph/view/GraphView.java
@@ -174,6 +174,10 @@ public class GraphView {
     
     /**
      * Get graph's desired aspect ratio.
+     * Most graphs are drawn with aspect ratio 2:1, which is fairly arbitrary
+     * and happened to look nice for partographs. Bar graphs are drawn square - 
+     * again, arbitrary, happens to look nice for mobile UCR. Expect to revisit
+     * this eventually (make all graphs square? user-configured aspect ratio?).
      *
      * @return Ratio, expressed as a double: width / height.
      */

--- a/app/src/org/commcare/graph/view/GraphView.java
+++ b/app/src/org/commcare/graph/view/GraphView.java
@@ -12,6 +12,7 @@ import android.widget.LinearLayout;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.graph.model.GraphData;
 import org.commcare.graph.util.GraphException;
+import org.commcare.graph.util.GraphUtil;
 import org.commcare.graph.view.c3.AxisConfiguration;
 import org.commcare.graph.view.c3.DataConfiguration;
 import org.commcare.graph.view.c3.GridConfiguration;
@@ -169,5 +170,17 @@ public class GraphView {
      */
     public static LinearLayout.LayoutParams getLayoutParams() {
         return new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
+    }
+    
+    /**
+     * Get graph's desired aspect ratio.
+     *
+     * @return Ratio, expressed as a double: width / height.
+     */
+    public double getRatio(GraphData data) {
+        if (GraphUtil.TYPE_BAR.equals(data.getType())) {
+            return 1;
+        }
+        return 2;
     }
 }

--- a/app/src/org/commcare/views/EntityDetailView.java
+++ b/app/src/org/commcare/views/EntityDetailView.java
@@ -268,10 +268,6 @@ public class EntityDetailView extends FrameLayout {
                 try {
                     graphHTML = g.getHTML((GraphData)field);
                     graphView = g.getView(graphHTML);
-                    // Most graphs are drawn with aspect ratio 2:1, which is mostly arbitrary
-                    // and happened to look nice for partographs. Bar graphs are drawn square - 
-                    // again, arbitrary, happens to look nice for mobile UCR. Expect to revisit
-                    // this eventually (make all graphs square? user-configured aspect ratio?).
                     graphLayout.setRatio((float)g.getRatio((GraphData)field), (float)1);
                 } catch (GraphException ex) {
                     graphView = new TextView(context);

--- a/app/src/org/commcare/views/EntityDetailView.java
+++ b/app/src/org/commcare/views/EntityDetailView.java
@@ -268,10 +268,11 @@ public class EntityDetailView extends FrameLayout {
                 try {
                     graphHTML = g.getHTML((GraphData)field);
                     graphView = g.getView(graphHTML);
-                    // Graphs are drawn with aspect ratio 2:1, which is mostly arbitrary
-                    // and happened to look nice for partographs. Expect to revisit
+                    // Most graphs are drawn with aspect ratio 2:1, which is mostly arbitrary
+                    // and happened to look nice for partographs. Bar graphs are drawn square - 
+                    // again, arbitrary, happens to look nice for mobile UCR. Expect to revisit
                     // this eventually (make all graphs square? user-configured aspect ratio?).
-                    graphLayout.setRatio(2, 1);
+                    graphLayout.setRatio((float)g.getRatio((GraphData)field), (float)1);
                 } catch (GraphException ex) {
                     graphView = new TextView(context);
                     int padding = (int)context.getResources().getDimension(R.dimen.spacer_small);


### PR DESCRIPTION
Revert https://github.com/dimagi/commcare-odk/pull/840

While there are no longer technical reasons that require bar graphs to be square, bar graphs are mostly used for mobile UCR, which looks nicer with taller graphs.