### PR TITLE
Add prompt to view notification when it is available

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -654,12 +654,15 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     /**
      * Raise failure message and return to the home activity with cancel code
      */
-    private void fail(NotificationMessage message, boolean alwaysNotify) {
-        Toast.makeText(this, message.getTitle(), Toast.LENGTH_LONG).show();
-
-        if (alwaysNotify) {
+    private void fail(NotificationMessage message, boolean reportNotification) {
+        String toastMessage;
+        if (reportNotification) {
             CommCareApplication._().reportNotificationMessage(message);
+            toastMessage = Localization.get("notification.for.details.wrapper", new String[]{message.getTitle()});
+        } else {
+            toastMessage = message.getTitle();
         }
+        Toast.makeText(this, toastMessage, Toast.LENGTH_LONG).show();
 
         // Last install attempt failed, so restore to starting uistate to try again
         uiState = UiState.CHOOSE_INSTALL_ENTRY_METHOD;


### PR DESCRIPTION
When an install failure has a useful error message, include in the toast message a prompt to view notifications for more info.

Before: 
![screenshot_20160525-214027](https://cloud.githubusercontent.com/assets/3723143/15553860/2e1fb1bc-228f-11e6-8c93-bfa893b7c448.png)

After:
![screenshot_20160525-213808](https://cloud.githubusercontent.com/assets/3723143/15553863/31b7d0b6-228f-11e6-9fb9-c017ec2f842e.png)

