### PR TITLE
Fix confusing behavior when enabling developer options

### DIFF
--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -1281,22 +1281,27 @@ public class CommCareHomeActivity
 
     private void showAboutCommCareDialog() {
         CommCareAlertDialog dialog = DialogCreationHelpers.buildAboutCommCareDialog(this);
-
-        dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+        dialog.makeCancelable();
+        dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
             @Override
-            public void onCancel(DialogInterface dialog) {
-                mDeveloperModeClicks++;
-                if (mDeveloperModeClicks == 4) {
-                    CommCareApplication._().getCurrentApp().getAppPreferences().
-                            edit().putString(DeveloperPreferences.SUPERUSER_ENABLED, "yes").commit();
-                    Toast.makeText(CommCareHomeActivity.this,
-                            Localization.get("home.developer.options.enabled"),
-                            Toast.LENGTH_SHORT).show();
-                }
+            public void onDismiss(DialogInterface dialog) {
+                handleDeveloperModeClicks();
             }
         });
-
         showAlertDialog(dialog);
+    }
+
+    private void handleDeveloperModeClicks() {
+        mDeveloperModeClicks++;
+        if (mDeveloperModeClicks == 4) {
+            CommCareApplication._().getCurrentApp().getAppPreferences()
+                    .edit()
+                    .putString(DeveloperPreferences.SUPERUSER_ENABLED, CommCarePreferences.YES)
+                    .commit();
+            Toast.makeText(CommCareHomeActivity.this,
+                    Localization.get("home.developer.options.enabled"),
+                    Toast.LENGTH_SHORT).show();
+        }
     }
 
     @Override

--- a/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
@@ -19,8 +19,7 @@ public abstract class CommCareAlertDialog {
     protected DialogInterface.OnCancelListener cancelListener;
     private DialogInterface.OnDismissListener dismissListener;
     protected View view;
-    // false by default, can be overridden by calling setOnCancelListener(), or by subclass
-    // definitions if desired
+    // false by default, can be overridden if desired
     protected boolean isCancelable;
 
     public void finalizeView() {
@@ -28,6 +27,7 @@ public abstract class CommCareAlertDialog {
         if (isCancelable) {
             dialog.setOnCancelListener(cancelListener);
         }
+        dialog.setOnDismissListener(dismissListener);
         dialog.setView(view);
     }
 
@@ -47,13 +47,16 @@ public abstract class CommCareAlertDialog {
         return isCancelable;
     }
 
+    public void makeCancelable() {
+        isCancelable = true;
+    }
+
     public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
         isCancelable = true;
         cancelListener = listener;
     }
 
     public void setOnDismissListener(DialogInterface.OnDismissListener listener) {
-        dialog.setOnDismissListener(listener);
         dismissListener = listener;
     }
 

--- a/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CommCareAlertDialog.java
@@ -24,11 +24,15 @@ public abstract class CommCareAlertDialog {
 
     public void finalizeView() {
         dialog.setCancelable(isCancelable);
-        if (isCancelable) {
+        if (cancelListener != null) {
             dialog.setOnCancelListener(cancelListener);
         }
-        dialog.setOnDismissListener(dismissListener);
-        dialog.setView(view);
+        if (dismissListener != null) {
+            dialog.setOnDismissListener(dismissListener);
+        }
+        if (view != null) {
+            dialog.setView(view);
+        }
     }
 
     public void performCancel(DialogInterface dialog) {

--- a/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
+++ b/app/src/org/commcare/views/dialogs/CustomViewAlertDialog.java
@@ -26,10 +26,7 @@ public class CustomViewAlertDialog extends CommCareAlertDialog {
     @Override
     public void finalizeView() {
         dialog = builder.create();
-        dialog.setCancelable(isCancelable);
-        if (isCancelable) {
-            dialog.setOnCancelListener(cancelListener);
-        }
+        super.finalizeView();
     }
 
 }


### PR DESCRIPTION
Phillip recently added an OK button to the About CommCare dialog, but pressing it did not contribute to the count for enabling Developer Options. This PR makes it so that either pressing OK or pressing 'back' contribute to the count (canceling a dialog calls both `onCancel` and `onDismiss`, so placing the code in the `OnDismissListener` only is sufficient). 

Also fix a small bug in `CommCareAlertDialog`