### PR TITLE
Fix for Busted Menu Audio Layout

### DIFF
--- a/app/res/layout/menu_list_item_modern.xml
+++ b/app/res/layout/menu_list_item_modern.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<org.commcare.views.ShrinkingLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                            xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_width="fill_parent"
               android:layout_height="fill_parent"
+              app:shrinkable_view="@+id/row_txt"
               android:textAppearance="@style/EntityItemText">
 
     <ImageView
         android:id="@+id/row_img"
-        android:layout_gravity="center_vertical|left"
         android:layout_width="wrap_content"
         style="@style/ListContentV2"/>
 
     <TextView
         android:id="@+id/row_txt"
-        android:layout_gravity="center_vertical|center_horizontal"
         android:layout_width="wrap_content"
+        android:layout_weight="1"
         style="@style/ListContentV2"/>
 
     <org.commcare.views.media.AudioButton
         android:id="@+id/row_soundicon"
-        android:layout_gravity="center_vertical|right"
         android:layout_width="wrap_content"
+        style="@style/ListContentV2"
         android:background="@color/transparent_background"
-        style="@style/ListContentV2"/>
-</LinearLayout>
+        />
+
+</org.commcare.views.ShrinkingLinearLayout>

--- a/app/res/layout/menu_list_item_modern.xml
+++ b/app/res/layout/menu_list_item_modern.xml
@@ -20,8 +20,7 @@
     <org.commcare.views.media.AudioButton
         android:id="@+id/row_soundicon"
         android:layout_width="wrap_content"
-        style="@style/ListContentV2"
         android:background="@color/transparent_background"
-        />
+        style="@style/ListContentV2"/>
 
 </org.commcare.views.ShrinkingLinearLayout>

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -19,6 +19,10 @@
     <attr name="img" format="reference"/>
     <attr name="textColor" format="reference|color"/>
 
+    <declare-styleable name="ShrinkingLinearLayout">
+        <attr name="shrinkable_view" format="reference"/>
+    </declare-styleable>
+
     <declare-styleable name="CustomButtonWithText">
         <attr name="backgroundColor"/>
         <attr name="subtitle"/>

--- a/app/src/org/commcare/views/ShrinkingLinearLayout.java
+++ b/app/src/org/commcare/views/ShrinkingLinearLayout.java
@@ -1,0 +1,87 @@
+package org.commcare.views;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Build;
+import android.text.Layout;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+
+import org.commcare.dalvik.R;
+import org.commcare.utils.AndroidUtil;
+
+/**
+ * A shrinking linear layout is capable of denoting one child view which can change its size
+ * if the full space is not needed.
+ *
+ * Normally a linear layout requires either fully laying out (IE: Pre-determined static sizes or
+ * ratios) all of its children _or_ accepting that if the linear layout grows larger than its parent
+ * some views will be cut off.
+ *
+ * When designing a shrinking layout, the view can be laid out fully "expanded" (IE: All of the
+ * child views are the largest they will ever be), then one view can be chosen to shrink to its
+ * "natural" width if it doesn't need the full space. This allows for things like text fields with
+ * an element next to the text that can grow horizontally _until_ running into the fully "expanded"
+ * layout.
+ *
+ * Limitations:
+ * This layout is incrementally slower than a traditional linear layout.
+ * The view will currently only shrink horizontally
+ *
+ * Created by ctsims on 5/18/2016.
+ */
+public class ShrinkingLinearLayout extends LinearLayout {
+    int shrinkingViewId = -1;
+
+    public ShrinkingLinearLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        loadViewConfig(context, attrs);
+    }
+
+    private void loadViewConfig(Context context, AttributeSet attrs) {
+        TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.ShrinkingLinearLayout);
+        shrinkingViewId = typedArray.getResourceId(R.styleable.ShrinkingLinearLayout_shrinkable_view, -1);
+    }
+
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        View dynamicView = this.findViewById(shrinkingViewId);
+
+        if(shrinkingViewId == -1 || dynamicView == null) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            return;
+        }
+
+        //Figure out how much width the constrained view _really_ wants
+        dynamicView.measure(MeasureSpec.UNSPECIFIED, heightMeasureSpec);
+        int desiredWidth = dynamicView.getMeasuredWidth();
+
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+        //If after everything is measured the view is bigger than it needs to be, forget the other
+        //layout directives, and have the view only request that width
+        if(dynamicView.getMeasuredWidth() > desiredWidth) {
+            LayoutParams params = (LinearLayout.LayoutParams)dynamicView.getLayoutParams();
+
+            //NOTE: Any parameters used to control the final size will need to be copied in this
+            //way. API19+ supports copy construction for layout params, but that's a ways away
+            int oldWidth = params.width;
+            float oldWeight = params.weight;
+
+            params.width = desiredWidth;
+            params.weight = 0;
+
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+            //reset the parameters, since they are directives, not values.
+            params.width = oldWidth;
+            params.weight = oldWeight;
+        }
+
+    }
+}

--- a/app/src/org/commcare/views/ShrinkingLinearLayout.java
+++ b/app/src/org/commcare/views/ShrinkingLinearLayout.java
@@ -1,18 +1,12 @@
 package org.commcare.views;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.os.Build;
-import android.text.Layout;
 import android.util.AttributeSet;
-import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import org.commcare.dalvik.R;
-import org.commcare.utils.AndroidUtil;
 
 /**
  * A shrinking linear layout is capable of denoting one child view which can change its size

--- a/app/src/org/commcare/views/ShrinkingLinearLayout.java
+++ b/app/src/org/commcare/views/ShrinkingLinearLayout.java
@@ -29,7 +29,7 @@ import org.commcare.dalvik.R;
  * Created by ctsims on 5/18/2016.
  */
 public class ShrinkingLinearLayout extends LinearLayout {
-    int shrinkingViewId = -1;
+    private int shrinkingViewId = -1;
 
     public ShrinkingLinearLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -39,6 +39,7 @@ public class ShrinkingLinearLayout extends LinearLayout {
     private void loadViewConfig(Context context, AttributeSet attrs) {
         TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.ShrinkingLinearLayout);
         shrinkingViewId = typedArray.getResourceId(R.styleable.ShrinkingLinearLayout_shrinkable_view, -1);
+        typedArray.recycle();
     }
 
 
@@ -59,7 +60,7 @@ public class ShrinkingLinearLayout extends LinearLayout {
 
         //If after everything is measured the view is bigger than it needs to be, forget the other
         //layout directives, and have the view only request that width
-        if(dynamicView.getMeasuredWidth() > desiredWidth) {
+        if (dynamicView.getMeasuredWidth() > desiredWidth) {
             LayoutParams params = (LinearLayout.LayoutParams)dynamicView.getLayoutParams();
 
             //NOTE: Any parameters used to control the final size will need to be copied in this


### PR DESCRIPTION
The previous audio button behavior has been broken for what appears to be a long time. The audio buttons would drift off the screen if menu text got too long.

Fix for: http://manage.dimagi.com/default.asp?225035

Implementing the new Audio UI to Biyuen's spec was surprisingly not well supported, had to implement a custom layout rule. 

NOTE: I'm going to figure out whether this needs to make it into 2.27, will probably splice in the change if so.

Examples of the new behavior for short and long text, along with the broken behavior, and the pre-new-ui behavior (far right) that is really awkward on larger screens:
![image](https://cloud.githubusercontent.com/assets/155066/15378487/daf6adcc-1d31-11e6-8381-30d6c7de8ca1.png)