### PR TITLE
Redo demo warning dialog

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -299,7 +299,6 @@ home.sync.message.last.demo=You are using CommCare in demo mode
 
 demo.mode.warning.title=Starting Demo Mode
 demo.mode.warning=You are logging into CommCare in Demo mode. Demo mode is for testing and practice only!
-demo.mode.warning.dismiss=I Understand
 
 demo.mode.feature.unavailable=Sorry, this app uses a feature that is not available in Demo mode. Please log in as a named user.
 

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -735,24 +735,9 @@ public class CommCareHomeActivity
     }
 
     private void showDemoModeWarning() {
-        AlertDialog demoModeWarning = new AlertDialog.Builder(new ContextThemeWrapper(this, android.R.style.Theme_Light)).setInverseBackgroundForced(true).create();
-        demoModeWarning.setTitle(Localization.get("demo.mode.warning.title"));
-        demoModeWarning.setCancelable(false);
-
-        DialogInterface.OnClickListener demoModeWarningListener = new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int i) {
-                // user has acknowledged demo warning
-            }
-        };
-        demoModeWarning.setButton(android.content.DialogInterface.BUTTON_POSITIVE,
-                Localization.get("demo.mode.warning.dismiss"),
-                demoModeWarningListener);
-
-        HorizontalMediaView tiav = new HorizontalMediaView(this);
-        tiav.setAVT(Localization.get("demo.mode.warning"), null, null);
-
-        demoModeWarning.setView(tiav);
-        demoModeWarning.show();
+        showAlertDialog(StandardAlertDialog.getBasicAlertDialogWithIcon(this,
+                Localization.get("demo.mode.warning.title"), Localization.get("demo.mode.warning"),
+                android.R.drawable.ic_dialog_info, null));
     }
 
     private void createErrorDialog(String errorMsg, AlertDialog.OnClickListener errorListener) {

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile 'ch.acra:acra:4.8.5@aar'
     compile 'joda-time:joda-time:2.9.3'
     compile 'net.sf.kxml:kxml2:2.3.0'
-    compile 'net.zetetic:android-database-sqlcipher:3.3.1-2@aar'
+    compile 'net.zetetic:android-database-sqlcipher:3.4.0@aar'
     compile 'org.apache.james:apache-mime4j:0.7.2'
     compile('org.apache.httpcomponents:httpmime:4.3.6') {
         exclude module: 'httpclient'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.0'
-        classpath 'com.google.gms:google-services:2.0.0'
+        classpath 'com.google.gms:google-services:3.0.0'
     }
 }
 
@@ -58,8 +58,8 @@ dependencies {
     compile 'com.android.support:gridlayout-v7:23.4.0'
     compile 'com.madgag.spongycastle:core:1.54.0.0'
     compile 'com.madgag.spongycastle:prov:1.54.0.0'
-    compile 'com.google.android.gms:play-services-maps:8.4.0'
-    compile 'com.google.android.gms:play-services-analytics:8.4.0'
+    compile 'com.google.android.gms:play-services-maps:9.0.0'
+    compile 'com.google.android.gms:play-services-analytics:9.0.0'
     compile 'com.google.zxing:core:3.2.1'
     compile 'ch.acra:acra:4.8.5@aar'
     compile 'joda-time:joda-time:2.9.3'

--- a/templates/google-services.json
+++ b/templates/google-services.json
@@ -15,7 +15,7 @@
         }
       },
       "oauth_client": [],
-      "api_key": [],
+      "api_key": [{ "current_key": "" }],
       "services": {
         "analytics_service": {
           "status": 2,


### PR DESCRIPTION
| Old | New |
|---|---|
| ![demo-old](https://cloud.githubusercontent.com/assets/94817/15478800/9c48a5dc-20ea-11e6-9f92-7486ec05f5b1.png) | ![demo-new](https://cloud.githubusercontent.com/assets/94817/15478802/a166f280-20ea-11e6-914a-9f14a31e6a0f.png) |

Make demo warning persist across screen rotation

**Additionally**: 
 - updates to google-services 9.0, which has no notable changes to maps or analytics: https://developers.google.com/android/guides/releases 
 - update from SQLCipher 3.3.1-2 to 3.4.0. I read over the [changelog](https://discuss.zetetic.net/t/sqlcipher-3-4-0-release/1273) and looks like we are good to go, (checked that we don't use the now deprecated `PRAGMA cipher`). Touts something like up to a 20% performance improvement over 3.3.1