### PR TITLE
Synchronize Persisted's Field.setField calls

### DIFF
--- a/app/src/org/commcare/android/storage/framework/Persisted.java
+++ b/app/src/org/commcare/android/storage/framework/Persisted.java
@@ -51,8 +51,7 @@ public class Persisted implements Persistable, IMetaData {
                 orderings = new ArrayList<>();
                 fieldOrderings.put(this.getClass(), orderings);
             }
-        }
-        synchronized (orderings) {
+
             if (orderings.size() == 0) {
                 for (Field f : this.getClass().getDeclaredFields()) {
                     if (f.isAnnotationPresent(Persisting.class)) {

--- a/app/src/org/commcare/android/storage/framework/Persisted.java
+++ b/app/src/org/commcare/android/storage/framework/Persisted.java
@@ -97,6 +97,7 @@ public class Persisted implements Persistable, IMetaData {
     }
 
     private void readVal(Field f, Object o, DataInputStream in) throws DeserializationException, IOException, IllegalAccessException {
+        synchronized (fieldOrderings) {
         Persisting p = f.getAnnotation(Persisting.class);
         Class type = f.getType();
         try {
@@ -130,9 +131,11 @@ public class Persisted implements Persistable, IMetaData {
 
         //By Default
         throw new DeserializationException("Couldn't read persisted type " + f.getType().toString());
+        }
     }
 
     private void writeVal(Field f, Object o, DataOutputStream out) throws IOException, IllegalAccessException {
+        synchronized (fieldOrderings) {
         try {
             Persisting p = f.getAnnotation(Persisting.class);
             Class type = f.getType();
@@ -164,10 +167,12 @@ public class Persisted implements Persistable, IMetaData {
 
         //By Default
         throw new RuntimeException("Couldn't write persisted type " + f.getType().toString());
+        }
     }
 
     @Override
     public String[] getMetaDataFields() {
+        synchronized (fieldOrderings) {
         ArrayList<String> fields = new ArrayList<>();
 
         for (Field f : this.getClass().getDeclaredFields()) {
@@ -198,11 +203,13 @@ public class Persisted implements Persistable, IMetaData {
 
         }
         return fields.toArray(new String[fields.size()]);
+        }
     }
 
     //TODO: This looks like it's gonna be sllllooowwwww
     @Override
     public Object getMetaData(String fieldName) {
+        synchronized (fieldOrderings) {
         try {
             for (Field f : this.getClass().getDeclaredFields()) {
                 try {
@@ -240,6 +247,7 @@ public class Persisted implements Persistable, IMetaData {
         }
         //If we didn't find the field
         throw new IllegalArgumentException("No metadata field " + fieldName + " in the case storage system");
+        }
     }
 
 }


### PR DESCRIPTION
Fixes serialization crashes of the following nature that seem to be caused by object serialization synchronization issues when multiple threads are involved. Specifically, since we cache class fields that we do reflection on, issues arise if one thread sets a field to accessible, and before it can access the field another thread sets it to inaccessible.

```
org.commcare.android.adapters.IncompleteFormListAdapter.resetRecords(IncompleteFormListAdapter.java:164)
at org.commcare.dalvik.activities.FormRecordListActivity.refreshView(FormRecordListActivity.java:312)
at org.commcare.dalvik.activities.FormRecordListActivity.onCreate(FormRecordListActivity.java:223)
at android.app.Activity.performCreate(Activity.java:5451)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1093)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2377)
... 11 more
Caused by: org.javarosa.core.util.externalizable.DeserializationException: for fieldappId
at org.commcare.android.storage.framework.Persisted.readExternal(Persisted.java:41)
at org.commcare.android.database.SqlStorage.newObject(SqlStorage.java:227)
... 19 more
Caused by: java.lang.IllegalAccessException: access to field not allowed
at java.lang.reflect.Field.setField(Native Method)
at java.lang.reflect.Field.set(Field.java:585)
at org.commcare.android.storage.framework.Persisted.readVal(Persisted.java:107)
at org.commcare.android.storage.framework.Persisted.readExternal(Persisted.java:38)
... 20 more
```

https://github.com/dimagi/commcare-odk/pull/1298/files#diff-b72fa8b3bcb18ed59a32788845cc84b1R272 reproduces the crash above and I've verified in that PR that these changes prevent the crash.

Since this is a timing issue, it is hard to test. But before hotfixing we should verify that the following work fine:
 - [x] Opening forms while old form purging is running in the background
 - [x] Opening a form while a form submission is happening in the background