### PR TITLE
Refresh saved form list after form purge completes

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -635,6 +635,11 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     @Override
     public void handleTaskCompletion(Void result) {
         dismissProgressDialog();
+
+        // reload form list to make sure purged forms aren't shown
+        if (adapter != null) {
+            adapter.resetRecords();
+        }
     }
 
     /**

--- a/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
+++ b/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
@@ -58,7 +58,7 @@ public class PurgeStaleArchivedFormsTask
         synchronized (lock) {
             if (singletonRunningInstance == null) {
                 singletonRunningInstance = new PurgeStaleArchivedFormsTask();
-                singletonRunningInstance.execute();
+                singletonRunningInstance.executeParallel();
             }
         }
     }


### PR DESCRIPTION
If form purging takes so long that the user launches the saved form list, the user will be blocked by a dialog. This is to prevent the user from selecting a purged form. Once this dialog is dismissed, it is currently the case that purged forms are still shown.

This PR refreshes the saved form list after the purge task completes to prevent the user from selecting a purged form.

Also launches the purge task using the parallel thread pool when available.