### PR TITLE
2.28 version of Synchronize Persisted's Field.setField calls

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -99,7 +99,7 @@
         android:key="cc-auto-purge"
         android:title="Detect and Trigger Purge on Form Save"/>
     <ListPreference
-        android:defaultValue="yes"
+        android:defaultValue="saved"
         android:enabled="true"
         android:entries="@array/pref_load_form_payload_as_labels"
         android:entryValues="@array/pref_load_form_payload_as_vals"

--- a/app/src/org/commcare/android/storage/framework/Persisted.java
+++ b/app/src/org/commcare/android/storage/framework/Persisted.java
@@ -59,38 +59,40 @@ public class Persisted implements Persistable, IMetaData {
 
     private static void readVal(Field f, Object o, DataInputStream in)
             throws DeserializationException, IOException, IllegalAccessException {
-        Persisting p = f.getAnnotation(Persisting.class);
-        Class type = f.getType();
-        try {
-            f.setAccessible(true);
+        synchronized (fieldOrderings) {
+            Persisting p = f.getAnnotation(Persisting.class);
+            Class type = f.getType();
+            try {
+                f.setAccessible(true);
 
-            if (type.equals(String.class)) {
-                String read = ExtUtil.readString(in);
-                f.set(o, p.nullable() ? ExtUtil.nullIfEmpty(read) : read);
-                return;
-            } else if (type.equals(Integer.TYPE)) {
-                //Primitive Integers
-                f.setInt(o, ExtUtil.readInt(in));
-                return;
-            } else if (type.equals(Date.class)) {
-                f.set(o, ExtUtil.readDate(in));
-                return;
-            } else if (type.isArray()) {
-                //We only support byte arrays for now
-                if (type.getComponentType().equals(Byte.TYPE)) {
-                    f.set(o, ExtUtil.readBytes(in));
+                if (type.equals(String.class)) {
+                    String read = ExtUtil.readString(in);
+                    f.set(o, p.nullable() ? ExtUtil.nullIfEmpty(read) : read);
+                    return;
+                } else if (type.equals(Integer.TYPE)) {
+                    //Primitive Integers
+                    f.setInt(o, ExtUtil.readInt(in));
+                    return;
+                } else if (type.equals(Date.class)) {
+                    f.set(o, ExtUtil.readDate(in));
+                    return;
+                } else if (type.isArray()) {
+                    //We only support byte arrays for now
+                    if (type.getComponentType().equals(Byte.TYPE)) {
+                        f.set(o, ExtUtil.readBytes(in));
+                        return;
+                    }
+                } else if (type.equals(Boolean.TYPE)) {
+                    f.setBoolean(o, ExtUtil.readBool(in));
                     return;
                 }
-            } else if (type.equals(Boolean.TYPE)) {
-                f.setBoolean(o, ExtUtil.readBool(in));
-                return;
+            } finally {
+                f.setAccessible(false);
             }
-        } finally {
-            f.setAccessible(false);
-        }
 
-        //By Default
-        throw new DeserializationException("Couldn't read persisted type " + f.getType().toString());
+            //By Default
+            throw new DeserializationException("Couldn't read persisted type " + f.getType().toString());
+        }
     }
 
     @Override
@@ -107,43 +109,46 @@ public class Persisted implements Persistable, IMetaData {
 
     private static void writeVal(Field f, Object o, DataOutputStream out)
             throws IOException, IllegalAccessException {
-        try {
-            Persisting p = f.getAnnotation(Persisting.class);
-            Class type = f.getType();
-            f.setAccessible(true);
+        synchronized (fieldOrderings) {
+            try {
+                Persisting p = f.getAnnotation(Persisting.class);
+                Class type = f.getType();
+                f.setAccessible(true);
 
-            if (type.equals(String.class)) {
-                String s = (String)f.get(o);
-                ExtUtil.writeString(out, p.nullable() ? ExtUtil.emptyIfNull(s) : s);
-                return;
-            } else if (type.equals(Integer.TYPE)) {
-                ExtUtil.writeNumeric(out, f.getInt(o));
-                return;
-            } else if (type.equals(Date.class)) {
-                ExtUtil.writeDate(out, (Date)f.get(o));
-                return;
-            } else if (type.isArray()) {
-                //We only support byte arrays for now
-                if (type.getComponentType().equals(Byte.TYPE)) {
-                    ExtUtil.writeBytes(out, (byte[])f.get(o));
+                if (type.equals(String.class)) {
+                    String s = (String)f.get(o);
+                    ExtUtil.writeString(out, p.nullable() ? ExtUtil.emptyIfNull(s) : s);
+                    return;
+                } else if (type.equals(Integer.TYPE)) {
+                    ExtUtil.writeNumeric(out, f.getInt(o));
+                    return;
+                } else if (type.equals(Date.class)) {
+                    ExtUtil.writeDate(out, (Date)f.get(o));
+                    return;
+                } else if (type.isArray()) {
+                    //We only support byte arrays for now
+                    if (type.getComponentType().equals(Byte.TYPE)) {
+                        ExtUtil.writeBytes(out, (byte[])f.get(o));
+                        return;
+                    }
+                } else if (type.equals(Boolean.TYPE)) {
+                    ExtUtil.writeBool(out, f.getBoolean(o));
                     return;
                 }
-            } else if (type.equals(Boolean.TYPE)) {
-                ExtUtil.writeBool(out, f.getBoolean(o));
-                return;
+            } finally {
+                f.setAccessible(false);
             }
-        } finally {
-            f.setAccessible(false);
-        }
 
-        //By Default
-        throw new RuntimeException("Couldn't write persisted type " + f.getType().toString());
+            //By Default
+            throw new RuntimeException("Couldn't write persisted type " + f.getType().toString());
+        }
     }
 
     private static ArrayList<Field> getPersistedFieldsInOrder(Class persistedClass) {
-        ArrayList<Field> orderings;
         synchronized (fieldOrderings) {
-            orderings = fieldOrderings.get(persistedClass);
+            // Since fields are cached, we must sync changes in their
+            // accessibility across threads.
+            ArrayList<Field> orderings = fieldOrderings.get(persistedClass);
             if (orderings == null) {
                 orderings = new ArrayList<>();
                 fieldOrderings.put(persistedClass, orderings);
@@ -172,31 +177,35 @@ public class Persisted implements Persistable, IMetaData {
     }
 
     private static void addClassFieldsToMetas(List<String> fields, Class persistedClass) {
-        for (Field f : persistedClass.getDeclaredFields()) {
-            try {
-                f.setAccessible(true);
+        synchronized (fieldOrderings) {
+            for (Field f : persistedClass.getDeclaredFields()) {
+                try {
+                    f.setAccessible(true);
 
-                if (f.isAnnotationPresent(MetaField.class)) {
-                    MetaField mf = f.getAnnotation(MetaField.class);
-                    fields.add(mf.value());
+                    if (f.isAnnotationPresent(MetaField.class)) {
+                        MetaField mf = f.getAnnotation(MetaField.class);
+                        fields.add(mf.value());
+                    }
+                } finally {
+                    f.setAccessible(false);
                 }
-            } finally {
-                f.setAccessible(false);
             }
         }
     }
 
     private static void addClassMethodsToMetas(List<String> fields, Class persistedClass) {
-        for (Method m : persistedClass.getDeclaredMethods()) {
-            try {
-                m.setAccessible(true);
+        synchronized (fieldOrderings) {
+            for (Method m : persistedClass.getDeclaredMethods()) {
+                try {
+                    m.setAccessible(true);
 
-                if (m.isAnnotationPresent(MetaField.class)) {
-                    MetaField mf = m.getAnnotation(MetaField.class);
-                    fields.add(mf.value());
+                    if (m.isAnnotationPresent(MetaField.class)) {
+                        MetaField mf = m.getAnnotation(MetaField.class);
+                        fields.add(mf.value());
+                    }
+                } finally {
+                    m.setAccessible(false);
                 }
-            } finally {
-                m.setAccessible(false);
             }
         }
     }
@@ -204,43 +213,45 @@ public class Persisted implements Persistable, IMetaData {
     @Nullable
     @Override
     public Object getMetaData(String fieldName) {
-        try {
-            for (Field f : this.getClass().getDeclaredFields()) {
-                try {
-                    f.setAccessible(true);
+        synchronized (fieldOrderings) {
+            try {
+                for (Field f : this.getClass().getDeclaredFields()) {
+                    try {
+                        f.setAccessible(true);
 
-                    if (f.isAnnotationPresent(MetaField.class)) {
-                        MetaField mf = f.getAnnotation(MetaField.class);
-                        if (mf.value().equals(fieldName)) {
-                            return f.get(this);
+                        if (f.isAnnotationPresent(MetaField.class)) {
+                            MetaField mf = f.getAnnotation(MetaField.class);
+                            if (mf.value().equals(fieldName)) {
+                                return f.get(this);
+                            }
                         }
+                    } finally {
+                        f.setAccessible(false);
                     }
-                } finally {
-                    f.setAccessible(false);
-                }
-            }
-
-            for (Method m : this.getClass().getDeclaredMethods()) {
-                try {
-                    m.setAccessible(true);
-
-                    if (m.isAnnotationPresent(MetaField.class)) {
-                        MetaField mf = m.getAnnotation(MetaField.class);
-                        if (mf.value().equals(fieldName)) {
-                            return m.invoke(this, (Object[])null);
-                        }
-                    }
-                } finally {
-                    m.setAccessible(false);
                 }
 
+                for (Method m : this.getClass().getDeclaredMethods()) {
+                    try {
+                        m.setAccessible(true);
+
+                        if (m.isAnnotationPresent(MetaField.class)) {
+                            MetaField mf = m.getAnnotation(MetaField.class);
+                            if (mf.value().equals(fieldName)) {
+                                return m.invoke(this, (Object[])null);
+                            }
+                        }
+                    } finally {
+                        m.setAccessible(false);
+                    }
+
+                }
+            } catch (InvocationTargetException | IllegalArgumentException
+                    | IllegalAccessException e) {
+                throw new RuntimeException(e.getMessage());
             }
-        } catch (InvocationTargetException | IllegalArgumentException
-                | IllegalAccessException e) {
-            throw new RuntimeException(e.getMessage());
+            //If we didn't find the field
+            throw new IllegalArgumentException("No metadata field " + fieldName + " in the case storage system");
         }
-        //If we didn't find the field
-        throw new IllegalArgumentException("No metadata field " + fieldName + " in the case storage system");
     }
 
     @Override

--- a/app/src/org/commcare/android/storage/framework/Persisted.java
+++ b/app/src/org/commcare/android/storage/framework/Persisted.java
@@ -148,15 +148,17 @@ public class Persisted implements Persistable, IMetaData {
     }
 
     private static ArrayList<Field> getPersistedFieldsInOrder(Class persistedClass) {
+        ArrayList<Field> orderings;
         synchronized (fieldOrderings) {
             // Since fields are cached, we must sync changes in their
             // accessibility across threads.
-            ArrayList<Field> orderings = fieldOrderings.get(persistedClass);
+            orderings = fieldOrderings.get(persistedClass);
             if (orderings == null) {
                 orderings = new ArrayList<>();
                 fieldOrderings.put(persistedClass, orderings);
             }
-
+        }
+        synchronized (orderings) {
             if (orderings.size() == 0) {
                 for (Field f : persistedClass.getDeclaredFields()) {
                     if (f.isAnnotationPresent(Persisting.class)) {

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -8,6 +8,7 @@ import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.session.CommCareSession;
 import org.commcare.session.SessionFrame;
+import org.commcare.suite.model.ComputedDatum;
 import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.FormEntry;
@@ -219,7 +220,13 @@ public class AndroidSessionWrapper {
                     //This should fit the bill. Single selection.
                     SessionDatum datum = e.getSessionDataReqs().firstElement();
                     // we only know how to mock a single case selection
-                    if (datum instanceof EntityDatum) {
+                    if (datum instanceof ComputedDatum) {
+                        // Allow mocking of routes that need computed data, useful for case creation forms
+                        wrapper = new AndroidSessionWrapper(platform);
+                        wrapper.session.setCommand(platform.getModuleNameForEntry((FormEntry) e));
+                        wrapper.session.setCommand(e.getCommandId());
+                        wrapper.session.setComputedDatum(wrapper.getEvaluationContext());
+                    } else if (datum instanceof EntityDatum) {
                         EntityDatum entityDatum = (EntityDatum)datum;
                         //The only thing we need to know now is whether we have a better option available
                         int countPredicates = CommCareUtil.countPreds(entityDatum.getNodeset());


### PR DESCRIPTION
2.28 version of https://github.com/dimagi/commcare-odk/pull/1303
Includes test that fails before the fix is applied and code indentation, so ?w=1

The last commit fixes the debug feature that allows for loading saved forms onto the device from a payload.