### PR TITLE
Localize login password text hint

### DIFF
--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -213,6 +213,8 @@ public class LoginActivityUIController implements CommCareActivityUIController {
 
         if (activity.checkForSeatedAppChange()) {
             refreshForNewApp();
+        } else {
+            checkEnteredUsernameForMatch();
         }
     }
 


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?225005

Reproducible by downloading an app where the default is non-english (icds), logging in and then clearing user data. This will cause the LoginActivity to be started in such a way that the hint isn't localized.

@amstone326 not entirely if this is the correct code change to fix the issue, in that it fixes it but maybe there is a more appropriate approach.