### PR TITLE
Installation and update performance improvements

### DIFF
--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -85,7 +85,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
                 checkDuplicate(p);
             }
 
-            table.commitProfileResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
+            table.commitCompoundResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
             return true;
         } catch (XmlPullParserException | InvalidReferenceException | IOException e) {
             e.printStackTrace();

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -85,7 +85,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
                 checkDuplicate(p);
             }
 
-            table.commit(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
+            table.commitProfileResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());
             return true;
         } catch (XmlPullParserException | InvalidReferenceException | IOException e) {
             e.printStackTrace();

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -81,7 +81,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
 
             Suite s = parser.parse();
 
-            table.commit(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED);
+            table.commitCompoundResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED);
             return true;
         } catch (XmlPullParserException | InvalidStructureException
                 | InvalidReferenceException | IOException

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -48,7 +48,7 @@ public class AndroidResourceManager extends ResourceManager {
         app = CommCareApplication._().getCurrentApp();
 
         tempUpgradeTable =
-                ResourceTable.RetrieveTable(app.getStorage(TEMP_UPGRADE_TABLE_KEY, Resource.class),
+                new AndroidResourceTable(app.getStorage(TEMP_UPGRADE_TABLE_KEY, Resource.class),
                         new AndroidResourceInstallerFactory());
 
         updateStats = UpdateStats.loadUpdateStats(app);

--- a/app/src/org/commcare/engine/resource/AndroidResourceTable.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceTable.java
@@ -4,8 +4,10 @@ import org.commcare.models.database.SqlStorage;
 import org.commcare.resources.model.InstallerFactory;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
+import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 
+import java.util.HashSet;
 import java.util.Vector;
 
 /**
@@ -13,6 +15,7 @@ import java.util.Vector;
  */
 public class AndroidResourceTable extends ResourceTable {
     private final SqlStorage<Resource> sqlStorage;
+    private HashSet<String> resourcesInTable;
 
     public AndroidResourceTable(SqlStorage<Resource> storage, InstallerFactory factory) {
         super((IStorageUtilityIndexed) storage, factory);
@@ -24,5 +27,42 @@ public class AndroidResourceTable extends ResourceTable {
         Vector<Resource> v = new Vector<>();
         v.addAll(sqlStorage.getRecordsForValue(Resource.META_INDEX_PARENT_GUID, parent));
         return v;
+    }
+
+    @Override
+    protected boolean resourceDoesntExist(Resource resource) {
+        initResourcesInTable();
+        return !resourcesInTable.contains(resource.getResourceId());
+    }
+
+    private void initResourcesInTable() {
+        if (resourcesInTable == null) {
+            resourcesInTable = new HashSet<>();
+            for (IStorageIterator it = sqlStorage.iterate(); it.hasMore(); ) {
+                Resource r = (Resource)it.nextRecord();
+                resourcesInTable.add(r.getResourceId());
+            }
+        }
+    }
+
+    @Override
+    protected void cleanup() {
+        super.cleanup();
+        initResourcesInTable();
+        resourcesInTable.clear();
+    }
+
+    @Override
+    public void removeResource(Resource resource) {
+        super.removeResource(resource);
+        initResourcesInTable();
+        resourcesInTable.remove(resource.getResourceId());
+    }
+
+    @Override
+    public void commit(Resource r) {
+        super.commit(r);
+        initResourcesInTable();
+        resourcesInTable.add(r.getResourceId());
     }
 }

--- a/app/src/org/commcare/engine/resource/AndroidResourceTable.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceTable.java
@@ -24,9 +24,7 @@ public class AndroidResourceTable extends ResourceTable {
 
     @Override
     public Vector<Resource> getResourcesForParent(String parent) {
-        Vector<Resource> v = new Vector<>();
-        v.addAll(sqlStorage.getRecordsForValue(Resource.META_INDEX_PARENT_GUID, parent));
-        return v;
+        return sqlStorage.getRecordsForValue(Resource.META_INDEX_PARENT_GUID, parent);
     }
 
     @Override

--- a/app/src/org/commcare/engine/resource/AndroidResourceTable.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceTable.java
@@ -1,0 +1,28 @@
+package org.commcare.engine.resource;
+
+import org.commcare.models.database.SqlStorage;
+import org.commcare.resources.model.InstallerFactory;
+import org.commcare.resources.model.Resource;
+import org.commcare.resources.model.ResourceTable;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
+
+import java.util.Vector;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class AndroidResourceTable extends ResourceTable {
+    private final SqlStorage<Resource> sqlStorage;
+
+    public AndroidResourceTable(SqlStorage<Resource> storage, InstallerFactory factory) {
+        super((IStorageUtilityIndexed) storage, factory);
+        this.sqlStorage = storage;
+    }
+
+    @Override
+    public Vector<Resource> getResourcesForParent(String parent) {
+        Vector<Resource> v = new Vector<>();
+        v.addAll(sqlStorage.getRecordsForValue(Resource.META_INDEX_PARENT_GUID, parent));
+        return v;
+    }
+}

--- a/app/src/org/commcare/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/tasks/ResourceEngineTask.java
@@ -125,7 +125,7 @@ public abstract class ResourceEngineTask<R>
     }
 
     @Override
-    public void resourceStateUpdated(final ResourceTable table) {
+    public void compoundResourceAdded(final ResourceTable table) {
         synchronized (statusLock) {
             // if last time isn't set or is less than our spacing count, do not
             // perform status update. Also if we are already running one, just skip this.
@@ -193,7 +193,7 @@ public abstract class ResourceEngineTask<R>
     }
 
     @Override
-    public void resourceStateIncremented() {
+    public void simpleResourceAdded() {
         if (statusCheckRunning) {
             installedResourceCountWhileUpdating++;
         } else {

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -211,6 +211,11 @@ public class UpdateTask
     }
 
     @Override
+    public void resourceStateIncremented() {
+        incrementProgress(++currentProgress, maxProgress);
+    }
+
+    @Override
     public void incrementProgress(int complete, int total) {
         this.publishProgress(complete, total);
     }

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -194,7 +194,7 @@ public class UpdateTask
      * Calculate and report the resource install progress a table has made.
      */
     @Override
-    public void resourceStateUpdated(ResourceTable table) {
+    public void compoundResourceAdded(ResourceTable table) {
         Vector<Resource> resources =
                 AndroidResourceManager.getResourceListFromProfile(table);
 
@@ -211,7 +211,7 @@ public class UpdateTask
     }
 
     @Override
-    public void resourceStateIncremented() {
+    public void simpleResourceAdded() {
         incrementProgress(++currentProgress, maxProgress);
     }
 

--- a/app/src/org/commcare/tasks/VerificationTask.java
+++ b/app/src/org/commcare/tasks/VerificationTask.java
@@ -67,6 +67,10 @@ public abstract class VerificationTask<Reciever>
     }
 
     @Override
+    public void resourceStateIncremented() {
+    }
+
+    @Override
     public boolean wasInstallCancelled() {
         return isCancelled();
     }

--- a/app/src/org/commcare/tasks/VerificationTask.java
+++ b/app/src/org/commcare/tasks/VerificationTask.java
@@ -63,11 +63,11 @@ public abstract class VerificationTask<Reciever>
     }
 
     @Override
-    public void resourceStateUpdated(ResourceTable table) {
+    public void compoundResourceAdded(ResourceTable table) {
     }
 
     @Override
-    public void resourceStateIncremented() {
+    public void simpleResourceAdded() {
     }
 
     @Override

--- a/app/src/org/commcare/utils/AndroidCommCarePlatform.java
+++ b/app/src/org/commcare/utils/AndroidCommCarePlatform.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.engine.resource.AndroidResourceTable;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.suite.model.Profile;
@@ -56,21 +57,21 @@ public class AndroidCommCarePlatform extends CommCarePlatform {
 
     public ResourceTable getGlobalResourceTable() {
         if (global == null) {
-            global = ResourceTable.RetrieveTable(app.getStorage("GLOBAL_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
+            global = new AndroidResourceTable(app.getStorage("GLOBAL_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
         }
         return global;
     }
 
     public ResourceTable getUpgradeResourceTable() {
         if (upgrade == null) {
-            upgrade = ResourceTable.RetrieveTable(app.getStorage("UPGRADE_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
+            upgrade = new AndroidResourceTable(app.getStorage("UPGRADE_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
         }
         return upgrade;
     }
 
     public ResourceTable getRecoveryTable() {
         if (recovery == null) {
-            recovery = ResourceTable.RetrieveTable(app.getStorage("RECOVERY_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
+            recovery = new AndroidResourceTable(app.getStorage("RECOVERY_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
         }
         return recovery;
     }

--- a/app/src/org/commcare/utils/DummyResourceTable.java
+++ b/app/src/org/commcare/utils/DummyResourceTable.java
@@ -176,7 +176,7 @@ public class DummyResourceTable extends ResourceTable {
     }
 
     @Override
-    public void commit(Resource r, int status, int version) throws UnresolvedResourceException {
+    public void commitProfileResource(Resource r, int status, int version) throws UnresolvedResourceException {
     }
 
     @Override

--- a/app/src/org/commcare/utils/DummyResourceTable.java
+++ b/app/src/org/commcare/utils/DummyResourceTable.java
@@ -176,7 +176,7 @@ public class DummyResourceTable extends ResourceTable {
     }
 
     @Override
-    public void commitProfileResource(Resource r, int status, int version) throws UnresolvedResourceException {
+    public void commitCompoundResource(Resource r, int status, int version) throws UnresolvedResourceException {
     }
 
     @Override


### PR DESCRIPTION
Changes:
- Keep an in-memory set of resources present in a `ResourceTable`. This allows `resourceDoesntExist` calls to avoid hitting storage. Requires overriding additional logic to keep this set fresh.
- Use modern `SqlStorage.getRecordsForValue` in `getResourcesForParent` to avoid intermediate ID reads from storage.
- Implement `TableStateListener`'s `compoundResourceAdded` and `simpleResourceAdded` in `ResourceEngineTask, to keep counts in sync when async progress update threads are running.

cross-request: https://github.com/dimagi/commcare/pull/306