### PR TITLE
Small startup optimization: don't print tables in prod code

### DIFF
--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -191,18 +191,18 @@ public class CommCareApp implements AppFilePathBuilder {
         ResourceTable upgrade = platform.getUpgradeResourceTable();
         ResourceTable recovery = platform.getRecoveryTable();
 
-        Log.d(TAG, "Global\n" + global.toString());
-        Log.d(TAG, "Upgrade\n" + upgrade.toString());
-        Log.d(TAG, "Recovery\n" + recovery.toString());
+        logTable("Global", global);
+        logTable("Upgrade", upgrade);
+        logTable("Recovery", recovery);
 
         // See if any of our tables got left in a weird state
         if (global.getTableReadiness() == ResourceTable.RESOURCE_TABLE_UNCOMMITED) {
             global.rollbackCommits();
-            Log.d(TAG, "Global after rollback\n" + global.toString());
+            logTable("Global after rollback", global);
         }
         if (upgrade.getTableReadiness() == ResourceTable.RESOURCE_TABLE_UNCOMMITED) {
             upgrade.rollbackCommits();
-            Log.d(TAG, "upgrade after rollback\n" + upgrade.toString());
+            logTable("Upgrade after rollback", upgrade);
         }
 
         // See if we got left in the middle of an update
@@ -232,6 +232,13 @@ public class CommCareApp implements AppFilePathBuilder {
             return true;
         }
         return false;
+    }
+
+    private static void logTable(String name, ResourceTable table) {
+        if (BuildConfig.DEBUG) {
+            // Avoid printing resource tables in production; it's expensive
+            Log.d(TAG, name + "\n" + table.toString());
+        }
     }
 
     private void initializeStylizer() {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -61,10 +61,10 @@ import org.commcare.logging.analytics.TimedStatsTracker;
 import org.commcare.models.AndroidClassHasher;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.models.database.AndroidDbHelper;
-import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.HybridFileBackedSqlHelpers;
 import org.commcare.models.database.HybridFileBackedSqlStorage;
 import org.commcare.models.database.MigrationException;
+import org.commcare.models.database.AndroidPrototypeFactorySetup;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.app.DatabaseAppOpenHelper;
 import org.commcare.android.database.app.models.UserKeyRecord;
@@ -1470,7 +1470,7 @@ public class CommCareApplication extends Application {
     }
 
     public PrototypeFactory getPrototypeFactory(Context c) {
-        return DbUtil.getPrototypeFactory(c);
+        return AndroidPrototypeFactorySetup.getPrototypeFactory(c);
     }
 
 }

--- a/app/src/org/commcare/models/database/AndroidPrototypeFactorySetup.java
+++ b/app/src/org/commcare/models/database/AndroidPrototypeFactorySetup.java
@@ -76,7 +76,7 @@ public class AndroidPrototypeFactorySetup {
     public static void loadClass(String cn, List<String> classNames) {
         try {
             for (String packageName : packageNames) {
-                if (cn.startsWith(packageName) && !cn.contains(".test.") && !cn.contains("readystatesoftware")) {
+                if (cn.startsWith(packageName)) {
                     //TODO: These optimize by preventing us from statically loading classes we don't need, but they take a _long_ time to run.
                     //Maybe we should skip this and/or roll it into initializing the factory itself.
                     Class prototype = Class.forName(cn);

--- a/app/src/org/commcare/models/database/AndroidPrototypeFactorySetup.java
+++ b/app/src/org/commcare/models/database/AndroidPrototypeFactorySetup.java
@@ -1,0 +1,104 @@
+package org.commcare.models.database;
+
+import android.content.Context;
+
+import org.commcare.models.AndroidPrototypeFactory;
+import org.javarosa.core.util.PrefixTree;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import dalvik.system.DexFile;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class AndroidPrototypeFactorySetup {
+    private static final String[] packageNames = new String[]{"org.javarosa", "org.commcare", "org.odk.collect"};
+    private static PrototypeFactory factory;
+
+    /**
+     * Basically this is our PrototypeManager for Android
+     */
+    public static PrototypeFactory getPrototypeFactory(Context c) {
+        if (factory != null) {
+            return factory;
+        }
+
+        PrefixTree tree = new PrefixTree();
+
+        try {
+            List<String> classes = getClasses(c);
+            for (String cl : classes) {
+                tree.addString(cl);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        factory = new AndroidPrototypeFactory(tree);
+        return factory;
+    }
+
+    public static void setDBUtilsPrototypeFactory(PrototypeFactory factory) {
+        AndroidPrototypeFactorySetup.factory = factory;
+    }
+
+    /**
+     * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
+     */
+    private static List<String> getClasses(Context c)
+            throws IOException {
+        ArrayList<String> classNames = new ArrayList<>();
+
+        String zpath = c.getApplicationInfo().sourceDir;
+
+
+        if (zpath == null) {
+            zpath = "/data/app/org.commcare.android.apk";
+        }
+
+        DexFile df = new DexFile(new File(zpath));
+        for (Enumeration<String> en = df.entries(); en.hasMoreElements(); ) {
+            String cn = en.nextElement();
+            loadClass(cn, classNames);
+        }
+
+        return classNames;
+    }
+
+    public static void loadClass(String cn, List<String> classNames) {
+        try {
+            for (String packageName : packageNames) {
+                if (cn.startsWith(packageName) && !cn.contains(".test.") && !cn.contains("readystatesoftware")) {
+                    //TODO: These optimize by preventing us from statically loading classes we don't need, but they take a _long_ time to run.
+                    //Maybe we should skip this and/or roll it into initializing the factory itself.
+                    Class prototype = Class.forName(cn);
+                    if (prototype.isInterface()) {
+                        continue;
+                    }
+                    boolean emptyc = false;
+                    for (Constructor<?> cons : prototype.getConstructors()) {
+                        if (cons.getParameterTypes().length == 0) {
+                            emptyc = true;
+                        }
+                    }
+                    if (!emptyc) {
+                        continue;
+                    }
+                    if (Externalizable.class.isAssignableFrom(prototype)) {
+                        classNames.add(cn);
+                    }
+                }
+            }
+        } catch (Error | Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/org/commcare/models/database/DbUtil.java
+++ b/app/src/org/commcare/models/database/DbUtil.java
@@ -8,106 +8,13 @@ import android.util.Log;
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteDatabaseHook;
 
-import org.commcare.models.AndroidPrototypeFactory;
 import org.commcare.modern.database.DatabaseHelper;
-import org.javarosa.core.util.PrefixTree;
-import org.javarosa.core.util.externalizable.Externalizable;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-
-import dalvik.system.DexFile;
 
 public class DbUtil {
     private static final String TAG = DbUtil.class.getSimpleName();
     public final static String orphanFileTableName = "OrphanedFiles";
-
-    private static PrototypeFactory factory;
-    private static final String[] packageNames = new String[]{"org.javarosa", "org.commcare", "org.odk.collect"};
-
-    public static void setDBUtilsPrototypeFactory(PrototypeFactory factory) {
-        DbUtil.factory = factory;
-    }
-
-    /**
-     * Basically this is our PrototypeManager for Android
-     */
-    public static PrototypeFactory getPrototypeFactory(Context c) {
-        if (factory != null) {
-            return factory;
-        }
-
-        PrefixTree tree = new PrefixTree();
-
-        try {
-            List<String> classes = getClasses(c);
-            for (String cl : classes) {
-                tree.addString(cl);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        factory = new AndroidPrototypeFactory(tree);
-        return factory;
-    }
-
-    /**
-     * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
-     */
-    private static List<String> getClasses(Context c)
-            throws IOException {
-        ArrayList<String> classNames = new ArrayList<>();
-
-        String zpath = c.getApplicationInfo().sourceDir;
-
-
-        if (zpath == null) {
-            zpath = "/data/app/org.commcare.android.apk";
-        }
-
-        DexFile df = new DexFile(new File(zpath));
-        for (Enumeration<String> en = df.entries(); en.hasMoreElements(); ) {
-            String cn = en.nextElement();
-            loadClass(cn, classNames);
-        }
-
-        return classNames;
-    }
-
-    public static void loadClass(String cn, List<String> classNames) {
-        try {
-            for (String packageName : packageNames) {
-                if (cn.startsWith(packageName) && !cn.contains(".test.") && !cn.contains("readystatesoftware")) {
-                    //TODO: These optimize by preventing us from statically loading classes we don't need, but they take a _long_ time to run.
-                    //Maybe we should skip this and/or roll it into initializing the factory itself.
-                    Class prototype = Class.forName(cn);
-                    if (prototype.isInterface()) {
-                        continue;
-                    }
-                    boolean emptyc = false;
-                    for (Constructor<?> cons : prototype.getConstructors()) {
-                        if (cons.getParameterTypes().length == 0) {
-                            emptyc = true;
-                        }
-                    }
-                    if (!emptyc) {
-                        continue;
-                    }
-                    if (Externalizable.class.isAssignableFrom(prototype)) {
-                        classNames.add(cn);
-                    }
-                }
-            }
-        } catch (Error | Exception e) {
-
-        }
-    }
 
     /**
      * Provides a hook for Sqllite databases to be able to try to migrate themselves in place

--- a/app/src/org/commcare/models/legacy/LegacyDbHelper.java
+++ b/app/src/org/commcare/models/legacy/LegacyDbHelper.java
@@ -6,7 +6,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.util.Pair;
 
 import org.commcare.models.database.AndroidTableBuilder;
-import org.commcare.models.database.DbUtil;
+import org.commcare.models.database.AndroidPrototypeFactorySetup;
 import org.commcare.models.encryption.CryptUtil;
 import org.commcare.modern.database.DatabaseHelper;
 import org.commcare.modern.models.EncryptedModel;
@@ -141,6 +141,6 @@ public abstract class LegacyDbHelper {
     }
 
     public PrototypeFactory getPrototypeFactory() {
-        return DbUtil.getPrototypeFactory(c);
+        return AndroidPrototypeFactorySetup.getPrototypeFactory(c);
     }
 }

--- a/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -6,10 +6,10 @@ import android.util.Log;
 import org.commcare.android.util.TestUtils;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.models.AndroidPrototypeFactory;
-import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.HybridFileBackedSqlStorage;
 import org.commcare.models.database.HybridFileBackedSqlStorageMock;
 import org.commcare.android.database.app.models.UserKeyRecord;
+import org.commcare.models.database.AndroidPrototypeFactorySetup;
 import org.commcare.services.CommCareSessionService;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.storage.Persistable;
@@ -98,7 +98,7 @@ public class CommCareTestApplication extends CommCareApplication {
                         .replace("/", ".")
                         .replace(".class", "")
                         .replace(".class", "");
-                DbUtil.loadClass(className, externClasses);
+                AndroidPrototypeFactorySetup.loadClass(className, externClasses);
             }
         } catch (Exception e) {
             Log.w(TAG, e.getMessage());

--- a/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -10,7 +10,7 @@ import org.commcare.data.xml.TransactionParserFactory;
 import org.commcare.engine.cases.AndroidCaseInstanceTreeElement;
 import org.commcare.models.AndroidClassHasher;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
-import org.commcare.models.database.DbUtil;
+import org.commcare.models.database.AndroidPrototypeFactorySetup;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.user.DatabaseUserOpenHelper;
 import org.commcare.android.database.user.models.ACase;
@@ -55,7 +55,7 @@ public class TestUtils {
     public static void initializeStaticTestStorage() {
         //Sets the static strategy for the deserializtion code to be
         //based on an optimized md5 hasher. Major speed improvements.
-        DbUtil.setDBUtilsPrototypeFactory(new LivePrototypeFactory(new AndroidClassHasher()));
+        AndroidPrototypeFactorySetup.setDBUtilsPrototypeFactory(new LivePrototypeFactory(new AndroidClassHasher()));
         AndroidUtil.initializeStaticHandlers();
         disableSqlOptimizations();
     }


### PR DESCRIPTION
 - Only print resource tables on debug builds. Takes ~.25 seconds during startup time.
 - Move Android prototype factory setup code to its own file for better readability
 - Remove unneeded class name `contains` checks for `.test.` and `readystatesoftware`