### PR TITLE
Localize repeat dialog

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -740,5 +740,5 @@ repeat.dialog.leave=Do Not Add
 repeat.dialog.exit=Do Not Add. I'm Finished.
 repeat.dialog.add=Add Group
 repeat.dialog.add.one=And One More Group?
-repeat.dialog.add.another=Add another \"${0}\" group?
-repeat.dialog.add.new=Add a new \"${0}\" group?
+repeat.dialog.add.another=Add another "${0}" group?
+repeat.dialog.add.new=Add a new "${0}" group?

--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -734,3 +734,11 @@ clear.user.data.warning.title=Clear User Data
 clear.user.data.warning.message=Are you sure you want to clear all mobile user data? All unsynced data will be lost!
 force.log.submit=Force Log Submission
 recovery.mode=Recovery Mode
+
+repeat.dialog.go.back=Go Back
+repeat.dialog.leave=Do Not Add
+repeat.dialog.exit=Do Not Add. I'm Finished.
+repeat.dialog.add=Add Group
+repeat.dialog.add.one=And One More Group?
+repeat.dialog.add.another=Add another \"${0}\" group?
+repeat.dialog.add.new=Add a new \"${0}\" group?

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -14,10 +14,6 @@
     <string name="accept_location">Ubicacion de Dato</string>
     <string name="accuracy">Precision</string>
     <string name="activity_not_found">Ninguna actividad se encontro para manejar: %s</string>
-    <string name="add_another">Agregar Grupo</string>
-    <string name="add_another_repeat">Agregar otro grupo de \"%s\"?</string>
-    <string name="add_repeat">Agregar un nuevo grupo de \"%s\"?</string>
-    <string name="add_repeat_no">No Agregar</string>
     <string name="advance">avanzar a la \nproxima\npregunta</string>
     <string name="altitude">Altitud</string>
     <string name="audio_file_error">Ningun archivo de audio fue especificado.</string>
@@ -52,8 +48,6 @@
     <string name="do_not_exit">Cancelar</string>
     <string name="do_not_save">Ignorar Cambios</string>
     <string name="enter">iniciar</string>
-    <string name="entering_repeat">Agregar Grupo</string>
-    <string name="entering_repeat_ask">Agregar un Grupo Nuevo?</string>
     <string name="enter_data">Llenar el Formulario en Blanco</string>
     <string name="enter_data_button">Llenar el Formulario en Blanco</string>
     <string name="enter_data_description">Estas al inicio de \"%s\". Para iniciar deslice su dedo sobre la pantalla como se muestra.</string>
@@ -78,7 +72,6 @@
     <string name="jump_to_end">Ir al Final</string>
     <string name="jump_to_previous">Subir</string>
     <string name="latitude">Latitud</string>
-    <string name="leave_repeat_yes">No Agregar</string>
     <string name="leaving_repeat">Agregar Grupo</string>
     <string name="leaving_repeat_ask">Agregar Un Grupo Mas?</string>
     <string name="list_failed_with_error">El listado de formularios fracaso. %s.</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -14,10 +14,6 @@ License.
     <string name="accept_location">Enregistrer lieu</string>
     <string name="accuracy">Précision</string>
     <string name="activity_not_found">Pas d\'activité pour gérer: %s</string>
-    <string name="add_another">Ajouter un groupe</string>
-    <string name="add_another_repeat">Ajouter un autre groupe \"%s\" ?</string>
-    <string name="add_repeat">Ajouter un nouveau groupe \"%s\" ?</string>
-    <string name="add_repeat_no">Ne pas ajouter</string>
     <string name="advance">Avancer à\nnext\nprompt</string>
     <string name="altitude">Altitude</string>
     <string name="audio_file_error">Aucun fichier audio spécifié.</string>
@@ -52,8 +48,6 @@ License.
     <string name="do_not_exit">Annuler</string>
     <string name="do_not_save">Ignorer les changements</string>
     <string name="enter">Commencer</string>
-    <string name="entering_repeat">Ajouter un groupe</string>
-    <string name="entering_repeat_ask">Ajouter un nouveau groupe?</string>
     <string name="enter_data">Remplire formulaire vide</string>
     <string name="enter_data_button">Remplire formulaire vide</string>
     <string name="enter_data_description">Vous êtes au début du formulaire \"%s\". Pour commencer, éffleurer l\'écran comme illustré.</string>
@@ -78,7 +72,6 @@ License.
     <string name="jump_to_end">Aller à la fin</string>
     <string name="jump_to_previous">Monter</string>
     <string name="latitude">Latitude</string>
-    <string name="leave_repeat_yes">Ne pas ajouter</string>
     <string name="leaving_repeat">Ajouter un groupe</string>
     <string name="leaving_repeat_ask">" Nouveau groupe?"</string>
     <string name="list_failed_with_error">La liste a echoué. %s.</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -14,10 +14,6 @@
     <string name="accept_location">Įrašyti padėtį</string>
     <string name="accuracy">Tikslumas</string>
     <string name="activity_not_found">Nerasta, kas galėtų valdyti: %s</string>
-    <string name="add_another">Sukurti grupę</string>
-    <string name="add_another_repeat">Sukurti kitą \"%s\" grupę?</string>
-    <string name="add_repeat">Sukurti naują \"%s\" grupę?</string>
-    <string name="add_repeat_no">Nekurti</string>
     <string name="advance">pereiti į\nkitą\npuslapį</string>
     <string name="altitude">Altitudė</string>
     <string name="audio_file_error">Nebuvo nurodytas joks audio failas.</string>
@@ -53,8 +49,6 @@
     <string name="do_not_exit">Atšaukti</string>
     <string name="do_not_save">Ignoruoti pakeitimus</string>
     <string name="enter">pradėti</string>
-    <string name="entering_repeat">Sukurti grupę</string>
-    <string name="entering_repeat_ask">Sukurti naują grupę?</string>
     <string name="enter_data">Pildyti tuščią formą</string>
     <string name="enter_data_button">Pildyti tuščią formą</string>
     <string name="enter_data_description">Jūs pradėsite pildyti \"%s\". Kad pradėtumėte, perbraukite ekraną, kaip parodyta žemiau.</string>
@@ -79,7 +73,6 @@
     <string name="jump_to_end">Eiti į pabaigą</string>
     <string name="jump_to_previous">Eiti į viršų</string>
     <string name="latitude">Platuma</string>
-    <string name="leave_repeat_yes">Nesukurti</string>
     <string name="leaving_repeat">Sukurti grupę</string>
     <string name="leaving_repeat_ask">Sukurti dar vieną grupę?</string>
     <string name="list_failed_with_error">Nepavyko gauti formų sąrašo. %s.</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -14,10 +14,6 @@
     <string name="accept_location">Registrere posisjon</string>
     <string name="accuracy">Presisjon</string>
     <string name="activity_not_found">Fant ingen handling: %s</string>
-    <string name="add_another">Legg til gruppe</string>
-    <string name="add_another_repeat">Legg til annen \"%s\" gruppe?</string>
-    <string name="add_repeat">Legg til ny \"%s\" gruppe?</string>
-    <string name="add_repeat_no">Ikke legg til</string>
     <string name="advance">Gå til neste prompt</string>
     <string name="altitude">Høyde</string>
     <string name="audio_file_error">Uspesifisert lydfil</string>
@@ -53,8 +49,6 @@
     <string name="do_not_exit">Avbryt</string>
     <string name="do_not_save">Annuler endringer</string>
     <string name="enter">start</string>
-    <string name="entering_repeat">Legg til gruppe</string>
-    <string name="entering_repeat_ask">Legge til ny gruppe?</string>
     <string name="enter_data">Fyll ut blankt skjema</string>
     <string name="enter_data_button">Fyll ut blankt skjema</string>
     <string name="enter_data_description">Du er her \"%s\". Plasser én finger på skjermen, og dra den i vist retning.</string>
@@ -79,7 +73,6 @@
     <string name="jump_to_end">Go To End</string>
     <string name="jump_to_previous">Go Up</string>
     <string name="latitude">Bredde</string>
-    <string name="leave_repeat_yes">Ikke legg til</string>
     <string name="leaving_repeat">Legg til gruppe</string>
     <string name="leaving_repeat_ask">Legg til enda en gruppe?</string>
     <string name="list_failed_with_error">Form listing failed. %s.</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -14,10 +14,6 @@
     <string name="accept_location">Gravar Localização</string>
     <string name="accuracy">Precisão</string>
     <string name="activity_not_found">Nenhuma atividade detectada por: %s</string>
-    <string name="add_another">Adicionar Grupo</string>
-    <string name="add_another_repeat">Add another \"%s\" group?</string>
-    <string name="add_repeat">Adicionar um novo \"%s\" grupo?</string>
-    <string name="add_repeat_no">Não Adicionar</string>
     <string name="advance">seguir para o próximo agora</string>
     <string name="altitude">Altitude</string>
     <string name="audio_file_error">Não foi especificado arquivo de áudio</string>
@@ -53,8 +49,6 @@
     <string name="do_not_exit">Cancelar</string>
     <string name="do_not_save">Ignorar Alterações</string>
     <string name="enter">começar</string>
-    <string name="entering_repeat">Adicionar Grupo</string>
-    <string name="entering_repeat_ask">Adicionar Novo Grupo?</string>
     <string name="enter_data">Formulário em Branco</string>
     <string name="enter_data_button">Formulário em Branco</string>
     <string name="enter_data_description">Você está no início de \"%s\". Para começar arraste a tela como mostra abaixo.</string>
@@ -79,7 +73,6 @@
     <string name="jump_to_end">Ir para o Fim</string>
     <string name="jump_to_previous">Subir</string>
     <string name="latitude">Latitude</string>
-    <string name="leave_repeat_yes">Não Adicionar</string>
     <string name="leaving_repeat">Adicionar Grupo</string>
     <string name="leaving_repeat_ask">Adicionar um ou mais grupos?</string>
     <string name="list_failed_with_error">Listagem de formulários falhou. %s.</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -14,10 +14,6 @@
     <string name="accept_location">Record Location</string>
     <string name="accuracy">Accuracy</string>
     <string name="activity_not_found">No activity found to handle: %s</string>
-    <string name="add_another">Add Group</string>
-    <string name="add_another_repeat">Add another \"%s\" group?</string>
-    <string name="add_repeat">Add a new \"%s\" group?</string>
-    <string name="add_repeat_no">Do Not Add</string>
     <string name="advance">forward to\nnext\nprompt</string>
     <string name="altitude">Altitude</string>
     <string name="audio_file_error">No audio file was specified.</string>
@@ -53,8 +49,6 @@
     <string name="do_not_exit">Cancel</string>
     <string name="do_not_save">Ignore Changes</string>
     <string name="enter">start</string>
-    <string name="entering_repeat">Add Group</string>
-    <string name="entering_repeat_ask">Add New Group?</string>
     <string name="enter_data">Fill Blank Form</string>
     <string name="enter_data_button">Fill Blank Form</string>
     <string name="enter_data_description">You are at the start of \"%s\". Swipe the screen as shown below to begin.</string>
@@ -79,7 +73,6 @@
     <string name="jump_to_end">Go To End</string>
     <string name="jump_to_previous">Go Up</string>
     <string name="latitude">Latitude</string>
-    <string name="leave_repeat_yes">Do Not Add</string>
     <string name="leaving_repeat">Add Group</string>
     <string name="leaving_repeat_ask">And One More Group?</string>
     <string name="list_failed_with_error">Form listing failed. %s.</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -145,11 +145,6 @@ Copyright © 2012 readyState Software Ltd.</string>
     <string name="accept_location" cc:translatable="true">Record Location</string>
     <string name="accuracy" cc:translatable="true">Accuracy</string>
     <string name="activity_not_found" cc:translatable="true">No activity found to handle: %s</string>
-    <string name="add_another" cc:translatable="true">Add Group</string>
-    <string name="add_another_repeat" cc:translatable="true">Add another \"%s\" group?</string>
-    <string name="add_repeat" cc:translatable="true">Add a new \"%s\" group?</string>
-    <string name="add_repeat_no" cc:translatable="true">Do Not Add</string>
-    <string name="add_repeat_no_exits" cc:translatable="true">Do Not Add, I\'m Finished</string>
     <string name="advance" cc:translatable="true">forward to\nnext\nprompt</string>
     <string name="altitude" cc:translatable="true">Altitude</string>
     <string name="attachment_oversized" cc:translatable="true">Warning: attached large file of size %s kb. This could cause problems with submitting to the server depending on your network conditions.</string>
@@ -187,8 +182,6 @@ Copyright © 2012 readyState Software Ltd.</string>
     <string name="do_not_exit" cc:translatable="true">STAY IN FORM</string>
     <string name="do_not_save" cc:translatable="true">EXIT WITHOUT SAVING</string>
     <string name="enter" cc:translatable="true">start</string>
-    <string name="entering_repeat" cc:translatable="true">Add Group</string>
-    <string name="entering_repeat_ask" cc:translatable="true">Add New Group?</string>
     <string name="enter_data" cc:translatable="true">Fill Blank Form</string>
     <string name="enter_data_button" cc:translatable="true">Fill Blank Form</string>
     <string name="enter_data_description" cc:translatable="true">You are at the start of \"%s\". Swipe the screen as shown below to begin.</string>
@@ -213,9 +206,6 @@ Copyright © 2012 readyState Software Ltd.</string>
     <string name="jump_to_end" cc:translatable="true">Go To End</string>
     <string name="jump_to_previous" cc:translatable="true">Go Up</string>
     <string name="latitude" cc:translatable="true">Latitude</string>
-    <string name="leave_repeat_yes" cc:translatable="true">Do Not Add</string>
-    <string name="leave_repeat_yes_exits" cc:translatable="true">Do Not Add. I\'m Finished.</string>
-    <string name="repeat_go_back" cc:translatable="true">Go Back</string>
     <string name="leaving_repeat" cc:translatable="true">Add Group</string>
     <string name="leaving_repeat_ask" cc:translatable="true">And One More Group?</string>
     <string name="list_failed_with_error" cc:translatable="true">Form listing failed. %s.</string>

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1205,7 +1205,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             skipText = Localization.get("repeat.dialog.exit");
         }
         if (mFormController.getLastRepeatCount() > 0) {
-            title = Localization.get("repeat.dialgo.add.another", mFormController.getLastGroupText());
+            title = Localization.get("repeat.dialog.add.another", mFormController.getLastGroupText());
         } else {
             title = Localization.get("repeat.dialog.add.new", mFormController.getLastGroupText());
         }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1196,24 +1196,18 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         final boolean nextExitsForm = details.relevantAfterCurrentScreen == 0;
 
         // Assign title and text strings based on the current state
-        String title, addAnotherText, skipText, backText;
-        backText = Localization.get("repeat.dialog.go.back");
+        String backText = Localization.get("repeat.dialog.go.back");
+        String addAnotherText = Localization.get("repeat.dialog.add");
+        String title, skipText;
+        if (!nextExitsForm) {
+            skipText = Localization.get("repeat.dialog.leave");
+        } else {
+            skipText = Localization.get("repeat.dialog.exit");
+        }
         if (mFormController.getLastRepeatCount() > 0) {
             title = Localization.get("repeat.dialgo.add.another", mFormController.getLastGroupText());
-            addAnotherText = Localization.get("repeat.dialog.add");
-            if (!nextExitsForm) {
-                skipText = Localization.get("repeat.dialog.leave");
-            } else {
-                skipText = Localization.get("repeat.dialog.exit");
-            }
         } else {
             title = Localization.get("repeat.dialog.add.new", mFormController.getLastGroupText());
-            addAnotherText = Localization.get("repeat.dialog.add");
-            if (!nextExitsForm) {
-                skipText = Localization.get("repeat.dialog.leave");
-            } else {
-                skipText = Localization.get("repeat.dialog.exit");
-            }
         }
 
         // Create the choice dialog

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -53,6 +53,7 @@ import org.commcare.activities.components.FormRelevancyUpdating;
 import org.commcare.activities.components.ImageCaptureProcessing;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
+import org.commcare.utils.MarkupUtil;
 import org.commcare.views.media.MediaLayout;
 import org.commcare.android.javarosa.IntentCallout;
 import org.commcare.android.javarosa.PollSensorAction;
@@ -1196,24 +1197,22 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         // Assign title and text strings based on the current state
         String title, addAnotherText, skipText, backText;
-        backText = StringUtils.getStringSpannableRobust(this, R.string.repeat_go_back).toString();
+        backText = Localization.get("repeat.dialog.go.back");
         if (mFormController.getLastRepeatCount() > 0) {
-            title = StringUtils.getStringSpannableRobust(this, R.string.add_another_repeat,
-                    mFormController.getLastGroupText()).toString();
-            addAnotherText = StringUtils.getStringSpannableRobust(this, R.string.add_another).toString();
+            title = Localization.get("repeat.dialgo.add.another", mFormController.getLastGroupText());
+            addAnotherText = Localization.get("repeat.dialog.add");
             if (!nextExitsForm) {
-                skipText = StringUtils.getStringSpannableRobust(this, R.string.leave_repeat_yes).toString();
+                skipText = Localization.get("repeat.dialog.leave");
             } else {
-                skipText = StringUtils.getStringSpannableRobust(this, R.string.leave_repeat_yes_exits).toString();
+                skipText = Localization.get("repeat.dialog.exit");
             }
         } else {
-            title = StringUtils.getStringSpannableRobust(this, R.string.add_repeat,
-                    mFormController.getLastGroupText()).toString();
-            addAnotherText = StringUtils.getStringSpannableRobust(this, R.string.entering_repeat).toString();
+            title = Localization.get("repeat.dialog.add.new", mFormController.getLastGroupText());
+            addAnotherText = Localization.get("repeat.dialog.add");
             if (!nextExitsForm) {
-                skipText = StringUtils.getStringSpannableRobust(this, R.string.add_repeat_no).toString();
+                skipText = Localization.get("repeat.dialog.leave");
             } else {
-                skipText = StringUtils.getStringSpannableRobust(this, R.string.add_repeat_no_exits).toString();
+                skipText = Localization.get("repeat.dialog.exit");
             }
         }
 


### PR DESCRIPTION
Allow repeat dialog to be localized in standard fashion.

| Before add first group | After add first group |
| --- | --- |
| ![a_new_repeat](https://cloud.githubusercontent.com/assets/94817/15938576/bb8b45b2-2e41-11e6-8746-aab510930a64.png) | ![b_new_repeat](https://cloud.githubusercontent.com/assets/94817/15938581/c31703b6-2e41-11e6-9ed8-42f2678cd445.png) |

| Before add another group | After add another group |
| --- | --- |
| ![a_another_repeat](https://cloud.githubusercontent.com/assets/94817/15938599/d0fc349c-2e41-11e6-93dc-cca22e9dac30.png) | ![b_another_repeat](https://cloud.githubusercontent.com/assets/94817/15938607/d5f6b800-2e41-11e6-928f-951e0723ecf2.png) | 


Follow-up for http://manage.dimagi.com/default.asp?229190