### PR TITLE
Don't modify incoming object in list union code

### DIFF
--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -118,12 +118,12 @@ public class MenuAdapter implements ListAdapter {
     private void addRelevantCommandEntries(Menu m, Vector<MenuDisplayable> items,
                                            Hashtable<String, Entry> map)
             throws XPathSyntaxException {
+        EvaluationContext ec = asw.getEvaluationContext();
         for (String command : m.getCommandIds()) {
             errorXpathException = "";
             XPathExpression mRelevantCondition = m.getCommandRelevance(m.indexOfCommand(command));
             if (mRelevantCondition != null) {
                 errorXpathException = m.getCommandRelevanceRaw(m.indexOfCommand(command));
-                EvaluationContext ec = asw.getEvaluationContext();
                 Object ret = mRelevantCondition.eval(ec);
                 try {
                     if (!XPathFuncExpr.toBoolean(ret)) {
@@ -134,9 +134,6 @@ public class MenuAdapter implements ListAdapter {
                     XPathErrorLogger.INSTANCE.logErrorToCurrentApp(e.getSource(), msg);
                     Logger.log(AndroidLogger.TYPE_ERROR_CONFIG_STRUCTURE, msg);
                     throw new RuntimeException(msg);
-                }
-                if (!XPathFuncExpr.toBoolean(ret)) {
-                    continue;
                 }
             }
 

--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -54,6 +54,7 @@ public class AndroidUtil {
 
     private static class AndroidUnionLambda extends UnionLambda {
         public <T> Vector<T> union(Vector<T> a, Vector<T> b) {
+            Vector<T> result = new Vector<>();
             //This is kind of (ok, so really) awkward looking, but we can't use sets in 
             //ccj2me (Thanks, Nokia!) also, there's no _collections_ interface in
             //j2me (thanks Sun!) so this is what we get.
@@ -65,9 +66,8 @@ public class AndroidUtil {
 
             joined.retainAll(other);
 
-            a.clear();
-            a.addAll(joined);
-            return a;
+            result.addAll(joined);
+            return result;
         }
     }
 


### PR DESCRIPTION
Case loading code was caching a Vector instance, which was then getting modified when it was union'ed with another list. The fix is to make the union code not modify the incoming objects.

Fix for http://manage.dimagi.com/default.asp?229108