### PR TITLE
Fix saved form crash when app has sync-request

### DIFF
--- a/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
@@ -90,7 +90,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
         for (Suite s : platform.getInstalledSuites()) {
             for (Enumeration en = s.getEntries().elements(); en.hasMoreElements(); ) {
                 Entry entry = (Entry) en.nextElement();
-                if (!entry.isView()) {
+                if (!(entry.isView() || entry.isSync())) {
                     String namespace = ((FormEntry)entry).getXFormNamespace();
                     //Some of our old definitions for views still come in as entries with dead
                     //namespaces for now, so check. Can clean up when FormEntry's enforce a

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -211,7 +211,7 @@ public class AndroidSessionWrapper {
         Hashtable<String, Entry> menuMap = platform.getMenuMap();
         for (String key : menuMap.keySet()) {
             Entry e = menuMap.get(key);
-            if (!e.isView() && formNamespace.equals(((FormEntry)e).getXFormNamespace())) {
+            if (!(e.isView() || e.isSync()) && formNamespace.equals(((FormEntry)e).getXFormNamespace())) {
                 //We have an entry. Don't worry too much about how we're supposed to get there for now.
 
                 //The ideal is that we only need one piece of data


### PR DESCRIPTION
If you install an app that has a `sync-request` entry in the suite.xml file, CommCare crashes when you open the 'saved forms' view.

Also update `mockEasiestRoute` with the same fix. `mockEasiestRoute` is only a debug method used to load saved forms onto a device manually