### PR TITLE
Fix session unavailable crash after uninstall

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -277,11 +277,11 @@ public class CommCareApplication extends Application {
         c.startActivity(i);
     }
 
-    public static void restartCommCare(Activity originActivity) {
-        restartCommCare(originActivity, DispatchActivity.class);
+    public static void restartCommCare(Activity originActivity, boolean systemExit) {
+        restartCommCare(originActivity, DispatchActivity.class, systemExit);
     }
 
-    public static void restartCommCare(Activity originActivity, Class c) {
+    public static void restartCommCare(Activity originActivity, Class c, boolean systemExit) {
         Intent intent = new Intent(originActivity, c);
 
         // Make sure that the new stack starts with the given class, and clear everything
@@ -294,7 +294,9 @@ public class CommCareApplication extends Application {
         originActivity.startActivity(intent);
         originActivity.finish();
 
-        System.exit(0);
+        if (systemExit) {
+            System.exit(0);
+        }
     }
 
     public void startUserSession(byte[] symetricKey, UserKeyRecord record, boolean restoreSession) {
@@ -649,6 +651,7 @@ public class CommCareApplication extends Application {
         // 1) If the app we are uninstalling is the currently-seated app, tear down its sandbox
         if (isSeated(record)) {
             getCurrentApp().teardownSandbox();
+            unseat(record);
         }
 
         // 2) Set record's status to delete requested, so we know if we have left it in a bad

--- a/app/src/org/commcare/activities/CrashWarningActivity.java
+++ b/app/src/org/commcare/activities/CrashWarningActivity.java
@@ -54,7 +54,7 @@ public class CrashWarningActivity extends Activity {
         closeButton.setText(Localization.get("crash.warning.button"));
         closeButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                CommCareApplication.restartCommCare(CrashWarningActivity.this);
+                CommCareApplication.restartCommCare(CrashWarningActivity.this, true);
             }
         });
 

--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -172,7 +172,8 @@ public class SingleAppManagerActivity extends CommCareActivity {
         GoogleAnalyticsUtils.reportAppManagerAction(GoogleAnalyticsFields.ACTION_UNINSTALL_APP);
         CommCareApplication._().expireUserSession();
         CommCareApplication._().uninstall(appRecord);
-        CommCareApplication.restartCommCare(SingleAppManagerActivity.this, AppManagerActivity.class);
+        CommCareApplication.restartCommCare(
+                SingleAppManagerActivity.this, AppManagerActivity.class, false);
     }
 
     /**

--- a/app/src/org/commcare/activities/UnrecoverableErrorActivity.java
+++ b/app/src/org/commcare/activities/UnrecoverableErrorActivity.java
@@ -39,7 +39,7 @@ public class UnrecoverableErrorActivity extends Activity {
         StandardAlertDialog d = new StandardAlertDialog(this, title, message);
         DialogInterface.OnClickListener buttonListener = new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int i) {
-                CommCareApplication.restartCommCare(UnrecoverableErrorActivity.this);
+                CommCareApplication.restartCommCare(UnrecoverableErrorActivity.this, true);
             }
         };
         d.setPositiveButton(Localization.get("app.storage.missing.button"), buttonListener);

--- a/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
+++ b/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
@@ -102,20 +102,6 @@ public class AppUpdateTest {
     }
 
     @Test
-    public void testUpdateWithNoAppInstalled() {
-        Log.d(TAG, "Update without installing an app first");
-
-        ApplicationRecord appRecord = CommCareApplication._().getInstalledAppRecords().get(0);
-        CommCareApplication._().uninstall(appRecord);
-        installUpdate("invalid_update",
-                taskListenerFactory(AppInstallStatus.UnknownFailure),
-                AppInstallStatus.UnknownFailure);
-
-        Profile p = CommCareApplication._().getCommCarePlatform().getCurrentProfile();
-        Assert.assertTrue(p.getVersion() == 6);
-    }
-
-    @Test
     public void testUpdateToAppWithMultimedia() {
         Log.d(TAG, "updating to an app that has multimedia present");
 


### PR DESCRIPTION
@phillipm Embarrassed that it took me so long to figure this out, but here goes: the problem was that the `unredirectedSessionExpiration` getting registered by the app uninstall was getting wiped out by the call to `System.exit()` in `restartCommCare`. I played around a bit and realized that it was fine to remove this in the case of uninstalling, as long as I also made sure that the app that's being uninstalled gets unseated first, if it is the currently seated app.