### PR TITLE
Remove red text on blue sync button

### DIFF
--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -53,7 +53,7 @@ public class SyncDetailCalculations {
         setSyncSubtextColor(
                 squareButtonViewHolder.subTextView, numUnsentForms, lastSyncTimeAndMessage.first,
                 activity.getResources().getColor(cardDisplayData.subTextColor),
-                activity.getResources().getColor(R.color.cc_attention_negative_text));
+                activity.getResources().getColor(R.color.cc_dark_warm_accent_color));
     }
 
     private static Pair<Long, String> getLastSyncTimeAndMessage() {


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?190347. Make warning text on sync button orange (Biyeun's suggestion) instead of red.