### PR TITLE
Specify app version for consumer apps

### DIFF
--- a/scripts/consumer_apps_builder.py
+++ b/scripts/consumer_apps_builder.py
@@ -76,8 +76,7 @@ def get_app_fields(config_filename):
 
 
 def download_ccz(app_id, domain, build_number):
-    #TODO: Get HQ to implement downloading a specific build
-    subprocess.call(["./scripts/download_app_into_standalone_asset.sh", domain, app_id, PATH_TO_ASSETS_DIR_FROM_ODK]) 
+    subprocess.call(["./scripts/download_app_into_standalone_asset.sh", domain, app_id, PATH_TO_ASSETS_DIR_FROM_ODK, build_number])
 
 
 def download_restore_file(domain, username, password):

--- a/scripts/download_app_into_standalone_asset.sh
+++ b/scripts/download_app_into_standalone_asset.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
-# args: $1 = domain, $2 = app_id, $3 = path to asset dir
+# args: $1 = domain, $2 = app_id, $3 = path to asset dir, $4 = version_number
 # download and extract commcare app with id of $1
 
 DOMAIN=$1
 APP_ID=$2
 ASSET_DIR=$3/direct_install
+VERSION_NUMBER=$4
 
 echo "Downloading $1 (id $2) into $ASSET_DIR"
 
 mkdir -p $ASSET_DIR
 
-wget "https://www.commcarehq.org/a/$1/apps/api/download_ccz/?app_id=${2}#hack=commcare.ccz" -O "$ASSET_DIR/ccapp.zip"
+wget "https://www.commcarehq.org/a/$DOMAIN/apps/api/download_ccz?app_id=$APP_ID&version=$VERSION_NUMBER" -O "$ASSET_DIR/ccapp.zip"
 
 cd $ASSET_DIR
 unzip -o ccapp.zip


### PR DESCRIPTION
Now that Ethan has augmented the endpoint to take additional parameters, have the consumer apps builder script pull down the specified app version.