### PR TITLE
Make consumer apps work on non-Android 6 devices

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -846,10 +846,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                     scanSMSLinks(manualSMSInstall);
                 }
             }
-
-            if (isSingleAppBuild()) {
-                SingleAppInstallation.installSingleApp(this, DIALOG_INSTALL_PROGRESS);
-            }
         } else if (requestCode == Permissions.ALL_PERMISSIONS_REQUEST) {
             String[] requiredPerms = Permissions.getRequiredPerms();
 
@@ -870,8 +866,12 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 uiStateScreenTransition();
             }
 
-            // Since SMS asks for more permissions, call was delayed until here
-            performSMSInstall(false);
+            if (isSingleAppBuild()) {
+                SingleAppInstallation.installSingleApp(this, DIALOG_INSTALL_PROGRESS);
+            } else {
+                // Since SMS asks for more permissions, call was delayed until here
+                performSMSInstall(false);
+            }
         }
     }
 

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -196,9 +196,12 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 Permissions.acquireAllAppPermissions(this, this,
                         Permissions.ALL_PERMISSIONS_REQUEST);
         if (!askingForPerms) {
-            // With basic perms satisfied, ask user to allow SMS reading for
-            // sms app install code
-            performSMSInstall(false);
+            // With basic perms satisfied, ask user to allow SMS reading for sms app install code
+            if (isSingleAppBuild()) {
+                SingleAppInstallation.installSingleApp(this, DIALOG_INSTALL_PROGRESS);
+            } else {
+                performSMSInstall(false);
+            }
         }
     }
 

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -196,10 +196,10 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 Permissions.acquireAllAppPermissions(this, this,
                         Permissions.ALL_PERMISSIONS_REQUEST);
         if (!askingForPerms) {
-            // With basic perms satisfied, ask user to allow SMS reading for sms app install code
             if (isSingleAppBuild()) {
                 SingleAppInstallation.installSingleApp(this, DIALOG_INSTALL_PROGRESS);
             } else {
+                // With basic perms satisfied, ask user to allow SMS reading for sms app install code
                 performSMSInstall(false);
             }
         }


### PR DESCRIPTION
Since I had placed the installation code for single app installs after the permissions checks, the install just didn't happen on devices that don't check for permissions... This was dumb, I should have realized this earlier. 