### PR TITLE
Robolectric tests for Saved Forms view

### DIFF
--- a/app/res/layout/formrecordview.xml
+++ b/app/res/layout/formrecordview.xml
@@ -4,7 +4,7 @@
     android:layout_width="wrap_content"
     android:layout_height="fill_parent"
     android:orientation="horizontal"
-    >
+    android:paddingRight="@dimen/content_min_margin" >
 
     <ImageView
         android:padding="@dimen/cell_padding_horizontal"
@@ -33,6 +33,16 @@
             android:layout_above="@+id/formrecord_txt_right"
             android:textColor="@color/cc_neutral_color"
             android:gravity="right"/>
+        <ImageView
+            android:id="@+id/formrecord_sync_icon"
+            android:visibility="gone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:layout_alignLeftOf="@id/formrecord_txt_upp_right"
+            android:tint="@color/cc_neutral_color"
+            android:tintMode="src_atop"
+            android:src="@android:drawable/stat_notify_sync_noanim"/>
 
         <TextView
             android:layout_width="wrap_content"

--- a/app/res/layout/formrecordview.xml
+++ b/app/res/layout/formrecordview.xml
@@ -4,7 +4,8 @@
     android:layout_width="wrap_content"
     android:layout_height="fill_parent"
     android:orientation="horizontal"
-    android:paddingRight="@dimen/content_min_margin" >
+    android:paddingRight="@dimen/row_padding_vertical"
+    android:paddingLeft="@dimen/row_padding_vertical" >
 
     <ImageView
         android:padding="@dimen/cell_padding_horizontal"
@@ -31,15 +32,18 @@
             android:layout_alignParentRight="true"
             android:id="@+id/formrecord_txt_upp_right"
             android:layout_above="@+id/formrecord_txt_right"
+            style="@style/WarningTextStyle"
             android:textColor="@color/cc_neutral_color"
             android:gravity="right"/>
+
         <ImageView
             android:id="@+id/formrecord_sync_icon"
             android:visibility="gone"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:layout_alignLeftOf="@id/formrecord_txt_upp_right"
+            android:layout_toLeftOf="@id/formrecord_txt_upp_right"
+            android:layout_above="@+id/formrecord_txt_right"
             android:tint="@color/cc_neutral_color"
             android:tintMode="src_atop"
             android:src="@android:drawable/stat_notify_sync_noanim"/>

--- a/app/res/layout/formrecordview.xml
+++ b/app/res/layout/formrecordview.xml
@@ -32,7 +32,6 @@
             android:layout_alignParentRight="true"
             android:id="@+id/formrecord_txt_upp_right"
             android:layout_above="@+id/formrecord_txt_right"
-            style="@style/WarningTextStyle"
             android:textColor="@color/cc_neutral_color"
             android:gravity="right"/>
 

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -69,6 +69,7 @@
 
     <style name="WarningTextStyle">
         <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/cc_neutral_color</item>
     </style>
 
     <dimen name="menu_icon_size">60dp</dimen>

--- a/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
@@ -257,11 +257,11 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
         FormRecord r = current.get(i);
         IncompleteFormRecordView ifrv = (IncompleteFormRecordView) v;
         if (ifrv == null) {
-            ifrv = new IncompleteFormRecordView(context, names);
+            ifrv = new IncompleteFormRecordView(context);
         }
 
         if (searchCache.containsKey(r.getID())) {
-            ifrv.setParams(r, searchCache.get(r.getID())[1], r.lastModified().getTime());
+            ifrv.setParams(r, searchCache.get(r.getID())[1], r.lastModified().getTime(), names);
         } else {
             // notify the loader that we need access to this record immediately
             loader.registerPriority(r);
@@ -270,7 +270,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
             // local notifyPriorityLoaded method should probably be defined to
             // reset the params of this record. It will eventually get reset,
             // once this method is called again...
-            ifrv.setParams(r, "Loading...", r.lastModified().getTime());
+            ifrv.setParams(r, "Loading...", r.lastModified().getTime(), names);
         }
 
         return ifrv;

--- a/app/src/org/commcare/views/IncompleteFormRecordView.java
+++ b/app/src/org/commcare/views/IncompleteFormRecordView.java
@@ -30,17 +30,14 @@ public class IncompleteFormRecordView extends LinearLayout {
     public final TextView mRightTextView;
     private final TextView mUpperRight;
 
-    private final Hashtable<String, Text> names;
     private final Date start;
 
     private Drawable rightHandSync;
 
-    public IncompleteFormRecordView(Context context, Hashtable<String, Text> names) {
+    public IncompleteFormRecordView(Context context) {
         super(context);
 
         ViewGroup vg = (ViewGroup)View.inflate(context, R.layout.formrecordview, null);
-        this.names = names;
-
         mPrimaryTextView = (TextView)vg.findViewById(R.id.formrecord_txt_main);
         mLowerTextView = (TextView)vg.findViewById(R.id.formrecord_txt_btm);
         mRightTextView = (TextView)vg.findViewById(R.id.formrecord_txt_right);
@@ -53,10 +50,10 @@ public class IncompleteFormRecordView extends LinearLayout {
         addView(vg, l);
 
         start = new Date();
-
     }
 
-    public void setParams(FormRecord record, String dataTitle, Long timestamp) {
+    public void setParams(FormRecord record, String dataTitle,
+                          Long timestamp, Hashtable<String, Text> names) {
         if (names.containsKey(record.getFormNamespace())) {
             Text name = names.get(record.getFormNamespace());
             mPrimaryTextView.setText(MarkupUtil.styleSpannable(getContext(), name.evaluate()));

--- a/app/src/org/commcare/views/IncompleteFormRecordView.java
+++ b/app/src/org/commcare/views/IncompleteFormRecordView.java
@@ -1,8 +1,6 @@
 package org.commcare.views;
 
 import android.content.Context;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.text.format.DateUtils;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/org/commcare/views/IncompleteFormRecordView.java
+++ b/app/src/org/commcare/views/IncompleteFormRecordView.java
@@ -77,7 +77,7 @@ public class IncompleteFormRecordView extends LinearLayout {
             syncIcon.setVisibility(View.VISIBLE);
         } else {
             mUpperRight.setText("");
-            mUpperRight.setCompoundDrawables(null, null, null, null);
+            syncIcon.setVisibility(View.GONE);
         }
     }
 }

--- a/app/src/org/commcare/views/IncompleteFormRecordView.java
+++ b/app/src/org/commcare/views/IncompleteFormRecordView.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable;
 import android.text.format.DateUtils;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -29,10 +30,9 @@ public class IncompleteFormRecordView extends LinearLayout {
     private final TextView mLowerTextView;
     public final TextView mRightTextView;
     private final TextView mUpperRight;
+    private final ImageView syncIcon;
 
     private final Date start;
-
-    private Drawable rightHandSync;
 
     public IncompleteFormRecordView(Context context) {
         super(context);
@@ -42,11 +42,12 @@ public class IncompleteFormRecordView extends LinearLayout {
         mLowerTextView = (TextView)vg.findViewById(R.id.formrecord_txt_btm);
         mRightTextView = (TextView)vg.findViewById(R.id.formrecord_txt_right);
         mUpperRight = (TextView)vg.findViewById(R.id.formrecord_txt_upp_right);
+        syncIcon = (ImageView)vg.findViewById(R.id.formrecord_sync_icon);
 
         mPrimaryTextView.setTextAppearance(context, android.R.style.TextAppearance_Large);
         mUpperRight.setTextAppearance(context, android.R.style.TextAppearance_Large);
 
-        LayoutParams l = new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT);
+        LayoutParams l = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
         addView(vg, l);
 
         start = new Date();
@@ -75,13 +76,7 @@ public class IncompleteFormRecordView extends LinearLayout {
             mUpperRight.setText(MarkupUtil.localizeStyleSpannable(getContext(), "form.record.unsent"));
             mUpperRight.setTextAppearance(getContext(), R.style.WarningTextStyle);
 
-            if (rightHandSync == null) {
-                rightHandSync = getContext().getResources().getDrawable(android.R.drawable.stat_notify_sync_noanim);
-                if (rightHandSync != null) {
-                    rightHandSync.setColorFilter(getResources().getColor(R.color.cc_neutral_color), PorterDuff.Mode.SRC_ATOP);
-                }
-            }
-            mUpperRight.setCompoundDrawablesWithIntrinsicBounds(null, null, rightHandSync, null);
+            syncIcon.setVisibility(View.VISIBLE);
         } else {
             mUpperRight.setText("");
             mUpperRight.setCompoundDrawables(null, null, null, null);

--- a/unit-tests/resources/commcare-apps/form_nav_tests/form_instances_restore.xml
+++ b/unit-tests/resources/commcare-apps/form_nav_tests/form_instances_restore.xml
@@ -1,0 +1,68 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <data name="Hidden Group" uiVersion="1" version="95"
+          xmlns="http://openrosa.org/formdesigner/616F4108-566E-4E32-85C5-6153E3351D46"
+          xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
+        <fav_num>5</fav_num>
+        <question1>
+            <random_value>4.486532020265786</random_value>
+        </question1>
+        <question1>
+            <random_value>0.3218127012891425</random_value>
+        </question1>
+        <question1>
+            <random_value>4.7400500787703495</random_value>
+        </question1>
+        <question1>
+            <random_value>1.1886713568928826</random_value>
+        </question1>
+        <question1>
+            <random_value>0.5072332235396221</random_value>
+        </question1>
+        <n0:meta xmlns:n0="http://openrosa.org/jr/xforms">
+            <n0:deviceID>353626073782406</n0:deviceID>
+            <n0:timeStart>2016-06-02T14:53:32.134-04</n0:timeStart>
+            <n0:timeEnd>2016-06-02T14:53:34.698-04</n0:timeEnd>
+            <n0:username>fp</n0:username>
+            <n0:userID>2ebaf997aecf7e6fcbb4c6f62e8c1648</n0:userID>
+            <n0:instanceID>e02df607-2c9b-43e0-ad3a-b6063a9d6ecc</n0:instanceID>
+            <n1:appVersion xmlns:n1="http://commcarehq.org/xforms">CommCare Android, version &quot;2.28&quot;(1).
+                App v148. CommCare Version 2.28. Build 1, built on: 2016-06-02
+            </n1:appVersion>
+        </n0:meta>
+    </data>
+
+    <data name="Hidden Group" uiVersion="1" version="95"
+          xmlns="http://openrosa.org/formdesigner/616F4108-566E-4E32-85C5-6153E3351D46"
+          xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
+        <fav_num>6</fav_num>
+        <question1>
+            <random_value>2.0524448959079207</random_value>
+        </question1>
+        <question1>
+            <random_value>1.5958940048324437</random_value>
+        </question1>
+        <question1>
+            <random_value>4.948724293053524</random_value>
+        </question1>
+        <question1>
+            <random_value>5.369620044146055</random_value>
+        </question1>
+        <question1>
+            <random_value>2.624347760487655</random_value>
+        </question1>
+        <question1>
+            <random_value>4.198913353642006</random_value>
+        </question1>
+        <n0:meta xmlns:n0="http://openrosa.org/jr/xforms">
+            <n0:deviceID>353626073782406</n0:deviceID>
+            <n0:timeStart>2016-06-02T14:57:19.483-04</n0:timeStart>
+            <n0:timeEnd>2016-06-02T14:57:21.268-04</n0:timeEnd>
+            <n0:username>fp</n0:username>
+            <n0:userID>2ebaf997aecf7e6fcbb4c6f62e8c1648</n0:userID>
+            <n0:instanceID>11dbd7e7-c4f8-439b-8eab-12796f67335a</n0:instanceID>
+            <n1:appVersion xmlns:n1="http://commcarehq.org/xforms">CommCare Android, version &quot;2.28&quot;(1).
+                App v148. CommCare Version 2.28. Build 1, built on: 2016-06-02
+            </n1:appVersion>
+        </n0:meta>
+    </data>
+</OpenRosaResponse>

--- a/unit-tests/src/org/commcare/android/tests/activities/FormRecordListActivityTest.java
+++ b/unit-tests/src/org/commcare/android/tests/activities/FormRecordListActivityTest.java
@@ -1,0 +1,57 @@
+package org.commcare.android.tests.activities;
+
+import android.widget.ListView;
+
+import org.commcare.CommCareTestApplication;
+import org.commcare.activities.FormRecordListActivity;
+import org.commcare.adapters.IncompleteFormListAdapter;
+import org.commcare.android.CommCareTestRunner;
+import org.commcare.android.util.SavedFormLoader;
+import org.commcare.android.util.TestAppInstaller;
+import org.commcare.dalvik.BuildConfig;
+import org.commcare.dalvik.R;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowListView;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+@Config(application = CommCareTestApplication.class,
+        constants = BuildConfig.class)
+@RunWith(CommCareTestRunner.class)
+public class FormRecordListActivityTest {
+    @Before
+    public void setup() {
+        TestAppInstaller.installAppAndLogin(
+                "jr://resource/commcare-apps/form_nav_tests/profile.ccpr",
+                "test", "123");
+        SavedFormLoader.loadFormsFromPayload("/commcare-apps/form_nav_tests/form_instances_restore.xml");
+    }
+
+    /**
+     * Opens up the saved form list activity and checks that there are 2 forms listed
+     */
+    @Test
+    public void openSavedFormViewTest() {
+        FormRecordListActivity homeActivity =
+                Robolectric.buildActivity(FormRecordListActivity.class).create().start().resume().get();
+        // wait for entities to load
+        Robolectric.flushBackgroundThreadScheduler();
+        Robolectric.flushForegroundThreadScheduler();
+        ListView entityList =
+                (ListView)homeActivity.findViewById(R.id.screen_entity_select_list);
+        IncompleteFormListAdapter adapter = (IncompleteFormListAdapter)entityList.getAdapter();
+        adapter.setFormFilter(FormRecordListActivity.FormRecordFilter.Submitted);
+        adapter.resetRecords();
+        ShadowListView shadowListView = Shadows.shadowOf(entityList);
+        shadowListView.populateItems();
+        assertEquals(2, adapter.getCount());
+    }
+}

--- a/unit-tests/src/org/commcare/android/tests/activities/FormRecordListActivityTest.java
+++ b/unit-tests/src/org/commcare/android/tests/activities/FormRecordListActivityTest.java
@@ -14,9 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowListView;
 
 import static org.junit.Assert.assertEquals;
 
@@ -50,8 +48,6 @@ public class FormRecordListActivityTest {
         IncompleteFormListAdapter adapter = (IncompleteFormListAdapter)entityList.getAdapter();
         adapter.setFormFilter(FormRecordListActivity.FormRecordFilter.Submitted);
         adapter.resetRecords();
-        ShadowListView shadowListView = Shadows.shadowOf(entityList);
-        shadowListView.populateItems();
         assertEquals(2, adapter.getCount());
     }
 }


### PR DESCRIPTION
Added a test to open saved form list in Robolectric.
Required moving image resource setup from java class to xml layout due to robolectric resource availability constraints.

Also make white 'Unsent' text darker

| Before | After |
| --- | --- |
| ![screen](https://cloud.githubusercontent.com/assets/94817/15834978/f5571c1e-2bfb-11e6-9ec6-8f43493b5915.png) | ![after](https://cloud.githubusercontent.com/assets/94817/15834980/f9af5178-2bfb-11e6-91a6-8d98c6be5b01.png) |

