### PR TITLE
Fix login redirection bug

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -54,7 +54,6 @@ public class DispatchActivity extends FragmentActivity {
     private static final String KEY_APP_FILES_CHECK_OCCURRED = "check-for-changed-app-files-occurred";
     private static final String KEY_WAITING_FOR_ACTIVITY_RESULT = "waiting-for-login-activity-result";
 
-    // Used for soft assert for login redirection bug
     private boolean waitingForActivityResultFromLogin;
 
     boolean alreadyCheckedForAppFilesChange;

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -215,6 +215,7 @@ public class DispatchActivity extends FragmentActivity {
 
     private void launchLoginScreen() {
         if (!waitingForActivityResultFromLogin) {
+            // AMS 06/09/16: This check is needed due to what we believe is a bug in the Android platform
             Intent i = new Intent(this, LoginActivity.class);
             i.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, userTriggeredLogout);
             startActivityForResult(i, LOGIN_USER);

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -217,6 +217,11 @@ public class DispatchActivity extends FragmentActivity {
             i.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, userTriggeredLogout);
             startActivityForResult(i, LOGIN_USER);
             waitingForActivityResultFromLogin = true;
+        } else {
+            Logger.log(AndroidLogger.SOFT_ASSERT,
+                    "Login redirection bug occurred; DispatchActivity is attempting to launch " +
+                            "a new LoginActivity while it is still waiting for a result from " +
+                            "another one.");
         }
     }
 

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -52,6 +52,7 @@ public class DispatchActivity extends FragmentActivity {
 
     private static final String EXTRA_CONSUMED_KEY = "shortcut_extra_was_consumed";
     private static final String KEY_APP_FILES_CHECK_OCCURRED = "check-for-changed-app-files-occurred";
+    private static final String KEY_WAITING_FOR_ACTIVITY_RESULT = "waiting-for-login-activity-result";
 
     // Used for soft assert for login redirection bug
     private boolean waitingForActivityResultFromLogin;
@@ -69,6 +70,7 @@ public class DispatchActivity extends FragmentActivity {
         if (savedInstanceState != null) {
             shortcutExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
             alreadyCheckedForAppFilesChange = savedInstanceState.getBoolean(KEY_APP_FILES_CHECK_OCCURRED);
+            waitingForActivityResultFromLogin = savedInstanceState.getBoolean(KEY_WAITING_FOR_ACTIVITY_RESULT);
         }
     }
 
@@ -108,6 +110,7 @@ public class DispatchActivity extends FragmentActivity {
         super.onSaveInstanceState(outState);
         outState.putBoolean(EXTRA_CONSUMED_KEY, shortcutExtraWasConsumed);
         outState.putBoolean(KEY_APP_FILES_CHECK_OCCURRED, alreadyCheckedForAppFilesChange);
+        outState.putBoolean(KEY_WAITING_FOR_ACTIVITY_RESULT, waitingForActivityResultFromLogin);
     }
 
     private void checkForChangedCCZ() {

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -212,15 +212,12 @@ public class DispatchActivity extends FragmentActivity {
     }
 
     private void launchLoginScreen() {
-        if (waitingForActivityResultFromLogin) {
-            Logger.log(AndroidLogger.SOFT_ASSERT, "Login redirection bug occurred; " +
-                    "DispatchActivity is attempting to launch a new LoginActivity while it is " +
-                    "still waiting for a result from another one.");
+        if (!waitingForActivityResultFromLogin) {
+            Intent i = new Intent(this, LoginActivity.class);
+            i.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, userTriggeredLogout);
+            startActivityForResult(i, LOGIN_USER);
+            waitingForActivityResultFromLogin = true;
         }
-        Intent i = new Intent(this, LoginActivity.class);
-        i.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, userTriggeredLogout);
-        startActivityForResult(i, LOGIN_USER);
-        waitingForActivityResultFromLogin = true;
     }
 
     private void launchHomeScreen() {


### PR DESCRIPTION
After a lot of debugging and scratching our heads, Clayton and I finally decided a while back that this was the result of an Android-level bug, in which they are not adhering to the contract that an activity will not resume until the activity that it has called out to with `startActivityForResult()` has in fact returned a result.

The fix is to manually make sure that we don't relaunch the LoginActivity if we are currently waiting for a result from the LoginActivity.

Added the 'don't pull' label until we collectively agree that we want to go this route. @ctsims @phillipm 