### PR TITLE
Use built-in String.split() in Android code

### DIFF
--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -77,11 +77,28 @@ public class AndroidUtil {
     }
 
     public static class AndroidStringSplitter extends DataUtil.StringSplitter {
+
+        @Override
         public String[] splitOnSpaces(String s) {
             if ("".equals(s)) {
                 return new String[0];
             }
             return s.split("[ ]+");
+        }
+
+        @Override
+        public String[] splitOnDash(String s) {
+            return s.split("-");
+        }
+
+        @Override
+        public String[] splitOnColon(String s) {
+            return s.split(":");
+        }
+
+        @Override
+        public String[] splitOnPlus(String s) {
+            return s.split("[+]");
         }
     }
 

--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.util.TypedValue;
 import android.view.View;
 
+import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.DataUtil.UnionLambda;
 
@@ -50,9 +51,12 @@ public class AndroidUtil {
      */
     public static void initializeStaticHandlers() {
         DataUtil.setUnionLambda(new AndroidUnionLambda());
+        DataUtil.setStringSplitter(new AndroidStringSplitter());
     }
 
     private static class AndroidUnionLambda extends UnionLambda {
+
+        @Override
         public <T> Vector<T> union(Vector<T> a, Vector<T> b) {
             Vector<T> result = new Vector<>();
             //This is kind of (ok, so really) awkward looking, but we can't use sets in 
@@ -69,8 +73,17 @@ public class AndroidUtil {
             result.addAll(joined);
             return result;
         }
+
     }
 
+    public static class AndroidStringSplitter extends DataUtil.StringSplitter {
+        public String[] splitOnSpaces(String s) {
+            if ("".equals(s)) {
+                return new String[0];
+            }
+            return s.split("[ ]+");
+        }
+    }
 
     /**
      * Returns an int array with the color values for the given attributes (R.attr).

--- a/unit-tests/src/org/commcare/utils/StaticInjectionTests.java
+++ b/unit-tests/src/org/commcare/utils/StaticInjectionTests.java
@@ -1,0 +1,50 @@
+package org.commcare.utils;
+
+import org.commcare.CommCareApplication;
+import org.commcare.android.CommCareTestRunner;
+import org.commcare.dalvik.BuildConfig;
+import org.javarosa.core.util.DataUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+
+/**
+ * Test that the output of the j2me- and Android- implementations of methods that use static
+ * injection for the Android version have identical behavior
+ *
+ * Created by amstone326 on 6/14/16.
+ */
+@Config(application = CommCareApplication.class,
+        constants = BuildConfig.class)
+@RunWith(CommCareTestRunner.class)
+public class StaticInjectionTests {
+
+    @Test
+    public void testStringSplitterEquivalence() {
+        String basicString = "hello my name is Sam";
+        String noDelimitersString = "hellomynameisSam";
+        String multipleDelimitersString = "hello   my  name is    Sam";
+        String emptyString = "";
+
+        Assert.assertTrue(identicalResults(basicString));
+        Assert.assertTrue(identicalResults(noDelimitersString));
+        Assert.assertTrue(identicalResults(multipleDelimitersString));
+        Assert.assertTrue(identicalResults(emptyString));
+    }
+
+    private static boolean identicalResults(String testString) {
+        return Arrays.equals(getAndroidResult(testString), getJ2MEResult(testString));
+    }
+
+    private static String[] getAndroidResult(String s) {
+        return (new AndroidUtil.AndroidStringSplitter()).splitOnSpaces(s);
+    }
+
+    private static String[] getJ2MEResult(String s) {
+        return (new DataUtil.StringSplitter()).splitOnSpaces(s);
+    }
+
+}

--- a/unit-tests/src/org/commcare/utils/StaticInjectionTests.java
+++ b/unit-tests/src/org/commcare/utils/StaticInjectionTests.java
@@ -23,28 +23,103 @@ import java.util.Arrays;
 public class StaticInjectionTests {
 
     @Test
-    public void testStringSplitterEquivalence() {
+    public void testSplitOnSpacesEquivalence() {
         String basicString = "hello my name is Sam";
         String noDelimitersString = "hellomynameisSam";
         String multipleDelimitersString = "hello   my  name is    Sam";
         String emptyString = "";
 
-        Assert.assertTrue(identicalResults(basicString));
-        Assert.assertTrue(identicalResults(noDelimitersString));
-        Assert.assertTrue(identicalResults(multipleDelimitersString));
-        Assert.assertTrue(identicalResults(emptyString));
+        Assert.assertTrue(identicalSplitOnSpacesResults(basicString));
+        Assert.assertTrue(identicalSplitOnSpacesResults(noDelimitersString));
+        Assert.assertTrue(identicalSplitOnSpacesResults(multipleDelimitersString));
+        Assert.assertTrue(identicalSplitOnSpacesResults(emptyString));
     }
 
-    private static boolean identicalResults(String testString) {
-        return Arrays.equals(getAndroidResult(testString), getJ2MEResult(testString));
+    private static boolean identicalSplitOnSpacesResults(String testString) {
+        return Arrays.equals(getAndroidSplitOnSpaces(testString), getJ2MESplitOnSpaces(testString));
     }
 
-    private static String[] getAndroidResult(String s) {
+    private static String[] getAndroidSplitOnSpaces(String s) {
         return (new AndroidUtil.AndroidStringSplitter()).splitOnSpaces(s);
     }
 
-    private static String[] getJ2MEResult(String s) {
+    private static String[] getJ2MESplitOnSpaces(String s) {
         return (new DataUtil.StringSplitter()).splitOnSpaces(s);
+    }
+
+    @Test
+    public void testSplitOnColonEquivalence() {
+        String basicString = "hello:my:name:is:Sam";
+        String noDelimitersString = "hellomynameisSam";
+        String multipleDelimitersString = "hello::my:::name:is::::Sam";
+        String emptyString = "";
+
+        Assert.assertTrue(identicalSplitOnColonResults(basicString));
+        Assert.assertTrue(identicalSplitOnColonResults(noDelimitersString));
+        Assert.assertTrue(identicalSplitOnColonResults(multipleDelimitersString));
+        Assert.assertTrue(identicalSplitOnColonResults(emptyString));
+    }
+
+    private static boolean identicalSplitOnColonResults(String testString) {
+        return Arrays.equals(getAndroidSplitOnColon(testString), getJ2MESplitOnColon(testString));
+    }
+
+    private static String[] getAndroidSplitOnColon(String s) {
+        return (new AndroidUtil.AndroidStringSplitter()).splitOnColon(s);
+    }
+
+    private static String[] getJ2MESplitOnColon(String s) {
+        return (new DataUtil.StringSplitter()).splitOnColon(s);
+    }
+
+    @Test
+    public void testSplitOnDashEquivalence() {
+        String basicString = "hello-my-name-is-Sam";
+        String noDelimitersString = "hellomynameisSam";
+        String multipleDelimitersString = "hello--my---name-is----Sam";
+        String emptyString = "";
+
+        Assert.assertTrue(identicalSplitOnDashResults(basicString));
+        Assert.assertTrue(identicalSplitOnDashResults(noDelimitersString));
+        Assert.assertTrue(identicalSplitOnDashResults(multipleDelimitersString));
+        Assert.assertTrue(identicalSplitOnDashResults(emptyString));
+    }
+
+    private static boolean identicalSplitOnDashResults(String testString) {
+        return Arrays.equals(getAndroidSplitOnDash(testString), getJ2MESplitOnDash(testString));
+    }
+
+    private static String[] getAndroidSplitOnDash(String s) {
+        return (new AndroidUtil.AndroidStringSplitter()).splitOnDash(s);
+    }
+
+    private static String[] getJ2MESplitOnDash(String s) {
+        return (new DataUtil.StringSplitter()).splitOnDash(s);
+    }
+
+    @Test
+    public void testSplitOnPlusEquivalence() {
+        String basicString = "hello+my+name+is+Sam";
+        String noDelimitersString = "hellomynameisSam";
+        String multipleDelimitersString = "hello++my+++name+is++++Sam";
+        String emptyString = "";
+
+        Assert.assertTrue(identicalSplitOnPlusResults(basicString));
+        Assert.assertTrue(identicalSplitOnPlusResults(noDelimitersString));
+        Assert.assertTrue(identicalSplitOnPlusResults(multipleDelimitersString));
+        Assert.assertTrue(identicalSplitOnPlusResults(emptyString));
+    }
+
+    private static boolean identicalSplitOnPlusResults(String testString) {
+        return Arrays.equals(getAndroidSplitOnPlus(testString), getJ2MESplitOnPlus(testString));
+    }
+
+    private static String[] getAndroidSplitOnPlus(String s) {
+        return (new AndroidUtil.AndroidStringSplitter()).splitOnPlus(s);
+    }
+
+    private static String[] getJ2MESplitOnPlus(String s) {
+        return (new DataUtil.StringSplitter()).splitOnPlus(s);
     }
 
 }


### PR DESCRIPTION
As part of performance improvements for ICDS Daily Feeding Form: Use static injection to use the  built-in String.split() method in Android, while retaining our custom implementation for j2me. Also add tests to assert equivalence between the 2 implementations.

A subset of these changes will be included in the 2.27 LTS release as well, but I haven't set that up yet (waiting to talk with @ctsims on the exact right way to do that)

cross-request: https://github.com/dimagi/javarosa/pull/304